### PR TITLE
test(MapCenterModal): add 6 data-testid attrs for E2E framework [TIEMPO-399]

### DIFF
--- a/src/app/components/Modals/misc/MapCenterModal.js
+++ b/src/app/components/Modals/misc/MapCenterModal.js
@@ -835,6 +835,7 @@ const MapCenterModal = ({
       onClose={onClose}
       maxWidth="md"
       fullWidth
+      data-testid="map-center-modal"
       PaperProps={{
         sx: {
           height: isMobile ? '95vh' : '90vh',
@@ -853,7 +854,7 @@ const MapCenterModal = ({
           <LocationOnIcon color="primary" />
           <Typography variant="h6">Map Center Settings</Typography>
         </Box>
-        <IconButton onClick={onClose} size="small">
+        <IconButton onClick={onClose} size="small" data-testid="map-center-close">
           <CloseIcon />
         </IconButton>
       </DialogTitle>
@@ -913,6 +914,7 @@ const MapCenterModal = ({
               onClick={handleSave}
               disabled={loading || !centerLat || !centerLng}
               size="small"
+              data-testid="map-center-save"
               startIcon={loading ? <CircularProgress size={14} color="inherit" /> : <LocationOnIcon />}
               sx={centerLat && centerLng ? {
                 animation: 'pulse 1.5s ease-in-out 3',
@@ -985,6 +987,7 @@ const MapCenterModal = ({
               size="small"
               color="primary"
               title="Use my current location"
+              data-testid="map-center-use-my-location"
             >
               {gettingLocation ? <CircularProgress size={18} /> : <MyLocationIcon />}
             </IconButton>
@@ -1012,6 +1015,10 @@ const MapCenterModal = ({
               variant="outlined"
               size="small"
               sx={{ mb: 1 }}
+              inputProps={{
+                ...params.inputProps,
+                'data-testid': 'map-center-city-search',
+              }}
               InputProps={{
                 ...params.InputProps,
                 endAdornment: (
@@ -1024,7 +1031,11 @@ const MapCenterModal = ({
             />
           )}
           renderOption={(props, option) => (
-            <li {...props} key={option._id || option.cityName}>
+            <li
+              {...props}
+              key={option._id || option.cityName}
+              data-testid={`city-option-${String(option.cityName || '').toLowerCase().trim().replace(/\s+/g, '-')}`}
+            >
               <Box>
                 <Typography variant="body2" sx={{ fontWeight: 500 }}>
                   {option.cityName}


### PR DESCRIPTION
## Summary
- Adds 6 `data-testid` attributes to `MapCenterModal.js` to unblock Gauge/Playwright in the E2E framework
- Zero logic changes, 13 insertions / 2 deletions
- T1-tier framework-enablement patch per Quinn coordinator-authority

## Testids added
- `map-center-modal` (Dialog root)
- `map-center-close` (X IconButton in DialogTitle)
- `map-center-save` (SET Button)
- `map-center-use-my-location` (geo IconButton)
- `map-center-city-search` (Autocomplete input)
- `city-option-<slug>` (each Autocomplete option, slug is lowercased + hyphenated cityName)

## Why
Gauge on UC-0001 found `role=button name=/^Boston/` matched both the Autocomplete dropdown option AND a Leaflet density marker on the embedded map — genuine DOM-level ambiguity. These testids give stable, deterministic selectors for the Autocomplete flow. Leaflet markers are NOT testid'd — they're fragile, rebuilt on redraw.

## Test plan
- [x] Visual: testids verified in source at commit 30e1a3de
- [ ] Deploy to DEVL preview (via this PR merge)
- [ ] Quinn re-spawns Gauge against DEVL preview URL
- [ ] Gauge UC-0001 passes

## Context
- TIEMPO-399
- Related: ORGANIZER-SHORTNAME-DESIGN.md (indirect — unblocks Phase 1 calibration so E2E framework can keep up with §3 feature work)
- Coordinator: Quinn authorized via hub 2026-04-14

🤖 Generated with [Claude Code](https://claude.com/claude-code)