### PR TITLE
chore: Bump to v1.22.12 [TIEMPO-399 TEST promotion]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
-  "version": "1.22.11",
+  "version": "1.22.12",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",


### PR DESCRIPTION
Version bump for DEVL→TEST promotion of MapCenterModal testids (PR #174). Required by GIT-BRANCHING-STRATEGY.md. Coordinator green-light from Quinn.