### PR TITLE
Release v1.22.8 - isDiscovered styling improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
-  "version": "1.22.6",
+  "version": "1.22.7",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
-  "version": "1.22.7",
+  "version": "1.22.8",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/calendar/boston/page.js
+++ b/src/app/calendar/boston/page.js
@@ -594,9 +594,6 @@ const BostonCalendarPage = () => {
         ? formatVenueTimeForCalendar(event.extendedProps.venueStartDisplay, event.extendedProps.venueEndDisplay, event.extendedProps.venueAbbr)
         : formatTimeForListView(event.start, event.end);
 
-      // Detect mobile for wrapping behavior
-      const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
-
       return (
         <div style={{
           padding: '4px 2px',
@@ -651,8 +648,7 @@ const BostonCalendarPage = () => {
               <div style={{
                 display: 'flex',
                 alignItems: 'center',
-                gap: '8px',
-                flexWrap: isMobile ? 'wrap' : 'nowrap'
+                gap: '8px'
               }}>
                 {/* TIEMPO-388: Show ⚠️ alert icon instead of time for canceled events */}
                 {isCanceled || getFeatureData(event)?.isCanceled ? (
@@ -681,7 +677,7 @@ const BostonCalendarPage = () => {
                       fontWeight: 'bold',
                       color: '#333',
                       overflow: 'visible',
-                      whiteSpace: isMobile ? 'normal' : 'nowrap',
+                      whiteSpace: 'nowrap',
                       flexShrink: 1,
                       lineHeight: '1.2',
                       textDecoration: isCanceled ? 'line-through' : 'none'
@@ -696,7 +692,7 @@ const BostonCalendarPage = () => {
                           fontWeight: 'normal',
                           color: '#666',
                           overflow: 'visible',
-                          whiteSpace: isMobile ? 'normal' : 'nowrap',
+                          whiteSpace: 'nowrap',
                           flexShrink: 1,
                           lineHeight: '1.2',
                           textDecoration: isCanceled ? 'line-through' : 'none'

--- a/src/app/calendar/boston/page.js
+++ b/src/app/calendar/boston/page.js
@@ -333,12 +333,15 @@ const BostonCalendarPage = () => {
                 gap: '3px',
                 marginBottom: '1px'
               }}>
-                <span style={{ color: '#C00', fontSize: '0.8rem' }}>🤖</span>
+                <span style={{ position: 'relative', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <span style={{ color: '#C00', fontSize: '0.75rem' }}>🤖</span>
+                  <span style={{ position: 'absolute', top: '-3px', left: '50%', transform: 'translateX(-50%)', fontSize: '0.35rem', fontWeight: 'bold', color: '#fff', background: '#C00', borderRadius: '2px', padding: '0 2px', lineHeight: 1.2 }}>AI</span>
+                </span>
                 <CategoryCircles eventProps={{...event.extendedProps, categorySecond: null, categoryThird: null}} />
                 <div style={{
-                  fontSize: '0.75rem',
-                  fontWeight: 'bold',
-                  color: '#333',
+                  fontSize: '0.7rem',
+                  fontWeight: 'normal',
+                  color: '#666',
                   overflow: 'hidden',
                   whiteSpace: 'nowrap',
                   textOverflow: 'ellipsis',
@@ -352,11 +355,10 @@ const BostonCalendarPage = () => {
                 display: 'flex',
                 alignItems: 'center',
                 gap: '3px',
-                fontSize: '0.65rem',
-                color: '#555'
+                fontSize: '0.6rem',
+                color: '#777'
               }}>
-                <span style={{ fontStyle: 'italic', color: '#888' }}>AI-found</span>
-                {startTime && <span>· {startTime}</span>}
+                <span style={{ fontStyle: 'italic', color: '#999' }}>AI-found</span>
                 {(event.extendedProps?.venueName || event.extendedProps?.venueCityName) && (
                   <span>· {event.extendedProps.venueName || event.extendedProps.venueCityName}</span>
                 )}
@@ -612,12 +614,15 @@ const BostonCalendarPage = () => {
                 alignItems: 'center',
                 gap: '6px'
               }}>
-                <span style={{ color: '#C00', fontSize: '1rem' }}>🤖</span>
+                <span style={{ position: 'relative', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <span style={{ color: '#C00', fontSize: '0.9rem' }}>🤖</span>
+                  <span style={{ position: 'absolute', top: '-3px', left: '50%', transform: 'translateX(-50%)', fontSize: '0.4rem', fontWeight: 'bold', color: '#fff', background: '#C00', borderRadius: '2px', padding: '0 2px', lineHeight: 1.2 }}>AI</span>
+                </span>
                 <CategoryCircles eventProps={{...event.extendedProps, categorySecond: null, categoryThird: null}} />
                 <div style={{
-                  fontSize: '0.85rem',
-                  fontWeight: 'bold',
-                  color: '#333',
+                  fontSize: '0.8rem',
+                  fontWeight: 'normal',
+                  color: '#666',
                   overflow: 'hidden',
                   whiteSpace: 'nowrap',
                   textOverflow: 'ellipsis',
@@ -631,11 +636,10 @@ const BostonCalendarPage = () => {
                 display: 'flex',
                 alignItems: 'center',
                 gap: '4px',
-                fontSize: '0.75rem',
-                color: '#555'
+                fontSize: '0.7rem',
+                color: '#777'
               }}>
-                <span style={{ fontStyle: 'italic', color: '#888' }}>AI-found</span>
-                {startTime && <span>· {startTime}</span>}
+                <span style={{ fontStyle: 'italic', color: '#999' }}>AI-found</span>
                 {(event.extendedProps?.venueName || event.extendedProps?.venueCityName) && (
                   <span>· {event.extendedProps.venueName || event.extendedProps.venueCityName}</span>
                 )}
@@ -1164,6 +1168,12 @@ const BostonCalendarPage = () => {
             initialView={currentViewType}
             events={coloredFilteredEvents}
             eventClick={handleEventClick}
+            // Sort isDiscovered events after regular events (within same time)
+            eventOrder={(a, b) => {
+              const aDiscovered = a.extendedProps?.isDiscovered ? 1 : 0;
+              const bDiscovered = b.extendedProps?.isDiscovered ? 1 : 0;
+              return aDiscovered - bDiscovered;
+            }}
             // Remove dateClick for read-only view
             headerToolbar={false}
             // TIEMPO-288: Custom date cell content with month abbreviations

--- a/src/app/calendar/page.js
+++ b/src/app/calendar/page.js
@@ -467,12 +467,15 @@ const CalendarPage = () => {
                 gap: '3px',
                 marginBottom: '1px'
               }}>
-                <span style={{ color: '#C00', fontSize: '0.8rem' }}>🤖</span>
+                <span style={{ position: 'relative', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <span style={{ color: '#C00', fontSize: '0.8rem' }}>🤖</span>
+                  <span style={{ position: 'absolute', top: '-3px', left: '50%', transform: 'translateX(-50%)', fontSize: '0.35rem', fontWeight: 'bold', color: '#fff', background: '#C00', borderRadius: '2px', padding: '0 2px', lineHeight: 1.2 }}>AI</span>
+                </span>
                 <CategoryCircles eventProps={{...event.extendedProps, categorySecond: null, categoryThird: null}} />
                 <div style={{
-                  fontSize: '0.75rem',
-                  fontWeight: 'bold',
-                  color: '#333',
+                  fontSize: '0.7rem',
+                  fontWeight: 'normal',
+                  color: '#666',
                   overflow: 'hidden',
                   whiteSpace: 'nowrap',
                   textOverflow: 'ellipsis',
@@ -486,11 +489,10 @@ const CalendarPage = () => {
                 display: 'flex',
                 alignItems: 'center',
                 gap: '3px',
-                fontSize: '0.65rem',
-                color: '#555'
+                fontSize: '0.6rem',
+                color: '#777'
               }}>
-                <span style={{ fontStyle: 'italic', color: '#888' }}>AI-found</span>
-                {startTime && <span>· {startTime}</span>}
+                <span style={{ fontStyle: 'italic', color: '#999' }}>AI-found</span>
                 {(event.extendedProps?.venueName || event.extendedProps?.venueCityName) && (
                   <span>· {event.extendedProps.venueName || event.extendedProps.venueCityName}</span>
                 )}
@@ -773,12 +775,15 @@ const CalendarPage = () => {
                 alignItems: 'center',
                 gap: '6px'
               }}>
-                <span style={{ color: '#C00', fontSize: '1rem' }}>🤖</span>
+                <span style={{ position: 'relative', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <span style={{ color: '#C00', fontSize: '0.9rem' }}>🤖</span>
+                  <span style={{ position: 'absolute', top: '-3px', left: '50%', transform: 'translateX(-50%)', fontSize: '0.4rem', fontWeight: 'bold', color: '#fff', background: '#C00', borderRadius: '2px', padding: '0 2px', lineHeight: 1.2 }}>AI</span>
+                </span>
                 <CategoryCircles eventProps={{...event.extendedProps, categorySecond: null, categoryThird: null}} />
                 <div style={{
-                  fontSize: '0.85rem',
-                  fontWeight: 'bold',
-                  color: '#333',
+                  fontSize: '0.8rem',
+                  fontWeight: 'normal',
+                  color: '#666',
                   overflow: 'hidden',
                   whiteSpace: 'nowrap',
                   textOverflow: 'ellipsis',
@@ -792,11 +797,10 @@ const CalendarPage = () => {
                 display: 'flex',
                 alignItems: 'center',
                 gap: '4px',
-                fontSize: '0.75rem',
-                color: '#555'
+                fontSize: '0.7rem',
+                color: '#777'
               }}>
-                <span style={{ fontStyle: 'italic', color: '#888' }}>AI-found</span>
-                {startTime && <span>· {startTime}</span>}
+                <span style={{ fontStyle: 'italic', color: '#999' }}>AI-found</span>
                 {(event.extendedProps?.venueName || event.extendedProps?.venueCityName) && (
                   <span>· {event.extendedProps.venueName || event.extendedProps.venueCityName}</span>
                 )}
@@ -1359,6 +1363,12 @@ const CalendarPage = () => {
           //        initialView="dayGridMonth"
           initialView={getInitialView()}
           events={eventsWithPlaceholders}
+          // Sort isDiscovered events after regular events (within same time)
+          eventOrder={(a, b) => {
+            const aDiscovered = a.extendedProps?.isDiscovered ? 1 : 0;
+            const bDiscovered = b.extendedProps?.isDiscovered ? 1 : 0;
+            return aDiscovered - bDiscovered;
+          }}
           // TIEMPO-288: Custom date cell content with month abbreviations
           dayCellContent={(arg) => {
             // Apply to both month view and 8-week view

--- a/src/app/components/UI/SiteMenuBar.js
+++ b/src/app/components/UI/SiteMenuBar.js
@@ -5,7 +5,6 @@ import MenuIcon from '@mui/icons-material/Menu';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import SearchIcon from '@mui/icons-material/Search';
 import CloseIcon from '@mui/icons-material/Close';
-import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import MailIcon from '@mui/icons-material/Mail';
 import { useSiteMenuBar } from '@/hooks/useSiteMenuBar';
 import { useMessages } from '@/hooks/useMessages';
@@ -151,10 +150,25 @@ const SiteMenuBar = ({ activeCategories, handleCategoryChange, categories, searc
           <IconButton
             onClick={onDiscoveredToggle}
             sx={{
-              color: showDiscovered ? 'primary.main' : 'action.disabled',
+              opacity: showDiscovered ? 1 : 0.4,
             }}
           >
-            <AutoAwesomeIcon />
+            <span style={{ position: 'relative', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
+              <span style={{ fontSize: '1.3rem' }}>🤖</span>
+              <span style={{
+                position: 'absolute',
+                top: '-4px',
+                left: '50%',
+                transform: 'translateX(-50%)',
+                fontSize: '0.5rem',
+                fontWeight: 'bold',
+                color: '#fff',
+                background: showDiscovered ? '#1976d2' : '#999',
+                borderRadius: '3px',
+                padding: '0 3px',
+                lineHeight: 1.3
+              }}>AI</span>
+            </span>
           </IconButton>
         </Tooltip>
 


### PR DESCRIPTION
## Release v1.22.8

### Changes
- isDiscovered events: smaller/greyer, grouped after regular events
- 🤖+AI badges on event rows and toggle button
- Remove time display from isDiscovered events
- Sync boston calendar nowrap behavior

### Testing
- ✅ Verified on test.tangotiempo.com
- ✅ All 4 calendar views synced
- ✅ Font sizes, weights, wraps consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)