### PR TITLE
v1.21.7: BE Failover + Duration Validation Fix

### DIFF
--- a/docs/SCOUT-ANALYSIS-LOCATION-MAPCENTER-SYSTEM.md
+++ b/docs/SCOUT-ANALYSIS-LOCATION-MAPCENTER-SYSTEM.md
@@ -1,0 +1,525 @@
+# Scout Analysis: MapCenter/Location System in TangoTiempo
+
+**Generated**: 2026-03-30
+**Analyzed by**: Scout (Sarah - TangoTiempo Frontend Agent)
+**Scope**: Comprehensive analysis of MapCenter/location system
+
+---
+
+## Executive Summary
+
+The MapCenter/location system is a complex, multi-layered architecture that has undergone significant evolution over the past 6 months. The system handles:
+- User location detection (browser geolocation, Google API, IP fallback)
+- Location storage (sessionStorage, localStorage, cookies, Azure Functions cloud)
+- Event filtering by geographic radius
+- User type differentiation (anonymous vs logged-in)
+- Multiple UI modals (WelcomeModal, MapCenterModal, MapCenterOnboardingModal)
+
+**Key Problem Areas Identified:**
+1. Google Geocoding API 429 rate limit errors (87% of all API errors)
+2. City name display race conditions (recently fixed in TIEMPO-388)
+3. Complex modal orchestration with potential race conditions
+4. Visit count mechanism exists but is underutilized
+
+---
+
+## 1. Git History Analysis (Last 6 Months)
+
+### Key Commits by Ticket
+
+| Ticket | Focus | Key Commits |
+|--------|-------|-------------|
+| **TIEMPO-388** | Geolocation + City Name Race Conditions | 15+ commits fixing pill display, modal timing, city name fetch |
+| **TIEMPO-381** | MapCenter Onboarding Flow | 12+ commits for new user onboarding, Boston route fixes |
+| **TIEMPO-360** | MapCenterModal Density Pills | Event density overlay on map |
+| **TIEMPO-329** | Welcome Modal + Visit Tracking | First-time visitor flow |
+| **TIEMPO-321** | Geolocation Migration to AFA | Backend proxy for geo APIs |
+| **TIEMPO-319** | Rate Limit Fixes | Caching to prevent 429 errors |
+| **TIEMPO-312** | Cloud Default Feature | Azure Functions mapCenter storage |
+
+### Evolution Timeline
+
+```
+2024-10: TIEMPO-312 - Cloud Default feature launched
+         - Users can save mapCenter to Azure Functions
+         - GeoLocationContext introduced
+
+2025-01: TIEMPO-319/321 - Rate limiting crisis
+         - Google Geo 429 errors hitting 150/day
+         - Added caching, migrated to AFA proxy
+
+2025-02: TIEMPO-329 - Welcome Modal
+         - First-time visitor tracking
+         - Visit count mechanism added
+
+2025-03: TIEMPO-360 - Density pills
+         - MapCenterModal shows event density
+
+2025-03: TIEMPO-381 - Onboarding flow
+         - Logged-in users without mapCenter get forced modal
+         - Boston route exceptions
+
+2025-03: TIEMPO-388 - Race condition fixes
+         - City name now stored in context (survives remount)
+         - Browser geolocation tried before modal
+         - Increased timeout from 5s to 10s
+```
+
+---
+
+## 2. SHOFF Handoff History (Location-Related)
+
+### Recent Session Findings
+
+**session_2026-03-20T13-05.md** - Two Blocking Bugs:
+1. Pill showing lat/long instead of city name ("Boston")
+2. MapCenter modal popping up unexpectedly for guests
+
+**Root cause**: `fetchNearestCity` not populating `nearestCityName` state due to race conditions.
+
+**session_2026-03-27T18-14.md** - Google Geo API Analysis:
+- 187 Google Geo 429 errors = 87% of all API errors
+- Recommendation: Switch sessionStorage to localStorage, increase TTL to 24h
+- **NOT YET IMPLEMENTED** - user declined
+
+---
+
+## 3. Current Code Architecture
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/app/contexts/GeoLocationContext.js` | **Single source of truth** for location state |
+| `src/app/contexts/LocationAPIContext.js` | API functions for fetching location data |
+| `src/app/components/Modals/misc/MapCenterModal.js` | Main modal for changing location |
+| `src/app/components/Modals/misc/MapCenterOnboardingModal.js` | Blocking modal for logged-in users without mapCenter |
+| `src/app/components/Modals/Welcome/WelcomeModal.js` | Anonymous user first visit flow |
+| `src/app/components/UI/SiteHeader.js` | Location pill display |
+| `src/app/components/UserLocationLoader.js` | Fetches cloud mapCenter on login |
+| `src/app/components/UI/NoEventsAlert.js` | "No events" message with Map Center button |
+| `src/app/utils/geolocationHelper.js` | Browser + Google API geolocation |
+| `src/app/utils/visitorTracking.js` | Cookie + localStorage for visitor tracking |
+| `src/app/hooks/useEvents.js` | Event fetching with location filtering |
+
+### GeoLocationContext State Shape
+
+```javascript
+// Current location (single source of truth)
+currentLocation: {
+  lat: number,
+  lng: number,
+  zoomRange: number (miles),
+  cityName: string | null,      // TIEMPO-388: Now stored here
+  cityNameLoading: boolean,     // TIEMPO-388: Prevents flash
+  cityNameFetched: boolean,     // TIEMPO-388: Tracks completion
+  source: string,               // Optional: 'boston' for locked routes
+  locked: boolean               // Optional: Prevents overwrite
+}
+
+// Saved location (from cloud)
+savedLocation: {
+  lat: number,
+  lng: number,
+  zoomRange: number
+}
+
+// Modal states
+mapCenterModalOpen: boolean
+needsOnboarding: boolean
+```
+
+---
+
+## 4. User Flow Analysis
+
+### A. Default Location Behavior
+
+**Anonymous User (no saved location):**
+```
+1. WelcomeModal useEffect runs
+2. incrementVisitCount() called
+3. needsLocationSetup() checks:
+   - Is /boston route? -> Skip (uses BOSTON_CONFIG)
+   - Has getLastMapCenter()? -> Skip (use stored)
+4. Try browser geolocation (10s timeout)
+   - Success -> setSessionLocation + show toast
+   - Fail -> openMapCenterModal()
+```
+
+**Logged-In User:**
+```
+1. UserLocationLoader.useEffect runs
+2. Check if Boston route -> Skip
+3. Call fetchMapCenter(firebaseToken)
+4. If no mapCenter returned -> setNeedsOnboarding(true)
+5. Calendar page shows MapCenterOnboardingModal when needsOnboarding && user
+```
+
+### B. Location Storage Hierarchy
+
+| Storage | Purpose | TTL | Used By |
+|---------|---------|-----|---------|
+| `sessionStorage['currentLocation']` | Session state | Session | GeoLocationContext |
+| `localStorage['last_map_center']` | Cross-session for anonymous | Forever | visitorTracking.js |
+| `localStorage['visit_count']` | Visit tracking | Forever | visitorTracking.js |
+| `cookie['visitor_id']` | Visitor identity | 365 days | visitorTracking.js |
+| Azure Functions `/api/mapcenter` | Cloud default | Forever | UserLocationLoader |
+| `sessionStorage['google_geo_cache']` | Geo API cache | 5 min | geolocationHelper.js |
+| `sessionStorage['google_geo_rate_limited']` | Rate limit flag | Session | geolocationHelper.js |
+
+### C. "No Events" Message Flow
+
+**File**: `src/app/components/UI/NoEventsAlert.js`
+
+**Conditions for display:**
+```javascript
+if (
+  noLocationSelected ||    // Still loading location
+  eventsLoading ||         // Still loading events
+  !events ||               // No events array
+  events.length > 0 ||     // Has events
+  dismissed ||             // User closed it
+  !showAlert              // 1-second delay not passed
+) {
+  return null;
+}
+```
+
+**TIEMPO-388 Fix**: Added 1-second delay (`showAlert` state) to prevent flash during initial load.
+
+**Boston-specific behavior**: Shows "Explore All Regions" link instead of "Adjust Map Center" button.
+
+---
+
+## 5. User Types and Filtering
+
+### Role Definitions
+
+| Role | Code Name | Description |
+|------|-----------|-------------|
+| Anonymous | `AnonymousUser` | Not logged in |
+| Named User | `NamedUser` | Logged in, no special roles |
+| Regional Organizer | `RegionalOrganizer` | Can create events |
+| Regional Admin | `RegionalAdmin` | Can manage organizers |
+| System Admin | `SystemAdmin` | Full system access |
+| Super Admin/Owner | `SystemOwner` | System owner |
+
+### Role-based Behavior
+
+**From `RoleContext.js`:**
+```javascript
+const ELEVATED_ROLES = ['RegionalOrganizer', 'RegionalAdmin', 'SystemAdmin', 'SystemOwner'];
+const BASE_ROLES = ['NamedUser', 'Anonymous', ''];
+```
+
+**Calendar Page Logic** (from `page.js`):
+```javascript
+const canAddEvents = selectedRole === listOfAllRoles.REGIONAL_ORGANIZER ||
+                    selectedRole === listOfAllRoles.REGIONAL_ADMIN ||
+                    selectedRole === listOfAllRoles.SYSTEM_ADMIN ||
+                    selectedRole === listOfAllRoles.SUPER_ADMIN;
+
+// Placeholder text changes based on role
+const placeholderText = canAddEvents ? 'Click to add event' : 'No events';
+```
+
+**Event Filtering**: Uses `useEvents` hook with:
+- `useGeoLocationContext: true` - Gets location from context
+- `useLocationPreferences: true` - Uses saved user preferences
+
+RO/RA do NOT see different events by default - they see the same geo-filtered events as other users. Their privilege is the ability to CREATE events.
+
+---
+
+## 6. Visit Count Mechanism
+
+### Current Implementation
+
+**File**: `src/app/utils/visitorTracking.js`
+
+```javascript
+// Storage key
+const VISIT_COUNT_KEY = 'visit_count';
+
+// Functions
+incrementVisitCount() -> number  // Called on each page load
+getVisitCount() -> number        // Read without increment
+resetVisitCount() -> void        // For testing
+```
+
+**Current Usage** (from `WelcomeModal.js`):
+```javascript
+useEffect(() => {
+  incrementVisitCount();
+  // ... rest of logic
+}, []);
+```
+
+**NOT CURRENTLY USED FOR:**
+- Progressive disclosure
+- Signup prompts on visit N
+- Feature unlock based on visits
+
+### What Would Be Needed for Visit-Based Features
+
+```javascript
+// Example: Show signup prompt on 5th visit
+const visitNum = getVisitCount();
+if (visitNum >= 5 && !user && !dismissedSignupPrompt) {
+  showSignupPrompt();
+}
+```
+
+---
+
+## 7. Google 429 Errors Analysis
+
+### Current Rate Limiting Implementation
+
+**File**: `src/app/utils/geolocationHelper.js`
+
+```javascript
+const CACHE_KEY = 'google_geo_cache';
+const RATE_LIMIT_KEY = 'google_geo_rate_limited';
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+// Check cache before API call
+if (sessionStorage.getItem(RATE_LIMIT_KEY)) {
+  console.warn('[Geolocation] Skipping Google API - rate limited this session');
+  return null;
+}
+
+// On 429 response
+if (response.status === 429) {
+  sessionStorage.setItem(RATE_LIMIT_KEY, 'true');
+}
+```
+
+### Problems
+
+1. **sessionStorage clears on tab close** - User opens new tab, hits API again
+2. **5-minute cache too short** - User returns after 6 minutes, hits API again
+3. **No cross-device persistence** - Same user, different device = duplicate calls
+4. **Backend not rate-limited** - FE caching doesn't help when multiple users hit simultaneously
+
+### Recommended Fixes (NOT YET IMPLEMENTED)
+
+**FE Side** (from handoff):
+- Switch `sessionStorage` -> `localStorage`
+- Increase TTL from 5 min -> 24 hours
+- Consider using visitor_id for more aggressive caching
+
+**BE Side** (MSG sent to Fulton):
+- Implement server-side rate limiting/caching
+- Use Redis or similar for cross-user deduplication
+
+---
+
+## 8. Alternative Geocoding Services
+
+### Current Services Used
+
+| Service | Endpoint | Accuracy | Rate Limit |
+|---------|----------|----------|------------|
+| Browser GPS | `navigator.geolocation` | 10m | None (user permission) |
+| Google Geolocation API | `/api/geo/google-geolocate` (via AFA) | 50-500m | Quota-based |
+| ipinfo.io | Backend fallback | ~10km | Handled by BE |
+| BigDataCloud | `/api/geo/bigdatacloud` (via AFA) | ~5km | Higher limits |
+
+### Fallback Chain (from `geolocationHelper.js`)
+
+```
+Priority 1: Browser GPS (best accuracy)
+    |
+    v (if denied/failed)
+Priority 2: Google Geolocation API (via AFA proxy)
+    |
+    v (if 429 or failed)
+Priority 3: ipinfo.io (handled by backend)
+```
+
+### Services NOT Currently Used
+
+- MapQuest Geocoding (mentioned in search results but not actively used)
+- Cloudflare IP geolocation (used for tracking, not for map center)
+
+---
+
+## 9. Infrastructure Considerations
+
+### Vercel Configuration
+
+- **No special geo configuration required** - Location detection handled by FE/BE
+- Vercel provides Edge Functions but not currently used for geo
+
+### Cloudflare
+
+- **Cloudflare IP info** available at `/cdn-cgi/trace`
+- Used in `trackingHelper.js` for analytics
+- NOT used for MapCenter location
+
+### API Usage Patterns
+
+**Google Geolocation API:**
+- Called via AFA proxy at `NEXT_PUBLIC_AF_URL/api/geo/google-geolocate`
+- Cached in sessionStorage for 5 minutes
+- Rate-limited flag set on 429
+
+**Azure Functions MapCenter:**
+- `GET /api/mapcenter` - Fetch saved mapCenter
+- `PUT /api/mapcenter` - Save mapCenter
+- Requires Firebase token for authentication
+
+---
+
+## 10. Findings by User Concern Area
+
+### A. Default Location Behavior
+
+**Current State:**
+- Anonymous: Try browser geo first, then show modal
+- Logged-in: Fetch from Azure Functions, show onboarding if none
+
+**Issues:**
+- No server-side default based on IP (could use Cloudflare headers)
+- Boston route has special hardcoded handling
+
+### B. "No Events" Messages
+
+**Appears when:**
+- `events.length === 0` AND `!eventsLoading` AND `!noLocationSelected`
+
+**Does NOT appear:**
+- During loading
+- Before location is set
+- After user dismisses (persists in sessionStorage)
+
+**Issue:** None currently identified - TIEMPO-388 fixed the timing issues
+
+### C. User Types and Filtering
+
+**RO/RA Behavior:**
+- See same events as other users (geo-filtered)
+- Can CREATE events (not filter-related)
+- Header image changes based on role
+
+**No special "No events" messages for RO/RA** - this could be an enhancement opportunity
+
+### D. Visit Count Tracking
+
+**Status:** Implemented but underutilized
+- `incrementVisitCount()` called in WelcomeModal
+- Not used for progressive disclosure or signup prompts
+
+### E. Google 429 Errors
+
+**Status:** CRITICAL - 87% of API errors
+- FE caching helps but sessionStorage is ephemeral
+- BE rate limiting requested but not confirmed
+
+### F. Alternative Geocoding
+
+**Status:** Fallback chain implemented
+- Browser GPS -> Google API -> ipinfo.io
+- BigDataCloud available but not in main chain
+
+---
+
+## 11. Recommendations
+
+### Immediate (High Priority)
+
+1. **Google Geo Caching Fix**
+   - File: `src/app/utils/geolocationHelper.js`
+   - Change: `sessionStorage` -> `localStorage`
+   - Change: TTL 5 min -> 24 hours
+   - Impact: Reduces 429 errors significantly
+
+2. **Verify BE Rate Limiting**
+   - Check with Fulton on status of server-side caching
+   - MSG already sent on 2026-03-27
+
+### Medium Priority
+
+3. **Visit-Based Signup Prompts**
+   - Infrastructure exists (`getVisitCount()`)
+   - Need to implement prompt UI
+   - Suggested trigger: 5th visit
+
+4. **RO/RA "No Events" Enhancement**
+   - When RO/RA sees no events: "No events in your area. Add the first one!"
+   - File: `NoEventsAlert.js` - add role check
+
+5. **Cloudflare IP Fallback**
+   - Use Cloudflare headers for initial location guess
+   - Reduces need for geolocation prompts
+
+### Low Priority / Future
+
+6. **Server-Side IP Geolocation**
+   - Move initial location detection to SSR
+   - Would require Vercel Edge Function
+
+7. **Location Accuracy Indicator**
+   - Show "(approx.)" or "Near-ish:" based on source accuracy
+   - Already partially implemented for > 100mi
+
+---
+
+## 12. Key File Locations (Absolute Paths)
+
+```
+/Users/tobybalsley/MyDocs/AppDev/MasterCalendar/tangotiempo.com/
+├── src/app/
+│   ├── contexts/
+│   │   ├── GeoLocationContext.js      # Main location state
+│   │   ├── LocationAPIContext.js      # API functions
+│   │   ├── RoleContext.js             # User roles
+│   │   └── AuthContext.js             # Authentication
+│   ├── components/
+│   │   ├── Modals/
+│   │   │   ├── misc/
+│   │   │   │   ├── MapCenterModal.js
+│   │   │   │   └── MapCenterOnboardingModal.js
+│   │   │   └── Welcome/
+│   │   │       └── WelcomeModal.js
+│   │   ├── UI/
+│   │   │   ├── SiteHeader.js          # Location pill
+│   │   │   └── NoEventsAlert.js       # No events message
+│   │   └── UserLocationLoader.js      # Cloud mapCenter fetch
+│   ├── hooks/
+│   │   ├── useEvents.js               # Event filtering
+│   │   └── useGeoLocations.js
+│   ├── utils/
+│   │   ├── geolocationHelper.js       # Geo API logic
+│   │   ├── visitorTracking.js         # Visit count
+│   │   └── trackingHelper.js          # Analytics geo
+│   └── calendar/
+│       ├── page.js                    # Main calendar
+│       └── boston/
+│           └── page.js                # Boston variant
+```
+
+---
+
+## 13. SNR Block
+
+**S -- Summarize:**
+Scout completed comprehensive analysis of the MapCenter/location system. Key findings:
+- System has evolved significantly over 6 months with 50+ related commits
+- Google 429 errors are the critical issue (87% of API errors)
+- City name race conditions were fixed in TIEMPO-388
+- Visit count tracking exists but is underutilized
+- User role affects what users CAN DO (create events) but not what they SEE
+
+**N -- Next Steps:**
+1. Implement Google Geo localStorage fix (sessionStorage -> localStorage, 5min -> 24h TTL)
+2. Verify BE rate limiting status with Fulton
+3. Consider visit-based signup prompts (infrastructure ready)
+4. Consider RO/RA specific "No events" messaging
+
+**R -- Request Role:**
+- **Architect Mode** recommended for designing the Google Geo caching fix (localStorage migration)
+- **CRK Mode** if implementing immediately to assess risks of localStorage change
+- **Builder Mode** for straightforward TTL/storage changes after approval

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
-  "version": "1.21.5",
+  "version": "1.21.6",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
-  "version": "1.21.4",
+  "version": "1.21.5",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
-  "version": "1.21.6",
+  "version": "1.21.7",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/calendar/boston/page.js
+++ b/src/app/calendar/boston/page.js
@@ -35,6 +35,7 @@ const BOSTON_CONFIG = {
   lat: 42.3601,
   lng: -71.0589,
   zoomRange: 200, // 200 mile radius - covers all New England
+  cityName: 'Boston',
   source: 'legacy-boston',
   locked: true
 };
@@ -1153,6 +1154,7 @@ const BostonCalendarPage = () => {
             events={coloredFilteredEvents}
             eventsLoading={eventsLoading}
             onOpenMapCenter={openMapCenterModal}
+            currentLocation={BOSTON_CONFIG}
             sx={{ mx: 2 }}
           />
 

--- a/src/app/calendar/page.js
+++ b/src/app/calendar/page.js
@@ -61,7 +61,8 @@ const CalendarPage = () => {
     needsOnboarding,
     setNeedsOnboarding,
     saveToCloudDefault,
-    isInitialized: geoInitialized
+    isInitialized: geoInitialized,
+    currentLocation
   } = useGeoLocation();
 
   // Get auth context to check if user is logged in
@@ -1346,6 +1347,7 @@ const CalendarPage = () => {
             eventsLoading={eventsLoading}
             noLocationSelected={noLocationSelected}
             onOpenMapCenter={openMapCenterModal}
+            currentLocation={currentLocation}
             sx={{ mx: 2 }}
           />
 

--- a/src/app/components/Modals/Welcome/WelcomeModal.js
+++ b/src/app/components/Modals/Welcome/WelcomeModal.js
@@ -3,12 +3,13 @@
  *
  * Part of TIEMPO-329: Managed User Entry Flow
  * Updated TIEMPO-388: Try browser geolocation before showing modal
+ * Updated TIEMPO-XXX: Enhanced toast with city name and change button
  *
  * Flow for anonymous users:
  * 1. If user has saved/session location → use it silently
  * 2. If on /boston route → use Boston coordinates (handled elsewhere)
  * 3. Otherwise → TRY browser geolocation first
- *    a. If granted → use it, show toast, DON'T show modal
+ *    a. If granted → use it, show toast with city name, DON'T show modal
  *    b. If denied/timeout → show MapCenterModal
  *
  * @module WelcomeModal
@@ -17,7 +18,9 @@
 'use client';
 
 import { useState, useEffect, useContext } from 'react';
-import { Snackbar, Alert } from '@mui/material';
+import { Snackbar, Alert, Button, Box, Typography, CircularProgress } from '@mui/material';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+import EditLocationIcon from '@mui/icons-material/EditLocation';
 import { AuthContext } from '@/contexts/AuthContext';
 import { useGeoLocation } from '@/contexts/GeoLocationContext';
 import {
@@ -44,14 +47,16 @@ const needsLocationSetup = () => {
  */
 const WelcomeModal = () => {
   const { user } = useContext(AuthContext);
-  const { openMapCenterModal, setSessionLocation } = useGeoLocation();
+  const { openMapCenterModal, setSessionLocation, currentLocation } = useGeoLocation();
   const [hasChecked, setHasChecked] = useState(false);
   const [toastOpen, setToastOpen] = useState(false);
+  const [isNewVisitor, setIsNewVisitor] = useState(false);
 
   useEffect(() => {
     if (hasChecked) return;
 
-    incrementVisitCount();
+    const visitCount = incrementVisitCount();
+    setIsNewVisitor(visitCount <= 5); // First 5 visits = new visitor
 
     // Skip for logged-in users - UserLocationLoader handles their location
     if (user) {
@@ -87,7 +92,7 @@ const WelcomeModal = () => {
           // Show friendly toast instead of modal
           setToastOpen(true);
         },
-        (error) => {
+        (_error) => {
           // Geolocation denied or failed - show modal
           openMapCenterModal();
         },
@@ -105,19 +110,63 @@ const WelcomeModal = () => {
     setHasChecked(true);
   }, [hasChecked, openMapCenterModal, setSessionLocation, user]);
 
+  // Build display text based on city name availability
+  const locationText = currentLocation?.cityName
+    ? `📍 Using ${currentLocation.cityName}`
+    : currentLocation?.cityNameLoading
+      ? '📍 Finding your city...'
+      : '📍 Using your location';
+
+  const handleChangeLocation = () => {
+    setToastOpen(false);
+    openMapCenterModal();
+  };
+
   return (
     <Snackbar
       open={toastOpen}
       onClose={() => setToastOpen(false)}
-      autoHideDuration={4000}
+      autoHideDuration={isNewVisitor ? 8000 : 5000}
       anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
     >
       <Alert
         onClose={() => setToastOpen(false)}
         severity="info"
-        sx={{ backgroundColor: '#1976d2', color: 'white' }}
+        icon={currentLocation?.cityNameLoading ? <CircularProgress size={16} color="inherit" /> : <LocationOnIcon />}
+        sx={{
+          backgroundColor: '#1976d2',
+          color: 'white',
+          alignItems: 'center',
+          '& .MuiAlert-icon': { color: 'white' },
+          '& .MuiAlert-action': { pt: 0 }
+        }}
+        action={
+          <Button
+            color="inherit"
+            size="small"
+            onClick={handleChangeLocation}
+            startIcon={<EditLocationIcon />}
+            sx={{
+              color: 'white',
+              borderColor: 'rgba(255,255,255,0.5)',
+              '&:hover': { borderColor: 'white', bgcolor: 'rgba(255,255,255,0.1)' }
+            }}
+            variant="outlined"
+          >
+            Change
+          </Button>
+        }
       >
-        Using your location. Tap the pill to change.
+        <Box>
+          <Typography variant="body2" sx={{ fontWeight: 500 }}>
+            {locationText}
+          </Typography>
+          {isNewVisitor && (
+            <Typography variant="caption" sx={{ opacity: 0.9, display: 'block' }}>
+              Tip: Use the 🗺️ icon anytime to change
+            </Typography>
+          )}
+        </Box>
       </Alert>
     </Snackbar>
   );

--- a/src/app/components/Providers.js
+++ b/src/app/components/Providers.js
@@ -1,7 +1,7 @@
 // @/components/Providers.js
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { AuthProvider } from '@/contexts/AuthContext';
 import { RoleProvider } from '@/contexts/RoleContext';
@@ -13,6 +13,7 @@ import { EventDiscoveryProvider } from '@/contexts/EventDiscoveryContext';
 import UserLocationLoader from '@/components/UserLocationLoader';
 import { getCachedGeolocation } from '@/utils/trackingHelper';
 import { getCountryMapLocation } from '@/utils/countryCenter';
+import { initializeApiFailover, isUsingFailover } from '@/utils/apiUrlResolver';
 import dynamic from 'next/dynamic';
 
 // Dynamic import to avoid SSR issues with Leaflet
@@ -82,7 +83,55 @@ const MapCenterModalWrapper = () => {
 // MAINTENANCE MODE - blocks entire app when true
 const SHOW_EMERGENCY_ALERT = false;
 
+// Failover indicator component - shows when using backup backend
+const FailoverIndicator = () => {
+  const [showIndicator, setShowIndicator] = useState(false);
+
+  useEffect(() => {
+    // Check if using failover after a small delay to ensure sessionStorage is populated
+    const checkFailover = () => {
+      setShowIndicator(isUsingFailover());
+    };
+    checkFailover();
+    // Re-check periodically in case of runtime failover switch
+    const interval = setInterval(checkFailover, 5000);
+    return () => clearInterval(interval);
+  }, []);
+
+  if (!showIndicator) return null;
+
+  return (
+    <div style={{
+      position: 'fixed',
+      bottom: '10px',
+      right: '10px',
+      backgroundColor: '#ff9800',
+      color: 'black',
+      padding: '6px 12px',
+      borderRadius: '4px',
+      fontSize: '12px',
+      fontWeight: 'bold',
+      zIndex: 9999,
+      boxShadow: '0 2px 8px rgba(0,0,0,0.3)',
+    }}>
+      ⚡ Failover Mode
+    </div>
+  );
+};
+
 const Providers = ({ children }) => {
+  const [apiReady, setApiReady] = useState(false);
+
+  // Initialize API failover on mount
+  useEffect(() => {
+    initializeApiFailover().then(({ url, isFailover }) => {
+      if (isFailover) {
+        console.warn('[Providers] App started in failover mode:', url);
+      }
+      setApiReady(true);
+    });
+  }, []);
+
   // MAINTENANCE MODE: Block entire app, no API calls
   if (SHOW_EMERGENCY_ALERT) {
     return (
@@ -112,6 +161,24 @@ const Providers = ({ children }) => {
     );
   }
 
+  // Show loading spinner while API failover initializes (fast, <2s max)
+  if (!apiReady) {
+    return (
+      <div style={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#1a1a2e',
+      }}>
+        <div style={{ textAlign: 'center', color: 'white' }}>
+          <div style={{ fontSize: '48px', marginBottom: '16px' }}>💃</div>
+          <div style={{ fontSize: '14px', opacity: 0.7 }}>Connecting...</div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <AuthProvider>
       <LocalizationProvider dateAdapter={AdapterDayjs}>
@@ -126,6 +193,7 @@ const Providers = ({ children }) => {
               <EventDiscoveryProvider>
                 <UserLocationLoader />
                 <MapCenterModalWrapper />
+                <FailoverIndicator />
                 {children}
               </EventDiscoveryProvider>
             </GeoLocationProvider>

--- a/src/app/components/UI/NoEventsAlert.js
+++ b/src/app/components/UI/NoEventsAlert.js
@@ -1,10 +1,20 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import PropTypes from 'prop-types';
-import { Alert, AlertTitle, Button, Box, IconButton } from '@mui/material';
+import { Alert, AlertTitle, Button, Box, IconButton, Typography } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
+import MapIcon from '@mui/icons-material/Map';
+import { RoleContext } from '@/contexts/RoleContext';
+import { getVisitCount } from '@/utils/visitorTracking';
+
+// TIEMPO-XXX: Elevated users don't need "no events" prompts - they know the system
+const ELEVATED_ROLES = ['RegionalOrganizer', 'RegionalAdmin', 'SystemAdmin', 'SystemOwner'];
+// TIEMPO-XXX: After 30 visits, assume user knows how to use map center
+const VISIT_THRESHOLD = 30;
+// Auto-dismiss after 8 seconds
+const AUTO_DISMISS_MS = 8000;
 
 /**
  * NoEventsAlert - Displays helpful message when no events are found
@@ -24,16 +34,26 @@ import LocationOnIcon from '@mui/icons-material/LocationOn';
  * @param {Function} props.onOpenMapCenter - Callback to open Map Center modal
  * @param {Object} [props.sx] - Optional MUI sx prop for custom styling
  */
-const NoEventsAlert = ({ events, eventsLoading, noLocationSelected, onOpenMapCenter, sx = {} }) => {
+const NoEventsAlert = ({ events, eventsLoading, noLocationSelected, onOpenMapCenter, currentLocation, sx = {} }) => {
   const [dismissed, setDismissed] = useState(false);
   const [showAlert, setShowAlert] = useState(false);
+  const { selectedRole } = useContext(RoleContext);
 
   // TIEMPO-381: Track Boston route for conditional rendering
   const [isBostonRoute, setIsBostonRoute] = useState(false);
+  // TIEMPO-XXX: Track if user is elevated or experienced
+  const [shouldSuppress, setShouldSuppress] = useState(false);
 
   useEffect(() => {
     setIsBostonRoute(window.location.pathname.includes('/boston'));
   }, []);
+
+  // TIEMPO-XXX: Suppress for elevated users and experienced visitors
+  useEffect(() => {
+    const isElevated = ELEVATED_ROLES.includes(selectedRole);
+    const isExperienced = getVisitCount() >= VISIT_THRESHOLD;
+    setShouldSuppress(isElevated || isExperienced);
+  }, [selectedRole]);
 
   // Check sessionStorage for dismissed state on mount
   useEffect(() => {
@@ -60,7 +80,7 @@ const NoEventsAlert = ({ events, eventsLoading, noLocationSelected, onOpenMapCen
   // Only show after 1 second of no events (after loading completes)
   useEffect(() => {
     let timer;
-    if (!eventsLoading && events && events.length === 0 && !dismissed) {
+    if (!eventsLoading && events && events.length === 0 && !dismissed && !shouldSuppress) {
       // Wait 1 second before showing the alert
       timer = setTimeout(() => {
         setShowAlert(true);
@@ -69,7 +89,18 @@ const NoEventsAlert = ({ events, eventsLoading, noLocationSelected, onOpenMapCen
       setShowAlert(false);
     }
     return () => clearTimeout(timer);
-  }, [eventsLoading, events, dismissed]);
+  }, [eventsLoading, events, dismissed, shouldSuppress]);
+
+  // TIEMPO-XXX: Auto-dismiss after 8 seconds (only for ANON/NU)
+  useEffect(() => {
+    let autoDismissTimer;
+    if (showAlert && !shouldSuppress) {
+      autoDismissTimer = setTimeout(() => {
+        handleDismiss();
+      }, AUTO_DISMISS_MS);
+    }
+    return () => clearTimeout(autoDismissTimer);
+  }, [showAlert, shouldSuppress]);
 
   // Don't show if:
   // - No location selected yet (user hasn't set map center)
@@ -77,14 +108,23 @@ const NoEventsAlert = ({ events, eventsLoading, noLocationSelected, onOpenMapCen
   // - Events exist
   // - User dismissed the alert
   // - Delay hasn't passed yet
-  if (noLocationSelected || eventsLoading || !events || events.length > 0 || dismissed || !showAlert) {
+  // - User is elevated (RO/RA/Admin) or experienced (30+ visits)
+  if (noLocationSelected || eventsLoading || !events || events.length > 0 || dismissed || !showAlert || shouldSuppress) {
     return null;
   }
+
+  // Build location info string if available
+  const locationInfo = currentLocation?.cityName
+    ? `${currentLocation.cityName} (${currentLocation.zoomRange || 50}mi)`
+    : currentLocation?.zoomRange
+      ? `${currentLocation.zoomRange}mi radius`
+      : null;
 
   return (
     <Box sx={{ mb: 2, ...sx }}>
       <Alert
         severity="info"
+        icon={<MapIcon fontSize="small" />}
         action={
           <IconButton
             aria-label="close"
@@ -98,37 +138,43 @@ const NoEventsAlert = ({ events, eventsLoading, noLocationSelected, onOpenMapCen
         sx={{
           '.MuiAlert-message': {
             width: '100%'
-          }
+          },
+          py: 1
         }}
       >
-        <AlertTitle>No Events Found</AlertTitle>
-        <Box sx={{ mb: 1 }}>
+        <AlertTitle sx={{ fontSize: '0.9rem', mb: 0.5 }}>No Events Found</AlertTitle>
+        <Typography variant="body2" sx={{ mb: 1 }}>
           {isBostonRoute
-            ? 'No events found in Boston area for this date range. Check back soon or explore more regions!'
-            : 'No events found in this area and date range. Try adjusting your Map Center location to see more events. Local organizers are invited to add their tango events to this free calendar!'
+            ? 'No events in Boston area for this date range.'
+            : locationInfo
+              ? `No events within ${locationInfo}.`
+              : 'No events in this area and date range.'
           }
+        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+          {isBostonRoute ? (
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<LocationOnIcon />}
+              href="https://www.tangotiempo.com/calendar"
+            >
+              Explore All Regions
+            </Button>
+          ) : (
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<LocationOnIcon />}
+              onClick={onOpenMapCenter}
+            >
+              Change Location
+            </Button>
+          )}
+          <Typography variant="caption" color="text.secondary">
+            Tip: Use 🗺️ icon anytime
+          </Typography>
         </Box>
-        {isBostonRoute ? (
-          <Button
-            size="small"
-            variant="outlined"
-            startIcon={<LocationOnIcon />}
-            href="https://www.tangotiempo.com/calendar"
-            sx={{ mt: 1 }}
-          >
-            Explore All Regions
-          </Button>
-        ) : (
-          <Button
-            size="small"
-            variant="outlined"
-            startIcon={<LocationOnIcon />}
-            onClick={onOpenMapCenter}
-            sx={{ mt: 1 }}
-          >
-            Adjust Map Center
-          </Button>
-        )}
       </Alert>
     </Box>
   );
@@ -139,6 +185,12 @@ NoEventsAlert.propTypes = {
   eventsLoading: PropTypes.bool.isRequired,
   noLocationSelected: PropTypes.bool,
   onOpenMapCenter: PropTypes.func.isRequired,
+  currentLocation: PropTypes.shape({
+    lat: PropTypes.number,
+    lng: PropTypes.number,
+    zoomRange: PropTypes.number,
+    cityName: PropTypes.string
+  }),
   sx: PropTypes.object
 };
 

--- a/src/app/components/UI/SiteMenuBarUserDrawer.js
+++ b/src/app/components/UI/SiteMenuBarUserDrawer.js
@@ -349,21 +349,29 @@ const SiteMenuBarUserDrawer = ({ userDrawerOpen, handleUserDrawerClose, showRole
                         cursor: 'pointer',
                       }}
                     >
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                        {!msg.receipt?.acknowledgedAt && (
-                          <MailIcon sx={{ fontSize: 16, color: 'primary.main', flexShrink: 0 }} />
-                        )}
+                      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
                         <Typography
-                          variant="body2"
-                          sx={{
-                            fontWeight: msg.receipt?.acknowledgedAt ? 'normal' : 'bold',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            whiteSpace: 'nowrap',
-                          }}
+                          variant="caption"
+                          sx={{ color: 'text.secondary', fontSize: '0.7rem' }}
                         >
-                          {msg.title}
+                          {msg.createdAt?.toLocaleDateString?.() || ''}
                         </Typography>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                          {!msg.receipt?.acknowledgedAt && (
+                            <MailIcon sx={{ fontSize: 16, color: 'primary.main', flexShrink: 0 }} />
+                          )}
+                          <Typography
+                            variant="body2"
+                            sx={{
+                              fontWeight: msg.receipt?.acknowledgedAt ? 'normal' : 'bold',
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              whiteSpace: 'nowrap',
+                            }}
+                          >
+                            {msg.title}
+                          </Typography>
+                        </Box>
                       </Box>
                     </Box>
                   ))

--- a/src/app/utils/apiUrlResolver.js
+++ b/src/app/utils/apiUrlResolver.js
@@ -1,26 +1,46 @@
 /**
  * API URL Resolver
  *
- * Central utility to resolve API base URLs based on the AF_ENABLED feature flag.
- * This allows clean migration from calendar-be to calendar-be-af.
+ * Central utility to resolve API base URLs with automatic failover support.
  *
  * Usage:
- *   import { getApiBaseUrl, getApiUrl } from '@/utils/apiUrlResolver';
+ *   import { getApiBaseUrl, getApiUrl, initializeApiFailover } from '@/utils/apiUrlResolver';
  *
- *   // Get base URL
- *   const baseUrl = getApiBaseUrl();  // Returns AF or BE URL based on flag
+ *   // Initialize failover on app startup (call once in Providers)
+ *   await initializeApiFailover();
+ *
+ *   // Get base URL (returns active URL after failover check)
+ *   const baseUrl = getApiBaseUrl();
  *
  *   // Get full endpoint URL
  *   const eventsUrl = getApiUrl('/api/events');
  *
  * Configuration:
- *   - NEXT_PUBLIC_AF_ENABLED=true  -> Use Azure Functions (NEXT_PUBLIC_AF_URL)
- *   - NEXT_PUBLIC_AF_ENABLED=false -> Use Express BE (NEXT_PUBLIC_BE_URL)
+ *   - NEXT_PUBLIC_AF_URL          -> Primary Azure Functions URL
+ *   - NEXT_PUBLIC_AF_URL_FAILOVER -> Failover Azure Functions URL
+ *   - NEXT_PUBLIC_AF_ENABLED=true -> Use Azure Functions
+ *
+ * Failover Behavior:
+ *   - On startup, health check primary URL
+ *   - If primary fails, switch to failover
+ *   - Active URL stored in sessionStorage for consistency
+ *   - Runtime failures trigger failover switch
  *
  * @module apiUrlResolver
  * @since 2026-01-22
- * @author Quinn (Migration Agent)
+ * @updated 2026-03-30 - Added failover support (Sarah)
  */
+
+// Session storage key for active URL
+const ACTIVE_URL_KEY = 'api_active_url';
+const FAILOVER_STATE_KEY = 'api_failover_active';
+
+// Health check timeout (fail fast)
+const HEALTH_CHECK_TIMEOUT = 2000; // 2 seconds
+
+// Module-level state (for SSR safety, initialized to null)
+let activeUrlOverride = null;
+let failoverInitialized = false;
 
 /**
  * Check if Azure Functions backend is enabled
@@ -31,12 +51,167 @@ export function isAFEnabled() {
 }
 
 /**
- * Get the base API URL based on feature flag
+ * Get the primary AF URL
+ * @returns {string} Primary URL
+ */
+function getPrimaryUrl() {
+  return process.env.NEXT_PUBLIC_AF_URL || 'http://localhost:7071';
+}
+
+/**
+ * Get the failover AF URL
+ * @returns {string|null} Failover URL or null if not configured
+ */
+function getFailoverUrl() {
+  return process.env.NEXT_PUBLIC_AF_URL_FAILOVER || null;
+}
+
+/**
+ * Check if a backend URL is healthy
+ * @param {string} url - The base URL to check
+ * @returns {Promise<boolean>} True if healthy
+ */
+async function checkHealth(url) {
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), HEALTH_CHECK_TIMEOUT);
+
+    // Use /api/roles as health check (lightweight, no auth required)
+    const response = await fetch(`${url}/api/roles?appId=1`, {
+      method: 'GET',
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+    return response.ok;
+  } catch {
+    // Network error, timeout, or abort
+    return false;
+  }
+}
+
+/**
+ * Get the currently active URL from sessionStorage
+ * @returns {string|null} Stored active URL or null
+ */
+function getStoredActiveUrl() {
+  if (typeof window === 'undefined') return null;
+  return sessionStorage.getItem(ACTIVE_URL_KEY);
+}
+
+/**
+ * Store the active URL in sessionStorage
+ * @param {string} url - The URL to store
+ * @param {boolean} isFailover - Whether this is the failover URL
+ */
+function storeActiveUrl(url, isFailover) {
+  if (typeof window === 'undefined') return;
+  sessionStorage.setItem(ACTIVE_URL_KEY, url);
+  sessionStorage.setItem(FAILOVER_STATE_KEY, isFailover ? 'true' : 'false');
+}
+
+/**
+ * Check if currently using failover
+ * @returns {boolean} True if on failover
+ */
+export function isUsingFailover() {
+  if (typeof window === 'undefined') return false;
+  return sessionStorage.getItem(FAILOVER_STATE_KEY) === 'true';
+}
+
+/**
+ * Initialize API failover - call on app startup
+ * Checks primary URL health, switches to failover if needed
+ * @returns {Promise<{url: string, isFailover: boolean}>} Active URL info
+ */
+export async function initializeApiFailover() {
+  // Skip on server-side
+  if (typeof window === 'undefined') {
+    return { url: getPrimaryUrl(), isFailover: false };
+  }
+
+  // Skip if already initialized this session
+  if (failoverInitialized) {
+    const storedUrl = getStoredActiveUrl();
+    if (storedUrl) {
+      return { url: storedUrl, isFailover: isUsingFailover() };
+    }
+  }
+
+  const primaryUrl = getPrimaryUrl();
+  const failoverUrl = getFailoverUrl();
+
+  // No failover configured - just use primary
+  if (!failoverUrl) {
+    storeActiveUrl(primaryUrl, false);
+    failoverInitialized = true;
+    return { url: primaryUrl, isFailover: false };
+  }
+
+  // Check primary health
+  console.log('[API Failover] Checking primary backend health...');
+  const primaryHealthy = await checkHealth(primaryUrl);
+
+  if (primaryHealthy) {
+    console.log('[API Failover] Primary backend healthy:', primaryUrl);
+    storeActiveUrl(primaryUrl, false);
+    activeUrlOverride = null;
+    failoverInitialized = true;
+    return { url: primaryUrl, isFailover: false };
+  }
+
+  // Primary unhealthy - check failover
+  console.warn('[API Failover] Primary backend unhealthy, checking failover...');
+  const failoverHealthy = await checkHealth(failoverUrl);
+
+  if (failoverHealthy) {
+    console.warn('[API Failover] Switched to failover backend:', failoverUrl);
+    storeActiveUrl(failoverUrl, true);
+    activeUrlOverride = failoverUrl;
+    failoverInitialized = true;
+    return { url: failoverUrl, isFailover: true };
+  }
+
+  // Both unhealthy - use primary anyway (let requests fail with better errors)
+  console.error('[API Failover] Both backends unhealthy! Using primary.');
+  storeActiveUrl(primaryUrl, false);
+  failoverInitialized = true;
+  return { url: primaryUrl, isFailover: false };
+}
+
+/**
+ * Switch to failover URL (call on runtime API failure)
+ * @returns {string|null} Failover URL or null if not available
+ */
+export function switchToFailover() {
+  const failoverUrl = getFailoverUrl();
+  if (!failoverUrl) return null;
+
+  console.warn('[API Failover] Runtime switch to failover:', failoverUrl);
+  storeActiveUrl(failoverUrl, true);
+  activeUrlOverride = failoverUrl;
+  return failoverUrl;
+}
+
+/**
+ * Get the base API URL based on feature flag and failover state
  * @returns {string} The base URL for API calls
  */
 export function getApiBaseUrl() {
   if (isAFEnabled()) {
-    return process.env.NEXT_PUBLIC_AF_URL || 'http://localhost:7071';
+    // Check for override (failover active)
+    if (activeUrlOverride) {
+      return activeUrlOverride;
+    }
+
+    // Check sessionStorage (persisted failover state)
+    const storedUrl = getStoredActiveUrl();
+    if (storedUrl) {
+      return storedUrl;
+    }
+
+    // Default to primary
+    return getPrimaryUrl();
   }
   return process.env.NEXT_PUBLIC_BE_URL || 'http://localhost:3010';
 }

--- a/src/app/utils/eventCategoryValidation.js
+++ b/src/app/utils/eventCategoryValidation.js
@@ -3,7 +3,7 @@
  *
  * Rules:
  * 1. SHORT events (Milonga, Practica, Class) must be >= 15 minutes and < 24 hours
- * 2. LONG events (Festival, Encuentro, Marathon, Workshop) must be >= 48 hours
+ * 2. LONG events (Festival, Encuentro, Marathon, Workshop) must be >= 24 hours
  * 3. SHORT and LONG categories cannot be mixed (mutual exclusion)
  * 4. SHORT and LONG events cannot exceed 7 days (168 hours)
  *
@@ -54,11 +54,11 @@ export const validateEventCategoryRules = (eventData, selectedRole) => {
     }
   }
 
-  // Rule 2: LONG events must be >= 48 hours
+  // Rule 2: LONG events must be >= 24 hours
   if (LONG_CATEGORIES.includes(categoryFirst)) {
-    if (durationHours < 48) {
+    if (durationHours < 24) {
       const categoryName = categoryFirst === 'Workshop' ? 'Workshops' : `${categoryFirst}s`;
-      errors.push(`${categoryName} must be 48 hours or longer. Current duration: ${Math.round(durationHours)} hours.`);
+      errors.push(`${categoryName} must be 24 hours or longer. Current duration: ${Math.round(durationHours)} hours.`);
     }
   }
 

--- a/src/app/utils/geolocationHelper.js
+++ b/src/app/utils/geolocationHelper.js
@@ -47,24 +47,28 @@ export const getBrowserGeolocation = async () => {
  * PERFORMANCE FIX (2026-03-23): Added caching and rate-limit tracking
  * to reduce 429 errors (was 150/day before fix)
  *
+ * TIEMPO-XXX (2026-03-30): Changed cache from sessionStorage to localStorage
+ * with 24h TTL to further reduce 429 errors (was 87% of all API errors).
+ * Rate limit flag stays in sessionStorage (clears on new session = retry).
+ *
  * @returns {Promise<object|null>} { lat, long } or null
  */
 export const getGoogleAPIGeolocation = async () => {
   const CACHE_KEY = 'google_geo_cache';
   const RATE_LIMIT_KEY = 'google_geo_rate_limited';
-  const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+  const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours (was 5 minutes)
 
-  // Check sessionStorage cache first
-  if (typeof window !== 'undefined' && window.sessionStorage) {
+  // Check localStorage cache first (persists across sessions)
+  if (typeof window !== 'undefined') {
     try {
-      // Check if rate limited (skip API entirely for this session)
-      if (sessionStorage.getItem(RATE_LIMIT_KEY)) {
+      // Check if rate limited this session (sessionStorage - clears on tab close)
+      if (window.sessionStorage?.getItem(RATE_LIMIT_KEY)) {
         console.warn('[Geolocation] Skipping Google API - rate limited this session');
         return null;
       }
 
-      // Check cache
-      const cached = sessionStorage.getItem(CACHE_KEY);
+      // Check cache (localStorage - persists across sessions)
+      const cached = window.localStorage?.getItem(CACHE_KEY);
       if (cached) {
         const { data, timestamp } = JSON.parse(cached);
         if (Date.now() - timestamp < CACHE_TTL_MS) {
@@ -72,7 +76,7 @@ export const getGoogleAPIGeolocation = async () => {
         }
       }
     } catch {
-      // sessionStorage errors (private browsing, etc.) - continue without cache
+      // Storage errors (private browsing, etc.) - continue without cache
     }
   }
 
@@ -112,10 +116,10 @@ export const getGoogleAPIGeolocation = async () => {
       long: data.location.lng
     };
 
-    // Cache successful response
-    if (typeof window !== 'undefined' && window.sessionStorage) {
+    // Cache successful response in localStorage (persists 24h)
+    if (typeof window !== 'undefined' && window.localStorage) {
       try {
-        sessionStorage.setItem(CACHE_KEY, JSON.stringify({
+        localStorage.setItem(CACHE_KEY, JSON.stringify({
           data: geoResult,
           timestamp: Date.now()
         }));


### PR DESCRIPTION
## Summary
- **v1.21.5**: BE Failover support (PROD2 backup), Google Geo cache (24h), NoEventsAlert improvements, LocationToast enhancements
- **v1.21.6**: Message date display in user drawer
- **v1.21.7**: Event duration validation fix (48h → 24h for LONG events)

## Changes
- `apiUrlResolver.js` — Failover logic with health check
- `Providers.js` — Failover init + indicator
- `SiteMenuBarUserDrawer.js` — Message date display
- `NoEventsAlert.js` — Role/visit awareness, auto-dismiss
- `WelcomeModal.js` — City name in toast, [Change] button
- `geolocationHelper.js` — localStorage + 24h TTL
- `eventCategoryValidation.js` — 48h → 24h for Festival/Marathon/Workshop

## Test Plan
- [x] BE Failover: Health check on startup, no badge when primary healthy
- [x] Message date: Shows above title in drawer
- [x] Duration validation: Festival 3h rejected with "24 hours" message
- [x] Geo cache: localStorage persists across sessions
- [x] NoEventsAlert: Auto-dismiss, role exemption

🤖 Generated with [Claude Code](https://claude.com/claude-code)