### PR TITLE
fix(apply): Make organizerRegion optional, remove hardcoded fallback ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
-  "version": "1.22.10",
+  "version": "1.22.11",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/components/Modals/UserSettings/UserSettingsApply.js
+++ b/src/app/components/Modals/UserSettings/UserSettingsApply.js
@@ -110,11 +110,12 @@ const UserSettingsApply = () => {
 
       // Create an organizer if needed
       if (!hasOrganizerId && userData._id) {
-        // Use a default region if user's region is not available
-        const defaultRegionId = '66c4d99042ec462ea22484bd'; // Fallback region ID
-
         const fullName = `${userData?.localUserInfo?.firstName || 'New'} ${userData?.localUserInfo?.lastName || 'Organizer'}`;
         const shortName = `${userData?.localUserInfo?.firstName || 'New'}${userData?.localUserInfo?.lastName ? ' ' + userData?.localUserInfo?.lastName.charAt(0) : ''}`;
+
+        // organizerRegion is optional — backend writes null when omitted. Only pass
+        // through if the user has set a region default. No hardcoded fallback.
+        const userRegionId = userData?.localUserInfo?.userDefaults?.region;
 
         const organizerData = {
           linkedUserLogin: userData._id,
@@ -123,7 +124,7 @@ const UserSettingsApply = () => {
           fullName: fullName,
           shortName: shortName, // REQUIRED by backend - generated from user name
           contactEmail: user?.email || userData.firebaseUserId || '', // REQUIRED by backend API - from Firebase Auth
-          organizerRegion: userData?.localUserInfo?.userDefaults?.region || defaultRegionId,
+          ...(userRegionId && { organizerRegion: userRegionId }),
           isActive: true,
           isEnabled: false,  // Requires manual enable for safety
           wantRender: false, // Not searchable until enabled

--- a/src/app/organizers/apply/components/OutreachApplyForm.js
+++ b/src/app/organizers/apply/components/OutreachApplyForm.js
@@ -343,12 +343,9 @@ const OutreachApplyForm = () => {
       }
 
       // Step 3: Create organizer record
+      // organizerRegion is optional — backend writes null when omitted. Only pass
+      // through if we have a real value from the orgToken prefill or user defaults.
       const resolvedRegionId = prefillData?.regionId || userData?.localUserInfo?.userDefaults?.region || null;
-      if (!resolvedRegionId) {
-        setSubmitError('Unable to determine your region. Please contact support or use the standard application.');
-        setSubmitting(false);
-        return;
-      }
 
       const organizerPayload = {
         linkedUserLogin: userData._id,
@@ -360,7 +357,7 @@ const OutreachApplyForm = () => {
         contactEmail: formData.contactEmail,
         description: formData.description,
         website: formData.website || '',
-        organizerRegion: resolvedRegionId,
+        ...(resolvedRegionId && { organizerRegion: resolvedRegionId }),
         isActive: true,
         isEnabled: true,
         wantRender: true,


### PR DESCRIPTION
## Summary
- Both organizer apply flows (outreach + legacy UserSettings) required `organizerRegion` to submit
- AIDI's first real E2E outreach test (WaiLing Ho Balsley) hit the block — no resolvable regionId → "Unable to determine your region" error
- Legacy UserSettingsApply silently papered over the same gap with a hardcoded Mongo ID fallback (`'66c4d99042ec462ea22484bd'`), violating YBOTBOT success criterion #11

## Changes
- `OutreachApplyForm.js` — drop the region-resolution throw; conditionally spread `organizerRegion` into payload only when prefill or user defaults supply a real value
- `UserSettingsApply.js` — delete hardcoded fallback ID; same conditional-spread pattern

## Why no backend change
Fulton confirmed `calendar-be-af` uses raw MongoClient (no Mongoose schema). `createOrganizer` already does `organizerRegion: body.organizerRegion || null` — omitting the field is identical to what the backend writes today when missing. Zero-risk wire format change.

## Null-safety audit
- `organizers/[slug]/page.js:74` — already null-safe via `|| {}` fallback
- `useOrganizers.js:83` — already conditional on `masteredRegionId`; null org-region correctly excludes from regional filters
- CalOps (Dash's domain) — heads-up sent via hub, eyeball pending on TEST

## Test plan
- [ ] Local dev: run outreach apply flow with an orgToken that has no regionId → form submits successfully
- [ ] Local dev: run standard UserSettings apply with a user that has no `userDefaults.region` → form submits successfully
- [ ] Verify existing organizers with populated `organizerRegion` still render correctly on `/organizers/[slug]`
- [ ] TEST deploy: retry WaiLing-equivalent E2E via calendar-campaigns → orgToken → TT apply
- [ ] CalOps eyeball from Dash on organizers list/filter with null-region orgs

## References
- Source: AIDI E2E test report on 2026-04-09
- Fulton's scout reply confirming backend already tolerant
- YBOTBOT success criterion #11 (no hardcoded Mongo IDs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)