### PR TITLE
DEVL→TEST: v1.22.14 mode toggle + /explore stub [TIEMPO-402]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
-  "version": "1.22.13",
+  "version": "1.22.14",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/components/UI/ModeToggle.js
+++ b/src/app/components/UI/ModeToggle.js
@@ -1,0 +1,43 @@
+'use client';
+
+import React from 'react';
+import { Box, ToggleButton, ToggleButtonGroup, Alert } from '@mui/material';
+import { useMode } from '@/hooks/useMode';
+
+const OPTIONS = [
+  { value: 'beginner', label: 'Beginner' },
+  { value: 'local', label: 'Local' },
+  { value: 'explore', label: 'Explore' },
+];
+
+export default function ModeToggle() {
+  const { mode, setMode } = useMode();
+
+  const handleChange = (_event, newMode) => {
+    if (newMode && newMode !== mode) setMode(newMode);
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%', my: 0.5 }}>
+      <ToggleButtonGroup
+        value={mode}
+        exclusive
+        onChange={handleChange}
+        size="small"
+        color="primary"
+        aria-label="display mode"
+      >
+        {OPTIONS.map(({ value, label }) => (
+          <ToggleButton key={value} value={value} sx={{ px: 2, textTransform: 'none' }}>
+            {label}
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
+      {mode === 'beginner' && (
+        <Alert severity="info" sx={{ mt: 1, py: 0, fontSize: '0.8rem' }}>
+          Beginner mode coming soon — showing Local calendar for now.
+        </Alert>
+      )}
+    </Box>
+  );
+}

--- a/src/app/components/UI/SiteMenuBar.js
+++ b/src/app/components/UI/SiteMenuBar.js
@@ -12,6 +12,7 @@ import PostFilter from '@/components/UI/PostFilter';
 import SidebarDrawer from '@/components/UI/SidebarDrawer';
 import SiteMenuBarUserDrawer from './SiteMenuBarUserDrawer';
 import MessagesModal from '@/components/Modals/Messages/MessagesModal';
+import ModeToggle from '@/components/UI/ModeToggle'; // TIEMPO-402
 
 // Pulse animation for new messages
 const pulse = keyframes`
@@ -56,15 +57,19 @@ const SiteMenuBar = ({ activeCategories, handleCategoryChange, categories, searc
     );
 
   return (
-    <Box
-      sx={{
-        width: '100%',
-        padding: '0 0',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-      }}
-    >
+    <Box sx={{ width: '100%', display: 'flex', flexDirection: 'column' }}>
+      {/* TIEMPO-402: 3-mode segmented control (Beginner | Local | Explore) */}
+      <ModeToggle />
+
+      <Box
+        sx={{
+          width: '100%',
+          padding: '0 0',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
       {/* Left Icons */}
       <Box sx={{ display: 'flex', alignItems: 'center' }}>
         <IconButton
@@ -198,6 +203,7 @@ const SiteMenuBar = ({ activeCategories, handleCategoryChange, categories, searc
         <Tooltip title={!user ? "Login here!" : ""} arrow placement="left">
           <IconButton onClick={() => setUserDrawerOpen(true)}>{renderUserIcon()}</IconButton>
         </Tooltip>
+      </Box>
       </Box>
 
       <SidebarDrawer open={sidebarDrawerOpen} onClose={() => setSidebarDrawerOpen(false)} />

--- a/src/app/explore/page.js
+++ b/src/app/explore/page.js
@@ -1,0 +1,32 @@
+'use client';
+
+import React from 'react';
+import { Box, Container, Typography, Paper } from '@mui/material';
+import SiteMenuBar from '@/components/UI/SiteMenuBar';
+
+// TIEMPO-402: Explore route stub. Timeline + map views ship in Phase 3.
+export default function ExplorePage() {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <SiteMenuBar
+        activeCategories={[]}
+        handleCategoryChange={() => {}}
+        categories={[]}
+        searchTerm=""
+        onSearchChange={() => {}}
+        showDiscovered={false}
+        onDiscoveredToggle={() => {}}
+      />
+      <Container maxWidth="md" sx={{ mt: 6, textAlign: 'center' }}>
+        <Paper elevation={2} sx={{ p: 4 }}>
+          <Typography variant="h4" gutterBottom>
+            Explore
+          </Typography>
+          <Typography variant="body1" color="textSecondary">
+            Travel-worthy events from around the world. Timeline and map views coming soon.
+          </Typography>
+        </Paper>
+      </Container>
+    </Box>
+  );
+}

--- a/src/app/hooks/useMode.js
+++ b/src/app/hooks/useMode.js
@@ -1,0 +1,56 @@
+'use client';
+
+import { useCallback, useContext, useEffect, useMemo } from 'react';
+import { useRouter, useSearchParams, usePathname } from 'next/navigation';
+import Cookies from 'js-cookie';
+import { AuthContext } from '@/contexts/AuthContext';
+
+const MODES = ['beginner', 'local', 'explore'];
+const DEFAULT_MODE = 'local';
+const COOKIE_NAME = 'tt_mode';
+
+const normalize = (value) => (MODES.includes(value) ? value : null);
+
+export function useMode() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const auth = useContext(AuthContext);
+  const user = auth?.user;
+
+  const urlMode = normalize(searchParams?.get('mode'));
+  const userMode = normalize(user?.backendInfo?.preferredMode);
+  const cookieMode = typeof window !== 'undefined' ? normalize(Cookies.get(COOKIE_NAME)) : null;
+
+  const mode = useMemo(() => {
+    if (pathname?.startsWith('/explore')) return 'explore';
+    return urlMode || userMode || cookieMode || DEFAULT_MODE;
+  }, [pathname, urlMode, userMode, cookieMode]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && mode) {
+      Cookies.set(COOKIE_NAME, mode, { expires: 365, sameSite: 'Lax' });
+    }
+  }, [mode]);
+
+  const setMode = useCallback((newMode) => {
+    const target = normalize(newMode) || DEFAULT_MODE;
+    Cookies.set(COOKIE_NAME, target, { expires: 365, sameSite: 'Lax' });
+
+    if (target === 'explore') {
+      router.push('/explore');
+      return;
+    }
+
+    const onBoston = pathname?.startsWith('/calendar/boston');
+    const baseRoute = onBoston ? '/calendar/boston' : '/calendar';
+
+    if (target === 'local') {
+      router.push(baseRoute);
+    } else {
+      router.push(`${baseRoute}?mode=beginner`);
+    }
+  }, [pathname, router]);
+
+  return { mode, setMode };
+}


### PR DESCRIPTION
## Summary

Promotes v1.22.14 from DEVL to TEST. Includes TIEMPO-402 Phase 2 scaffolding:

- 3-mode segmented control (Beginner | Local | Explore) in SiteMenuBar
- URL-param-driven with cookie + userLogins.preferredMode fallback
- /explore route stub (Timeline + Map placeholder)
- Beginner mode stub banner
- /calendar/page.js and /calendar/boston/page.js untouched

Feature tier: T2 (navigation/session) shared UI change. Quinn approved promotion.

## Test plan

- [ ] Mode toggle appears above search/filter row on /calendar, /calendar/boston, /explore
- [ ] Explore from /calendar → /explore works; back to Local from /explore → /calendar
- [ ] /calendar/boston → Explore → /explore → Local → /calendar/boston preserves Boston context
- [ ] Beginner shows stub banner, URL gets ?mode=beginner, no filtering change yet
- [ ] Cookie restores last-chosen mode across tabs
- [ ] No regressions on existing SiteMenuBar UI
- [ ] Mobile responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)