### PR TITLE
DEVL→TEST: v1.22.13 beginnerFriendly checkbox [TIEMPO-401]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
-  "version": "1.22.12",
+  "version": "1.22.13",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/components/Modals/CreateEvents/CreateEventDetailModal.js
+++ b/src/app/components/Modals/CreateEvents/CreateEventDetailModal.js
@@ -103,6 +103,8 @@ const CreateEventModal = ({ open, onClose, selectedDate, editMode = false, event
       // Other fields
       isRepeating: false,
       isCanceled: false,
+      // TIEMPO-401: Beginner-friendly flag (gates Beginner UX mode)
+      beginnerFriendly: false,
       // TIEMPO-388: Spotlights for non-repeating events
       spotlights: [],
       features: [],
@@ -219,6 +221,9 @@ const CreateEventModal = ({ open, onClose, selectedDate, editMode = false, event
           
           // Cancellation status
           isCanceled: eventToEdit.isCanceled || false,
+
+          // TIEMPO-401: Beginner-friendly flag
+          beginnerFriendly: eventToEdit.beginnerFriendly || false,
 
           // TIEMPO-388: Spotlights (features) for non-repeating events
           spotlights: eventToEdit.spotlights || eventToEdit.features || [],

--- a/src/app/components/Modals/CreateEvents/CreateEventDetailsBasic.js
+++ b/src/app/components/Modals/CreateEvents/CreateEventDetailsBasic.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useContext, useState, useMemo } from 'react';
-import { Box, Typography, FormControl, TextField, Grid, CircularProgress, Alert, Autocomplete } from '@mui/material';
+import { Box, Typography, FormControl, TextField, Grid, CircularProgress, Alert, Autocomplete, FormControlLabel, Checkbox } from '@mui/material';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -600,14 +600,32 @@ const CreateEventDetailsBasic = ({ eventData, setEventData, editMode = false, or
         {/* Cost Input */}
         <Grid item xs={12} md={6}>
           <FormControl fullWidth>
-            <TextField 
-              label="Cost" 
-              value={eventData.cost || ''} 
+            <TextField
+              label="Cost"
+              value={eventData.cost || ''}
               onChange={(e) => setEventData(prevData => ({ ...prevData, cost: e.target.value }))}
               placeholder="e.g., Free, $20, Donation"
               helperText="Enter the cost or pricing information for the event"
               fullWidth
             />
+          </FormControl>
+        </Grid>
+
+        {/* TIEMPO-401: Beginner-friendly flag (gates Beginner UX mode) */}
+        <Grid item xs={12} md={6}>
+          <FormControl fullWidth>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={Boolean(eventData.beginnerFriendly)}
+                  onChange={(e) => setEventData(prevData => ({ ...prevData, beginnerFriendly: e.target.checked }))}
+                />
+              }
+              label="Beginner-friendly event"
+            />
+            <Typography variant="caption" color="textSecondary" sx={{ ml: 4, mt: -0.5 }}>
+              Check if someone with zero tango experience can show up and feel welcome.
+            </Typography>
           </FormControl>
         </Grid>
       </Grid>
@@ -669,6 +687,7 @@ CreateEventDetailsBasic.propTypes = {
     authorOrganizerName: PropTypes.string,
     authorOrganizerShortName: PropTypes.string,
     cost: PropTypes.string,
+    beginnerFriendly: PropTypes.bool,
   }).isRequired,
   setEventData: PropTypes.func.isRequired,
   editMode: PropTypes.bool,


### PR DESCRIPTION
## Summary

Promotes v1.22.13 from DEVL to TEST. Includes TIEMPO-401 Phase 1 frontend:

- `beginnerFriendly` Boolean checkbox added to event creation/edit form (Basic tab)
- Wire format: camelCase, aligned with Fulton's CALBEAF-109 backend contract
- Safe fallback: existing events without the field render as unchecked

## Paired backend

CALBEAF-109 (Fulton) promoting to TEST in parallel. E2E round-trip test checklist coordinated via hub.

## Feature tier

T3 (Event CRUD) — autonomous push allowed, no CR needed. Quinn approved TEST promotion explicitly.

## Test plan

- [ ] Verify checkbox appears in Basic tab of event create modal
- [ ] Create event with box checked → verify `beginnerFriendly: true` in created doc (after CALBEAF-109 lands on TEST)
- [ ] Edit existing event → verify checkbox reflects stored value, saves correctly
- [ ] Verify backfilled events render as unchecked (default false)
- [ ] No regressions on other Basic tab fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)