### PR TITLE
chore: Bump to v1.22.10 for outreach onboarding PROD promotion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
-  "version": "1.22.9",
+  "version": "1.22.10",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump `package.json` version 1.22.9 → 1.22.10
- Required by promotion rule: no TEST→PROD promotion without a version increment
- This is the version bundle we intend to promote to PROD for outreach onboarding

## Context
TEST was cut at v1.22.9 (outreach onboarding + spotlight fix + eventOverrides fix + isDiscovered styling). To promote that bundle to PROD, we bump to 1.22.10 per CLAUDE.md rule.

## Coordinated promotion (not in this PR)
1. Fulton: BE outreach endpoints → calendarbeaf-prod + OUTREACH_API_KEY set
2. AIDI: seed TangoTiempoProd.outreachTokens
3. Toby: verify PROD Firebase email/password provider on `tangotiempoprod` project
4. This FE PR merges DEVL → then DEVL→TEST → then TEST→PROD with DEPLOY-PROD confirmation

## Test plan
- [ ] No code changes — version-only bump
- [ ] After merge to DEVL, Sarah promotes DEVL→TEST
- [ ] Wait for BE PROD + data seed before FE PROD checkpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)