### PR TITLE
feat(events): beginnerFriendly checkbox on event form (TIEMPO-401)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
-  "version": "1.22.12",
+  "version": "1.22.13",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/components/Modals/CreateEvents/CreateEventDetailModal.js
+++ b/src/app/components/Modals/CreateEvents/CreateEventDetailModal.js
@@ -103,6 +103,8 @@ const CreateEventModal = ({ open, onClose, selectedDate, editMode = false, event
       // Other fields
       isRepeating: false,
       isCanceled: false,
+      // TIEMPO-401: Beginner-friendly flag (gates Beginner UX mode)
+      beginnerFriendly: false,
       // TIEMPO-388: Spotlights for non-repeating events
       spotlights: [],
       features: [],
@@ -219,6 +221,9 @@ const CreateEventModal = ({ open, onClose, selectedDate, editMode = false, event
           
           // Cancellation status
           isCanceled: eventToEdit.isCanceled || false,
+
+          // TIEMPO-401: Beginner-friendly flag
+          beginnerFriendly: eventToEdit.beginnerFriendly || false,
 
           // TIEMPO-388: Spotlights (features) for non-repeating events
           spotlights: eventToEdit.spotlights || eventToEdit.features || [],

--- a/src/app/components/Modals/CreateEvents/CreateEventDetailsBasic.js
+++ b/src/app/components/Modals/CreateEvents/CreateEventDetailsBasic.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useContext, useState, useMemo } from 'react';
-import { Box, Typography, FormControl, TextField, Grid, CircularProgress, Alert, Autocomplete } from '@mui/material';
+import { Box, Typography, FormControl, TextField, Grid, CircularProgress, Alert, Autocomplete, FormControlLabel, Checkbox } from '@mui/material';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -600,14 +600,32 @@ const CreateEventDetailsBasic = ({ eventData, setEventData, editMode = false, or
         {/* Cost Input */}
         <Grid item xs={12} md={6}>
           <FormControl fullWidth>
-            <TextField 
-              label="Cost" 
-              value={eventData.cost || ''} 
+            <TextField
+              label="Cost"
+              value={eventData.cost || ''}
               onChange={(e) => setEventData(prevData => ({ ...prevData, cost: e.target.value }))}
               placeholder="e.g., Free, $20, Donation"
               helperText="Enter the cost or pricing information for the event"
               fullWidth
             />
+          </FormControl>
+        </Grid>
+
+        {/* TIEMPO-401: Beginner-friendly flag (gates Beginner UX mode) */}
+        <Grid item xs={12} md={6}>
+          <FormControl fullWidth>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={Boolean(eventData.beginnerFriendly)}
+                  onChange={(e) => setEventData(prevData => ({ ...prevData, beginnerFriendly: e.target.checked }))}
+                />
+              }
+              label="Beginner-friendly event"
+            />
+            <Typography variant="caption" color="textSecondary" sx={{ ml: 4, mt: -0.5 }}>
+              Check if someone with zero tango experience can show up and feel welcome.
+            </Typography>
           </FormControl>
         </Grid>
       </Grid>
@@ -669,6 +687,7 @@ CreateEventDetailsBasic.propTypes = {
     authorOrganizerName: PropTypes.string,
     authorOrganizerShortName: PropTypes.string,
     cost: PropTypes.string,
+    beginnerFriendly: PropTypes.bool,
   }).isRequired,
   setEventData: PropTypes.func.isRequired,
   editMode: PropTypes.bool,


### PR DESCRIPTION
## Summary

Phase 1 frontend for TIEMPO-400 epic (Event Classification & UX Modes). Adds a `beginnerFriendly` Boolean flag to the event creation/edit form so organizers can self-tag events that welcome dancers with zero experience. This flag will gate the upcoming Beginner UX mode (Phase 5).

- Checkbox "Beginner-friendly event" in Basic tab of `CreateEventDetailModal`, paired with Cost
- Helper caption: "Check if someone with zero tango experience can show up and feel welcome"
- `beginnerFriendly: false` added to initial state + edit-mode mapping
- Payload flows via existing `{ ...eventData }` spread in `handleSave` — no API client changes

## API contract

Confirmed with Fulton (CALBEAF-109) via hub: wire field AND Mongo field are camelCase `beginnerFriendly`, matching existing `isRepeating`/`isCanceled` convention. No snake_case mapping. What the frontend sends is what gets stored.

## Blocked on

CALBEAF-109 (Fulton's backend) for end-to-end round-trip testing. Frontend ships independently — existing events without the field render as unchecked (safe fallback).

## Test plan

- [ ] Open create event modal → verify checkbox appears paired with Cost, unchecked by default
- [ ] Create an event with the box checked → verify payload includes `beginnerFriendly: true` (blocked on CALBEAF-109 for backend persistence)
- [ ] Edit an existing event → verify checkbox reflects stored value (blocked on CALBEAF-109)
- [ ] Edit an existing event with no stored value → verify checkbox renders unchecked (safe fallback, testable today)
- [ ] Verify no regressions on other Basic tab fields (title, category, venue, cost)

Version bump: 1.22.12 → 1.22.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)