### PR TITLE
feat(explore): Milestone B — date-range bars + filter + density (TIEMPO-404)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
-  "version": "1.22.15",
+  "version": "1.22.16",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/components/Explore/CountryFilter.js
+++ b/src/app/components/Explore/CountryFilter.js
@@ -1,0 +1,87 @@
+'use client';
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Box, Button, ButtonGroup, FormGroup, FormControlLabel, Checkbox, Typography } from '@mui/material';
+import { REGIONS, regionFor } from './exploreConstants';
+
+// TIEMPO-404 Milestone B: region presets + per-country checkboxes.
+// Selection state lives in parent (ExplorePage) so filtered events
+// can flow to both the timeline and the density bar.
+
+export default function CountryFilter({ availableCountries, selected, onChange }) {
+  const selectedSet = React.useMemo(() => new Set(selected), [selected]);
+
+  const handleToggle = (country) => {
+    const next = new Set(selectedSet);
+    if (next.has(country)) next.delete(country);
+    else next.add(country);
+    onChange(Array.from(next));
+  };
+
+  const applyPreset = (preset) => {
+    if (preset === 'All') {
+      onChange([...availableCountries]);
+      return;
+    }
+    const regionCountries = REGIONS[preset] || [];
+    const intersection = availableCountries.filter((c) => regionCountries.includes(c));
+    onChange(intersection);
+  };
+
+  // Group available countries by region for display
+  const grouped = React.useMemo(() => {
+    const g = { Americas: [], Europe: [], 'Asia-Pacific': [], Other: [] };
+    availableCountries.forEach((c) => {
+      g[regionFor(c)].push(c);
+    });
+    return g;
+  }, [availableCountries]);
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      <ButtonGroup size="small" variant="outlined" sx={{ mb: 1 }}>
+        {['Americas', 'Europe', 'Asia-Pacific', 'All'].map((preset) => (
+          <Button key={preset} onClick={() => applyPreset(preset)}>
+            {preset}
+          </Button>
+        ))}
+      </ButtonGroup>
+
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+        {Object.entries(grouped).map(([region, list]) => {
+          if (list.length === 0) return null;
+          return (
+            <Box key={region} sx={{ minWidth: 180 }}>
+              <Typography variant="caption" color="textSecondary" sx={{ textTransform: 'uppercase', fontWeight: 'bold' }}>
+                {region}
+              </Typography>
+              <FormGroup>
+                {list.map((country) => (
+                  <FormControlLabel
+                    key={country}
+                    control={
+                      <Checkbox
+                        size="small"
+                        checked={selectedSet.has(country)}
+                        onChange={() => handleToggle(country)}
+                      />
+                    }
+                    label={<Typography variant="body2">{country}</Typography>}
+                    sx={{ my: -0.5 }}
+                  />
+                ))}
+              </FormGroup>
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}
+
+CountryFilter.propTypes = {
+  availableCountries: PropTypes.arrayOf(PropTypes.string).isRequired,
+  selected: PropTypes.arrayOf(PropTypes.string).isRequired,
+  onChange: PropTypes.func.isRequired,
+};

--- a/src/app/components/Explore/DensityBar.js
+++ b/src/app/components/Explore/DensityBar.js
@@ -1,0 +1,67 @@
+'use client';
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import dayjs from 'dayjs';
+
+// TIEMPO-404 Milestone B: events-per-week density bar.
+// Aligned to the timeline's xScale via shared dateRange + dims.
+
+const HEIGHT = 48;
+const BAR_COLOR = '#3b82f6';
+
+export default function DensityBar({ events, xScale, leftMargin, width }) {
+  if (!xScale || !events?.length) {
+    return <div style={{ height: HEIGHT }} />;
+  }
+
+  // Bucket events into calendar weeks by startDate.
+  const buckets = new Map(); // weekStartISO -> count
+  events.forEach((e) => {
+    const wk = dayjs(e.startDate).startOf('week').toISOString();
+    buckets.set(wk, (buckets.get(wk) || 0) + 1);
+  });
+
+  const maxCount = Math.max(...buckets.values(), 1);
+  const chartHeight = HEIGHT - 6; // leave space for bottom margin
+
+  return (
+    <div style={{ width }}>
+      <svg width={width} height={HEIGHT} aria-label="Events per week density">
+        <rect width={width} height={HEIGHT} fill="#f5f7fa" rx={4} />
+        {Array.from(buckets.entries()).map(([weekISO, count]) => {
+          const weekStart = new Date(weekISO);
+          const weekEnd = dayjs(weekStart).add(7, 'day').toDate();
+          const x1 = leftMargin + xScale(weekStart);
+          const x2 = leftMargin + xScale(weekEnd);
+          const barW = Math.max(2, x2 - x1 - 1);
+          const h = Math.round((count / maxCount) * chartHeight);
+          const y = HEIGHT - h - 3;
+          return (
+            <rect
+              key={weekISO}
+              x={x1}
+              y={y}
+              width={barW}
+              height={h}
+              fill={BAR_COLOR}
+              opacity={0.75}
+              rx={1}
+            >
+              <title>
+                {dayjs(weekStart).format('MMM D')}: {count} event{count !== 1 ? 's' : ''}
+              </title>
+            </rect>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}
+
+DensityBar.propTypes = {
+  events: PropTypes.arrayOf(PropTypes.object).isRequired,
+  xScale: PropTypes.func,
+  leftMargin: PropTypes.number.isRequired,
+  width: PropTypes.number.isRequired,
+};

--- a/src/app/components/Explore/ExploreTimeline.js
+++ b/src/app/components/Explore/ExploreTimeline.js
@@ -2,32 +2,22 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useRouter } from 'next/navigation';
 import { Group } from '@visx/group';
 import { scaleTime, scaleBand } from '@visx/scale';
-import { Circle } from '@visx/shape';
 import { AxisBottom, AxisLeft } from '@visx/axis';
 import { useTooltip, TooltipWithBounds, defaultStyles } from '@visx/tooltip';
 import dayjs from 'dayjs';
+import { CATEGORY_COLORS, categoryLabel, colorFor } from './exploreConstants';
 
-// TIEMPO-404 Milestone A: basic scatter plot on /explore.
-// No scroll, no filters, no density bar — proves the visx pipeline.
+// TIEMPO-404 Milestone B: date-range bars, horizontal scroll, click → /event/[id].
 
-const WIDTH = 1000;
-const HEIGHT = 520;
-const MARGIN = { top: 20, right: 40, bottom: 48, left: 160 };
-
-const CATEGORY_COLORS = {
-  Festival: '#e94560',
-  Marathon: '#f97316',
-  Encuentro: '#22c55e',
-  Workshop: '#ec4899',
-  Trip: '#3b82f6',
-  Class: '#8b5cf6',
-  Other: '#6b7280',
-};
-
-const categoryLabel = (c) => (c && c !== 'unknown' ? c : 'Other');
-const colorFor = (c) => CATEGORY_COLORS[categoryLabel(c)] || CATEGORY_COLORS.Other;
+const HEIGHT_BASE = 480;
+const MARGIN = { top: 16, right: 32, bottom: 44, left: 160 };
+const PX_PER_DAY = 4; // 4 → ~120px/month, readable without being giant
+const MIN_BAR_WIDTH = 6; // single-day events still clickable
+const MIN_CHART_WIDTH = 960;
+const ROW_PADDING = 0.35;
 
 const tooltipStyles = {
   ...defaultStyles,
@@ -39,31 +29,34 @@ const tooltipStyles = {
   maxWidth: 280,
 };
 
-export default function ExploreTimeline({ events }) {
+export default function ExploreTimeline({ events, countries, dateRange, onXScaleReady }) {
+  const router = useRouter();
   const { tooltipData, tooltipLeft, tooltipTop, tooltipOpen, showTooltip, hideTooltip } = useTooltip();
 
-  const countries = React.useMemo(
-    () => Array.from(new Set(events.map((e) => e.masteredCountryName))).sort(),
-    [events]
-  );
-
-  const { xScale, yScale, xMax, yMax } = React.useMemo(() => {
-    const allMs = events.flatMap((e) => [new Date(e.startDate).getTime(), new Date(e.endDate).getTime()]);
-    const minDate = allMs.length ? new Date(Math.min(...allMs)) : new Date();
-    const maxDate = allMs.length ? new Date(Math.max(...allMs)) : dayjs().add(6, 'month').toDate();
-    const paddedMin = dayjs(minDate).subtract(14, 'day').toDate();
-    const paddedMax = dayjs(maxDate).add(14, 'day').toDate();
-    const xMax = WIDTH - MARGIN.left - MARGIN.right;
-    const yMax = HEIGHT - MARGIN.top - MARGIN.bottom;
+  const { xScale, yScale, xMax, yMax, height, width } = React.useMemo(() => {
+    const totalDays = Math.max(1, dayjs(dateRange[1]).diff(dayjs(dateRange[0]), 'day'));
+    const width = Math.max(MIN_CHART_WIDTH, Math.ceil(totalDays * PX_PER_DAY) + MARGIN.left + MARGIN.right);
+    // Stretch chart vertically based on how many rows we have
+    const rowCount = Math.max(1, countries.length);
+    const height = Math.max(HEIGHT_BASE, MARGIN.top + MARGIN.bottom + rowCount * 44);
+    const xMax = width - MARGIN.left - MARGIN.right;
+    const yMax = height - MARGIN.top - MARGIN.bottom;
     return {
       xMax,
       yMax,
-      xScale: scaleTime({ domain: [paddedMin, paddedMax], range: [0, xMax] }),
-      yScale: scaleBand({ domain: countries, range: [0, yMax], padding: 0.3 }),
+      width,
+      height,
+      xScale: scaleTime({ domain: dateRange, range: [0, xMax] }),
+      yScale: scaleBand({ domain: countries, range: [0, yMax], padding: ROW_PADDING }),
     };
-  }, [events, countries]);
+  }, [countries, dateRange]);
 
-  const handleEnter = (event, datum) => {
+  // Expose xScale + width to parent so DensityBar can align
+  React.useEffect(() => {
+    if (onXScaleReady) onXScaleReady({ xScale, width, leftMargin: MARGIN.left, rightMargin: MARGIN.right });
+  }, [xScale, width, onXScaleReady]);
+
+  const handleMove = (event, datum) => {
     const svg = event.currentTarget.ownerSVGElement;
     const rect = svg.getBoundingClientRect();
     showTooltip({
@@ -74,19 +67,29 @@ export default function ExploreTimeline({ events }) {
   };
 
   const handleClick = (datum) => {
-    const q = encodeURIComponent(`${datum.title} ${datum.masteredCityName || ''} tango`.trim());
-    window.open(`https://www.google.com/search?q=${q}`, '_blank', 'noopener,noreferrer');
+    if (!datum?._id) return;
+    router.push(`/event/${datum._id}`);
   };
 
   return (
     <div style={{ position: 'relative', width: '100%', overflowX: 'auto' }}>
-      <svg width={WIDTH} height={HEIGHT} role="img" aria-label="Travel-worthy events timeline">
-        <rect width={WIDTH} height={HEIGHT} fill="#fafafa" rx={6} />
+      <svg width={width} height={height} role="img" aria-label="Travel-worthy events timeline">
+        <rect width={width} height={height} fill="#fafafa" rx={6} />
         <Group left={MARGIN.left} top={MARGIN.top}>
           {/* Horizontal gridlines per country */}
           {countries.map((country) => {
             const y = yScale(country) + yScale.bandwidth() / 2;
-            return <line key={country} x1={0} x2={xMax} y1={y} y2={y} stroke="#e5e7eb" strokeDasharray="2 4" />;
+            return (
+              <line
+                key={country}
+                x1={0}
+                x2={xMax}
+                y1={y}
+                y2={y}
+                stroke="#e5e7eb"
+                strokeDasharray="2 4"
+              />
+            );
           })}
 
           <AxisBottom
@@ -104,19 +107,28 @@ export default function ExploreTimeline({ events }) {
           />
 
           {events.map((e) => {
-            const x = xScale(new Date(e.startDate));
-            const y = yScale(e.masteredCountryName) + yScale.bandwidth() / 2;
+            const start = new Date(e.startDate);
+            const end = new Date(e.endDate);
+            const x1 = xScale(start);
+            const x2 = xScale(end);
+            const barW = Math.max(MIN_BAR_WIDTH, x2 - x1);
+            const rowY = yScale(e.masteredCountryName);
+            if (rowY === undefined) return null; // country not in current filter
+            const barH = yScale.bandwidth();
             return (
-              <Circle
+              <rect
                 key={e._id}
-                cx={x}
-                cy={y}
-                r={8}
+                x={x1}
+                y={rowY}
+                width={barW}
+                height={barH}
+                rx={3}
+                ry={3}
                 fill={colorFor(e.categoryFirst)}
                 stroke="#fff"
-                strokeWidth={1.5}
+                strokeWidth={1}
                 style={{ cursor: 'pointer' }}
-                onMouseMove={(evt) => handleEnter(evt, e)}
+                onMouseMove={(evt) => handleMove(evt, e)}
                 onMouseLeave={hideTooltip}
                 onClick={() => handleClick(e)}
               />
@@ -139,7 +151,7 @@ export default function ExploreTimeline({ events }) {
             {tooltipData.cost ? ` · ${tooltipData.cost}` : ''}
           </div>
           <div style={{ color: '#93c5fd', fontSize: '0.7rem', marginTop: 6 }}>
-            Click to search organizer ↗
+            Click to open on TangoTiempo ↗
           </div>
         </TooltipWithBounds>
       )}
@@ -148,7 +160,7 @@ export default function ExploreTimeline({ events }) {
       <div style={{ display: 'flex', gap: 16, justifyContent: 'center', padding: 8, fontSize: '0.75rem', color: '#6b7280', flexWrap: 'wrap' }}>
         {Object.entries(CATEGORY_COLORS).map(([name, color]) => (
           <span key={name} style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-            <span style={{ width: 10, height: 10, borderRadius: '50%', background: color, display: 'inline-block' }} />
+            <span style={{ width: 10, height: 10, borderRadius: 2, background: color, display: 'inline-block' }} />
             {name}
           </span>
         ))}
@@ -170,4 +182,7 @@ ExploreTimeline.propTypes = {
       cost: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     })
   ).isRequired,
+  countries: PropTypes.arrayOf(PropTypes.string).isRequired,
+  dateRange: PropTypes.arrayOf(PropTypes.instanceOf(Date)).isRequired,
+  onXScaleReady: PropTypes.func,
 };

--- a/src/app/components/Explore/exploreConstants.js
+++ b/src/app/components/Explore/exploreConstants.js
@@ -1,0 +1,43 @@
+// TIEMPO-404: Shared constants for Explore timeline
+// Region-country mapping for Explore filter presets.
+// Countries not in any region fall through to "Other".
+
+export const CATEGORY_COLORS = {
+  Festival: '#e94560',
+  Marathon: '#f97316',
+  Encuentro: '#22c55e',
+  Workshop: '#ec4899',
+  Trip: '#3b82f6',
+  Class: '#8b5cf6',
+  Other: '#6b7280',
+};
+
+export const categoryLabel = (c) => (c && c !== 'unknown' ? c : 'Other');
+export const colorFor = (c) => CATEGORY_COLORS[categoryLabel(c)] || CATEGORY_COLORS.Other;
+
+export const REGIONS = {
+  Americas: [
+    'United States', 'Canada', 'Argentina', 'Brazil', 'Mexico',
+    'Chile', 'Uruguay', 'Peru', 'Colombia', 'Ecuador', 'Venezuela',
+  ],
+  Europe: [
+    'Spain', 'Italy', 'Portugal', 'France', 'Germany', 'United Kingdom',
+    'Poland', 'Netherlands', 'Turkey', 'Greece', 'Switzerland', 'Belgium',
+    'Austria', 'Norway', 'Sweden', 'Denmark', 'Finland', 'Ireland',
+    'Czech Republic', 'Hungary', 'Russia', 'Ukraine', 'Croatia', 'Romania',
+  ],
+  'Asia-Pacific': [
+    'Japan', 'South Korea', 'Singapore', 'China', 'Hong Kong', 'Taiwan',
+    'Australia', 'New Zealand', 'Vietnam', 'Thailand', 'Indonesia',
+    'Philippines', 'India', 'Malaysia',
+  ],
+};
+
+export const regionFor = (country) => {
+  for (const [region, list] of Object.entries(REGIONS)) {
+    if (list.includes(country)) return region;
+  }
+  return 'Other';
+};
+
+export const COUNTRY_COOKIE = 'tt_explore_countries';

--- a/src/app/explore/page.js
+++ b/src/app/explore/page.js
@@ -1,18 +1,40 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import axios from 'axios';
-import { Box, Container, Typography, CircularProgress, Alert, Paper } from '@mui/material';
+import Cookies from 'js-cookie';
+import { Box, Container, Typography, CircularProgress, Alert, Paper, Divider } from '@mui/material';
 import SiteMenuBar from '@/components/UI/SiteMenuBar';
 import ExploreTimeline from '@/components/Explore/ExploreTimeline';
+import CountryFilter from '@/components/Explore/CountryFilter';
+import DensityBar from '@/components/Explore/DensityBar';
+import { COUNTRY_COOKIE } from '@/components/Explore/exploreConstants';
 import { getApiBaseUrl } from '@/utils/apiUrlResolver';
+import dayjs from 'dayjs';
 
-// TIEMPO-404 Milestone A: Explore timeline POC
-// Fetches travelWorthy events with country, renders a visx scatter plot.
-// Scroll / filter / density bar / mobile come in Milestones B + C.
+// TIEMPO-404 Milestone B: filtered timeline + density bar + country persistence.
+
+const readCookieCountries = () => {
+  if (typeof window === 'undefined') return null;
+  const raw = Cookies.get(COUNTRY_COOKIE);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+const writeCookieCountries = (countries) => {
+  Cookies.set(COUNTRY_COOKIE, JSON.stringify(countries), { expires: 365, sameSite: 'Lax' });
+};
+
 export default function ExplorePage() {
   const [events, setEvents] = useState(null);
   const [error, setError] = useState(null);
+  const [selectedCountries, setSelectedCountries] = useState(null); // null = not yet seeded
+  const [xInfo, setXInfo] = useState(null); // { xScale, width, leftMargin, rightMargin }
 
   useEffect(() => {
     const appId = process.env.NEXT_PUBLIC_APPLICATION_ID || '1';
@@ -26,6 +48,51 @@ export default function ExplorePage() {
       })
       .catch((err) => setError(err.message || 'Failed to load events'));
   }, []);
+
+  const availableCountries = useMemo(() => {
+    if (!events) return [];
+    return Array.from(new Set(events.map((e) => e.masteredCountryName))).sort();
+  }, [events]);
+
+  // Seed selection from cookie once events load; default to all available
+  useEffect(() => {
+    if (!events || selectedCountries !== null) return;
+    const stored = readCookieCountries();
+    const seeded = stored && stored.length
+      ? stored.filter((c) => availableCountries.includes(c))
+      : availableCountries;
+    setSelectedCountries(seeded.length ? seeded : availableCountries);
+  }, [events, availableCountries, selectedCountries]);
+
+  const handleCountryChange = useCallback((next) => {
+    setSelectedCountries(next);
+    writeCookieCountries(next);
+  }, []);
+
+  const filteredEvents = useMemo(() => {
+    if (!events || !selectedCountries) return [];
+    const set = new Set(selectedCountries);
+    return events.filter((e) => set.has(e.masteredCountryName));
+  }, [events, selectedCountries]);
+
+  const sortedActiveCountries = useMemo(
+    () => Array.from(new Set(filteredEvents.map((e) => e.masteredCountryName))).sort(),
+    [filteredEvents]
+  );
+
+  const dateRange = useMemo(() => {
+    if (!filteredEvents.length) {
+      return [dayjs().toDate(), dayjs().add(6, 'month').toDate()];
+    }
+    const allMs = filteredEvents.flatMap((e) => [
+      new Date(e.startDate).getTime(),
+      new Date(e.endDate).getTime(),
+    ]);
+    return [
+      dayjs(Math.min(...allMs)).subtract(14, 'day').toDate(),
+      dayjs(Math.max(...allMs)).add(14, 'day').toDate(),
+    ];
+  }, [filteredEvents]);
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
@@ -43,7 +110,7 @@ export default function ExplorePage() {
           Explore — travel-worthy tango events
         </Typography>
         <Typography variant="body2" color="textSecondary" paragraph>
-          Festivals, marathons, and multi-day workshops worldwide. Hover for details. Click a dot to search for the organizer.
+          Festivals, marathons, and multi-day workshops worldwide. Hover for details. Click a bar to open the event on TangoTiempo.
         </Typography>
 
         {events === null && !error && (
@@ -55,13 +122,47 @@ export default function ExplorePage() {
         {events && events.length === 0 && (
           <Alert severity="info">No travel-worthy events found with a resolved country yet.</Alert>
         )}
-        {events && events.length > 0 && (
-          <Paper elevation={1} sx={{ p: 2, mt: 2 }}>
-            <ExploreTimeline events={events} />
-            <Typography variant="caption" color="textSecondary" sx={{ display: 'block', mt: 1, textAlign: 'center' }}>
-              Showing {events.length} travel-worthy events. Scrollable time and country filters coming in next milestone.
-            </Typography>
-          </Paper>
+
+        {events && events.length > 0 && selectedCountries !== null && (
+          <>
+            <CountryFilter
+              availableCountries={availableCountries}
+              selected={selectedCountries}
+              onChange={handleCountryChange}
+            />
+
+            {filteredEvents.length === 0 ? (
+              <Alert severity="info">No events match the selected countries. Try a different filter.</Alert>
+            ) : (
+              <Paper elevation={1} sx={{ p: 2, mt: 1 }}>
+                <ExploreTimeline
+                  events={filteredEvents}
+                  countries={sortedActiveCountries}
+                  dateRange={dateRange}
+                  onXScaleReady={setXInfo}
+                />
+                {xInfo && (
+                  <>
+                    <Divider sx={{ my: 1 }} />
+                    <Box sx={{ overflowX: 'auto' }}>
+                      <DensityBar
+                        events={filteredEvents}
+                        xScale={xInfo.xScale}
+                        leftMargin={xInfo.leftMargin}
+                        width={xInfo.width}
+                      />
+                    </Box>
+                    <Typography variant="caption" color="textSecondary" sx={{ display: 'block', mt: 0.5, textAlign: 'center' }}>
+                      Density: events per week across selected countries
+                    </Typography>
+                  </>
+                )}
+                <Typography variant="caption" color="textSecondary" sx={{ display: 'block', mt: 1, textAlign: 'center' }}>
+                  Showing {filteredEvents.length} of {events.length} travel-worthy events
+                </Typography>
+              </Paper>
+            )}
+          </>
         )}
       </Container>
     </Box>


### PR DESCRIPTION
## Summary

**Milestone B of 3** for TIEMPO-404. Three planned features + two direction changes from Toby.

### Milestone B (as planned)
- **Horizontal scroll**: chart width scales with date span (~4 px/day), container is `overflow-x: auto`
- **CountryFilter**: region presets (Americas / Europe / Asia-Pacific / All) + per-country checkboxes grouped by region
- **Cookie persistence**: `tt_explore_countries` stores selected country names, 1-year expiry, seeded on load
- **DensityBar**: events-per-week mini bar chart below the timeline, aligned to the same X scale

### Toby's direction changes (absorbed)
- **Dots → date-range bars**: `<rect>` from `xScale(startDate)` to `xScale(endDate)`, min width 6px so single-day events stay clickable. Multi-day festivals now visually show their duration.
- **Click → /event/[id]**: opens the event on TangoTiempo (route already exists from TIEMPO-256 social sharing). Replaces Milestone A's Google search fallback.

### Architecture
- `exploreConstants.js`: category colors, region→country map, cookie name
- `ExploreTimeline` exposes `xScale + width` via `onXScaleReady` so `DensityBar` renders aligned
- Filter state owned by `ExplorePage`; filtered events + active countries + date range flow to both chart + density

### Out of scope (Milestone C + D)
- Polish (compact dates, icon badges, larger touch targets) — C
- Mobile portrait card-list fallback — D (separate pass, not absorbed into B per Quinn's sequencing)

### Version
1.22.15 → 1.22.16

### Test plan

- [ ] `/explore` renders bars (not dots), multi-day events span width, single-day events are narrow but clickable
- [ ] Click any bar → opens `/event/{_id}` on TangoTiempo
- [ ] Country filter: uncheck USA → US events disappear from chart + density bar
- [ ] Region presets: click "Europe" → only Europe checked, chart shows only European events
- [ ] Cookie persistence: change selection, refresh page, selection restored
- [ ] Density bar aligns with chart X-axis (peaks where dots cluster)
- [ ] Horizontal scroll: chart is wider than viewport, container scrolls
- [ ] Empty state: uncheck all countries → "No events match the selected countries" alert
- [ ] Lint clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)