### PR TITLE
fix(apply): Make organizerRegion optional + v1.22.11 (→ TEST)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
-  "version": "1.22.10",
+  "version": "1.22.11",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/components/Modals/UserSettings/UserSettingsApply.js
+++ b/src/app/components/Modals/UserSettings/UserSettingsApply.js
@@ -110,11 +110,12 @@ const UserSettingsApply = () => {
 
       // Create an organizer if needed
       if (!hasOrganizerId && userData._id) {
-        // Use a default region if user's region is not available
-        const defaultRegionId = '66c4d99042ec462ea22484bd'; // Fallback region ID
-
         const fullName = `${userData?.localUserInfo?.firstName || 'New'} ${userData?.localUserInfo?.lastName || 'Organizer'}`;
         const shortName = `${userData?.localUserInfo?.firstName || 'New'}${userData?.localUserInfo?.lastName ? ' ' + userData?.localUserInfo?.lastName.charAt(0) : ''}`;
+
+        // organizerRegion is optional — backend writes null when omitted. Only pass
+        // through if the user has set a region default. No hardcoded fallback.
+        const userRegionId = userData?.localUserInfo?.userDefaults?.region;
 
         const organizerData = {
           linkedUserLogin: userData._id,
@@ -123,7 +124,7 @@ const UserSettingsApply = () => {
           fullName: fullName,
           shortName: shortName, // REQUIRED by backend - generated from user name
           contactEmail: user?.email || userData.firebaseUserId || '', // REQUIRED by backend API - from Firebase Auth
-          organizerRegion: userData?.localUserInfo?.userDefaults?.region || defaultRegionId,
+          ...(userRegionId && { organizerRegion: userRegionId }),
           isActive: true,
           isEnabled: false,  // Requires manual enable for safety
           wantRender: false, // Not searchable until enabled

--- a/src/app/organizers/apply/components/OutreachApplyForm.js
+++ b/src/app/organizers/apply/components/OutreachApplyForm.js
@@ -343,12 +343,9 @@ const OutreachApplyForm = () => {
       }
 
       // Step 3: Create organizer record
+      // organizerRegion is optional — backend writes null when omitted. Only pass
+      // through if we have a real value from the orgToken prefill or user defaults.
       const resolvedRegionId = prefillData?.regionId || userData?.localUserInfo?.userDefaults?.region || null;
-      if (!resolvedRegionId) {
-        setSubmitError('Unable to determine your region. Please contact support or use the standard application.');
-        setSubmitting(false);
-        return;
-      }
 
       const organizerPayload = {
         linkedUserLogin: userData._id,
@@ -360,7 +357,7 @@ const OutreachApplyForm = () => {
         contactEmail: formData.contactEmail,
         description: formData.description,
         website: formData.website || '',
-        organizerRegion: resolvedRegionId,
+        ...(resolvedRegionId && { organizerRegion: resolvedRegionId }),
         isActive: true,
         isEnabled: true,
         wantRender: true,


### PR DESCRIPTION
## Summary
Promotes the organizerRegion-optional fix from DEVL (PR #172) onto TEST via cherry-pick path, because DEVL and TEST have diverged branch histories (two different v1.22.10 bump SHAs). Cherry-pick avoids a DEVL realignment rabbit hole and ships the fix fast.

- Drops the "Unable to determine your region" block in outreach apply
- Removes hardcoded Mongo ID fallback from UserSettings apply (success criterion #11 violation)
- Bumps to v1.22.11

## Context
AIDI's first real E2E outreach test (WaiLing Ho Balsley) hit the region block. Fulton confirmed calendar-be-af has no Mongoose schema — backend already writes null when field omitted. Zero backend change needed.

## Test plan
- [ ] Vercel TEST auto-deploy succeeds
- [ ] Visit tangotiempo-test.vercel.app/organizers/apply?orgToken=... — submit without region → success
- [ ] AIDI retries WaiLing E2E end-to-end against TEST
- [ ] Dash eyeballs CalOps organizer list/filter against any null-region orgs created

## Follow-up
- Open separate PROD → DEVL backport + DEVL → region-fix cherry-merge to realign DEVL before next DEVL promotion
- Cord: parallel HJ cleanup after this lands

## References
- Origin: PR #172 (DEVL merge)
- Fulton scout: no backend work needed
- AIDI outreach E2E test 2026-04-09

🤖 Generated with [Claude Code](https://claude.com/claude-code)