### PR TITLE
feat(explore): Milestone D mobile card-list (TIEMPO-404)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
-  "version": "1.22.18",
+  "version": "1.22.19",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/components/Explore/CountryFilter.js
+++ b/src/app/components/Explore/CountryFilter.js
@@ -9,7 +9,7 @@ import { REGIONS, regionFor } from './exploreConstants';
 // Selection state lives in parent (ExplorePage) so filtered events
 // can flow to both the timeline and the density bar.
 
-export default function CountryFilter({ availableCountries, selected, onChange }) {
+export default function CountryFilter({ availableCountries, selected, onChange, compact = false }) {
   const selectedSet = React.useMemo(() => new Set(selected), [selected]);
 
   const handleToggle = (country) => {
@@ -40,7 +40,7 @@ export default function CountryFilter({ availableCountries, selected, onChange }
 
   return (
     <Box sx={{ mb: 2 }}>
-      <ButtonGroup size="small" variant="outlined" sx={{ mb: 1 }}>
+      <ButtonGroup size="small" variant="outlined" sx={{ mb: 1, flexWrap: 'wrap' }}>
         {['Americas', 'Europe', 'Asia-Pacific', 'All'].map((preset) => (
           <Button key={preset} onClick={() => applyPreset(preset)}>
             {preset}
@@ -48,34 +48,41 @@ export default function CountryFilter({ availableCountries, selected, onChange }
         ))}
       </ButtonGroup>
 
-      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
-        {Object.entries(grouped).map(([region, list]) => {
-          if (list.length === 0) return null;
-          return (
-            <Box key={region} sx={{ minWidth: 180 }}>
-              <Typography variant="caption" color="textSecondary" sx={{ textTransform: 'uppercase', fontWeight: 'bold' }}>
-                {region}
-              </Typography>
-              <FormGroup>
-                {list.map((country) => (
-                  <FormControlLabel
-                    key={country}
-                    control={
-                      <Checkbox
-                        size="small"
-                        checked={selectedSet.has(country)}
-                        onChange={() => handleToggle(country)}
-                      />
-                    }
-                    label={<Typography variant="body2">{country}</Typography>}
-                    sx={{ my: -0.5 }}
-                  />
-                ))}
-              </FormGroup>
-            </Box>
-          );
-        })}
-      </Box>
+      {/* TIEMPO-404 Milestone D: compact mode for mobile — skip per-country checkboxes */}
+      {compact ? (
+        <Typography variant="caption" color="textSecondary" sx={{ display: 'block' }}>
+          {selected.length} of {availableCountries.length} countries selected
+        </Typography>
+      ) : (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+          {Object.entries(grouped).map(([region, list]) => {
+            if (list.length === 0) return null;
+            return (
+              <Box key={region} sx={{ minWidth: 180 }}>
+                <Typography variant="caption" color="textSecondary" sx={{ textTransform: 'uppercase', fontWeight: 'bold' }}>
+                  {region}
+                </Typography>
+                <FormGroup>
+                  {list.map((country) => (
+                    <FormControlLabel
+                      key={country}
+                      control={
+                        <Checkbox
+                          size="small"
+                          checked={selectedSet.has(country)}
+                          onChange={() => handleToggle(country)}
+                        />
+                      }
+                      label={<Typography variant="body2">{country}</Typography>}
+                      sx={{ my: -0.5 }}
+                    />
+                  ))}
+                </FormGroup>
+              </Box>
+            );
+          })}
+        </Box>
+      )}
     </Box>
   );
 }
@@ -84,4 +91,5 @@ CountryFilter.propTypes = {
   availableCountries: PropTypes.arrayOf(PropTypes.string).isRequired,
   selected: PropTypes.arrayOf(PropTypes.string).isRequired,
   onChange: PropTypes.func.isRequired,
+  compact: PropTypes.bool,
 };

--- a/src/app/components/Explore/ExploreCardList.js
+++ b/src/app/components/Explore/ExploreCardList.js
@@ -1,0 +1,102 @@
+'use client';
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useRouter } from 'next/navigation';
+import { Box, Paper, Typography, Chip, Stack } from '@mui/material';
+import dayjs from 'dayjs';
+import { colorFor, categoryLabel } from './exploreConstants';
+
+// TIEMPO-404 Milestone D: mobile card-list fallback for /explore.
+// Used below ~700px where the scatter plot becomes illegible.
+// Sorted chronologically — matches how travelers plan trips (by date).
+
+function formatDateRange(start, end) {
+  const s = dayjs(start);
+  const e = dayjs(end);
+  if (s.year() !== e.year()) {
+    return `${s.format('MMM D, YYYY')} – ${e.format('MMM D, YYYY')}`;
+  }
+  if (s.month() === e.month() && s.date() !== e.date()) {
+    return `${s.format('MMM D')}–${e.format('D, YYYY')}`;
+  }
+  if (s.month() === e.month() && s.date() === e.date()) {
+    return s.format('MMM D, YYYY');
+  }
+  return `${s.format('MMM D')} – ${e.format('MMM D, YYYY')}`;
+}
+
+export default function ExploreCardList({ events }) {
+  const router = useRouter();
+
+  const sorted = React.useMemo(
+    () => [...events].sort((a, b) => new Date(a.startDate) - new Date(b.startDate)),
+    [events]
+  );
+
+  return (
+    <Stack spacing={1.5}>
+      {sorted.map((e) => {
+        const color = colorFor(e.categoryFirst);
+        const cat = categoryLabel(e.categoryFirst);
+        return (
+          <Paper
+            key={e._id}
+            elevation={1}
+            onClick={() => router.push(`/event/${e._id}`)}
+            sx={{
+              display: 'flex',
+              cursor: 'pointer',
+              overflow: 'hidden',
+              '&:hover': { boxShadow: 3 },
+            }}
+          >
+            {/* Colored category stripe */}
+            <Box sx={{ width: 6, flexShrink: 0, background: color }} />
+            <Box sx={{ p: 1.5, flex: 1, minWidth: 0 }}>
+              <Typography variant="subtitle1" sx={{ fontWeight: 'bold', lineHeight: 1.2 }} noWrap>
+                {e.title}
+              </Typography>
+              <Typography variant="body2" color="textSecondary" sx={{ mt: 0.25 }}>
+                {formatDateRange(e.startDate, e.endDate)}
+              </Typography>
+              <Typography variant="body2" color="textSecondary" sx={{ mt: 0.25 }}>
+                {[e.masteredCityName, e.masteredCountryName].filter(Boolean).join(', ')}
+              </Typography>
+              <Box sx={{ display: 'flex', gap: 0.5, mt: 0.75, flexWrap: 'wrap' }}>
+                <Chip
+                  label={cat}
+                  size="small"
+                  sx={{ bgcolor: color, color: '#fff', fontSize: '0.7rem', height: 20 }}
+                />
+                {e.cost && (
+                  <Chip
+                    label={e.cost}
+                    size="small"
+                    variant="outlined"
+                    sx={{ fontSize: '0.7rem', height: 20 }}
+                  />
+                )}
+              </Box>
+            </Box>
+          </Paper>
+        );
+      })}
+    </Stack>
+  );
+}
+
+ExploreCardList.propTypes = {
+  events: PropTypes.arrayOf(
+    PropTypes.shape({
+      _id: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+      startDate: PropTypes.string.isRequired,
+      endDate: PropTypes.string.isRequired,
+      categoryFirst: PropTypes.string,
+      masteredCountryName: PropTypes.string,
+      masteredCityName: PropTypes.string,
+      cost: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    })
+  ).isRequired,
+};

--- a/src/app/explore/page.js
+++ b/src/app/explore/page.js
@@ -3,16 +3,18 @@
 import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import axios from 'axios';
 import Cookies from 'js-cookie';
-import { Box, Container, Typography, CircularProgress, Alert, Paper, Divider } from '@mui/material';
+import { Box, Container, Typography, CircularProgress, Alert, Paper, Divider, useMediaQuery } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import SiteMenuBar from '@/components/UI/SiteMenuBar';
 import ExploreTimeline from '@/components/Explore/ExploreTimeline';
+import ExploreCardList from '@/components/Explore/ExploreCardList';
 import CountryFilter from '@/components/Explore/CountryFilter';
 import DensityBar from '@/components/Explore/DensityBar';
 import { COUNTRY_COOKIE } from '@/components/Explore/exploreConstants';
 import { getApiBaseUrl } from '@/utils/apiUrlResolver';
 import dayjs from 'dayjs';
 
-// TIEMPO-404 Milestone B: filtered timeline + density bar + country persistence.
+// TIEMPO-404 Milestone D: responsive — scatter on desktop, card list on mobile portrait.
 
 const readCookieCountries = () => {
   if (typeof window === 'undefined') return null;
@@ -31,6 +33,8 @@ const writeCookieCountries = (countries) => {
 };
 
 export default function ExplorePage() {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md')); // <900px → card list
   const [events, setEvents] = useState(null);
   const [error, setError] = useState(null);
   const [selectedCountries, setSelectedCountries] = useState(null); // null = not yet seeded
@@ -126,10 +130,13 @@ export default function ExplorePage() {
               availableCountries={availableCountries}
               selected={selectedCountries}
               onChange={handleCountryChange}
+              compact={isMobile}
             />
 
             {filteredEvents.length === 0 ? (
               <Alert severity="info">No events match the selected countries. Try a different filter.</Alert>
+            ) : isMobile ? (
+              <ExploreCardList events={filteredEvents} />
             ) : (
               <Paper elevation={1} sx={{ p: 2, mt: 1 }}>
                 <ExploreTimeline


### PR DESCRIPTION
## Summary

**Milestone D** for TIEMPO-404. Responsive mobile pass — scatter stays on desktop, swaps to a card list on phones.

### Approach

Per Toby's direction + Quinn's sequencing: **no forced landscape**. Responsive redesign using MUI breakpoint `theme.breakpoints.down('md')` (<900px).

- Desktop/tablet-landscape: existing ExploreTimeline + DensityBar (untouched)
- Mobile/tablet-portrait: new ExploreCardList
- Filter state + cookie persistence shared across both views (same logic, different UI)

### Changes

- **`ExploreCardList.js` (new)**: scrollable list of MUI Paper cards, sorted chronologically by startDate. Each card has:
  - Colored category stripe on the left edge
  - Title (bold, truncated)
  - Compact date range (`"Mar 20–23, 2026"` style)
  - City + country
  - Category chip (colored) + optional cost chip
  - Tap card → `/event/[id]`
- **`CountryFilter.js`**: added `compact` prop. When true, renders only region preset buttons + "N of M countries selected" summary. Skips the per-country checkbox grid (too tall on phones; users get presets on mobile, fine-grain on desktop).
- **`/explore/page.js`**: `useMediaQuery` swaps ExploreTimeline/DensityBar for ExploreCardList below md breakpoint. Filter is compact on mobile.

### Version

1.22.18 → 1.22.19

### Test plan

- [ ] Resize browser to <900px → scatter disappears, card list appears
- [ ] Resize back to ≥900px → scatter returns
- [ ] Mobile (DevTools): card list renders sorted by date
- [ ] Tap card → navigates to `/event/{_id}`
- [ ] Country filter on mobile shows only region presets + summary text
- [ ] Region preset "Europe" filters card list correctly
- [ ] Cookie persistence still works across viewport changes
- [ ] Desktop regressions: none (desktop path is untouched)

## Session scoreboard

TIEMPO-404 Phase 3: Milestones A, B, B.1, C, D all shipped to TEST in a single session. No forced landscape. visx adopted as TT viz standard. `/event/{_id}` click-through reuses TIEMPO-256 route. Country/category filtering trusts Fulton's backend `travelWorthy` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)