### PR TITLE
feat(explore): D.1 mobile card upgrades (TIEMPO-404)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
-  "version": "1.22.19",
+  "version": "1.22.20",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/components/Explore/ExploreCardList.js
+++ b/src/app/components/Explore/ExploreCardList.js
@@ -5,11 +5,12 @@ import PropTypes from 'prop-types';
 import { useRouter } from 'next/navigation';
 import { Box, Paper, Typography, Chip, Stack } from '@mui/material';
 import dayjs from 'dayjs';
-import { colorFor, categoryLabel } from './exploreConstants';
+import { colorFor, categoryLabel, continentColorFor } from './exploreConstants';
 
-// TIEMPO-404 Milestone D: mobile card-list fallback for /explore.
-// Used below ~700px where the scatter plot becomes illegible.
-// Sorted chronologically — matches how travelers plan trips (by date).
+// TIEMPO-404 Milestone D.1: compact mobile cards with continent color stripe,
+// infinite scroll via IntersectionObserver.
+
+const PAGE_SIZE = 30;
 
 function formatDateRange(start, end) {
   const s = dayjs(start);
@@ -18,71 +19,118 @@ function formatDateRange(start, end) {
     return `${s.format('MMM D, YYYY')} – ${e.format('MMM D, YYYY')}`;
   }
   if (s.month() === e.month() && s.date() !== e.date()) {
-    return `${s.format('MMM D')}–${e.format('D, YYYY')}`;
+    return `${s.format('MMM D')}–${e.format('D')}`;
   }
   if (s.month() === e.month() && s.date() === e.date()) {
-    return s.format('MMM D, YYYY');
+    return s.format('MMM D');
   }
-  return `${s.format('MMM D')} – ${e.format('MMM D, YYYY')}`;
+  return `${s.format('MMM D')} – ${e.format('MMM D')}`;
 }
 
 export default function ExploreCardList({ events }) {
   const router = useRouter();
+  const [visibleCount, setVisibleCount] = React.useState(PAGE_SIZE);
+  const sentinelRef = React.useRef(null);
 
   const sorted = React.useMemo(
     () => [...events].sort((a, b) => new Date(a.startDate) - new Date(b.startDate)),
     [events]
   );
 
+  // Reset visible count when the underlying filtered set changes
+  React.useEffect(() => {
+    setVisibleCount(PAGE_SIZE);
+  }, [sorted]);
+
+  // Infinite scroll — observe the sentinel, bump visibleCount when in view
+  React.useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return undefined;
+    if (visibleCount >= sorted.length) return undefined;
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          setVisibleCount((n) => Math.min(n + PAGE_SIZE, sorted.length));
+        }
+      },
+      { rootMargin: '200px' }
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [visibleCount, sorted.length]);
+
+  const shown = sorted.slice(0, visibleCount);
+
   return (
-    <Stack spacing={1.5}>
-      {sorted.map((e) => {
-        const color = colorFor(e.categoryFirst);
-        const cat = categoryLabel(e.categoryFirst);
-        return (
-          <Paper
-            key={e._id}
-            elevation={1}
-            onClick={() => router.push(`/event/${e._id}`)}
-            sx={{
-              display: 'flex',
-              cursor: 'pointer',
-              overflow: 'hidden',
-              '&:hover': { boxShadow: 3 },
-            }}
-          >
-            {/* Colored category stripe */}
-            <Box sx={{ width: 6, flexShrink: 0, background: color }} />
-            <Box sx={{ p: 1.5, flex: 1, minWidth: 0 }}>
-              <Typography variant="subtitle1" sx={{ fontWeight: 'bold', lineHeight: 1.2 }} noWrap>
-                {e.title}
-              </Typography>
-              <Typography variant="body2" color="textSecondary" sx={{ mt: 0.25 }}>
-                {formatDateRange(e.startDate, e.endDate)}
-              </Typography>
-              <Typography variant="body2" color="textSecondary" sx={{ mt: 0.25 }}>
-                {[e.masteredCityName, e.masteredCountryName].filter(Boolean).join(', ')}
-              </Typography>
-              <Box sx={{ display: 'flex', gap: 0.5, mt: 0.75, flexWrap: 'wrap' }}>
-                <Chip
-                  label={cat}
-                  size="small"
-                  sx={{ bgcolor: color, color: '#fff', fontSize: '0.7rem', height: 20 }}
-                />
-                {e.cost && (
+    <Box>
+      <Stack spacing={0.75}>
+        {shown.map((e) => {
+          const stripeColor = continentColorFor(e.masteredCountryName);
+          const categoryColor = colorFor(e.categoryFirst);
+          const cat = categoryLabel(e.categoryFirst);
+          const location = [e.masteredCityName, e.masteredCountryName].filter(Boolean).join(', ');
+          return (
+            <Paper
+              key={e._id}
+              elevation={1}
+              onClick={() => router.push(`/event/${e._id}`)}
+              sx={{
+                display: 'flex',
+                cursor: 'pointer',
+                overflow: 'hidden',
+                '&:active': { boxShadow: 3 },
+              }}
+            >
+              <Box sx={{ width: 5, flexShrink: 0, background: stripeColor }} />
+              <Box sx={{ p: 1, flex: 1, minWidth: 0 }}>
+                <Typography variant="body2" sx={{ fontWeight: 'bold', lineHeight: 1.25 }} noWrap>
+                  {e.title}
+                </Typography>
+                <Typography variant="caption" color="textSecondary" sx={{ display: 'block', lineHeight: 1.3 }}>
+                  {formatDateRange(e.startDate, e.endDate)}
+                  {location && ` · ${location}`}
+                </Typography>
+                <Box sx={{ display: 'flex', gap: 0.5, mt: 0.5, flexWrap: 'wrap', alignItems: 'center' }}>
                   <Chip
-                    label={e.cost}
+                    label={cat}
                     size="small"
-                    variant="outlined"
-                    sx={{ fontSize: '0.7rem', height: 20 }}
+                    sx={{ bgcolor: categoryColor, color: '#fff', fontSize: '0.65rem', height: 18 }}
                   />
-                )}
+                  {e.cost && (
+                    <Chip
+                      label={e.cost}
+                      size="small"
+                      variant="outlined"
+                      sx={{ fontSize: '0.65rem', height: 18 }}
+                    />
+                  )}
+                  {e.isAiGenerated && (
+                    <Chip
+                      label="AI"
+                      size="small"
+                      title="AI-discovered event"
+                      sx={{
+                        fontSize: '0.6rem',
+                        height: 18,
+                        bgcolor: '#f1f5f9',
+                        color: '#475569',
+                        border: '1px solid #cbd5e1',
+                      }}
+                    />
+                  )}
+                </Box>
               </Box>
-            </Box>
-          </Paper>
-        );
-      })}
-    </Stack>
+            </Paper>
+          );
+        })}
+      </Stack>
+      <Box ref={sentinelRef} sx={{ height: 1 }} />
+      {visibleCount < sorted.length && (
+        <Typography variant="caption" color="textSecondary" sx={{ display: 'block', textAlign: 'center', mt: 1 }}>
+          Loading more…
+        </Typography>
+      )}
+    </Box>
   );
 }
 
@@ -97,6 +145,7 @@ ExploreCardList.propTypes = {
       masteredCountryName: PropTypes.string,
       masteredCityName: PropTypes.string,
       cost: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      isAiGenerated: PropTypes.bool,
     })
   ).isRequired,
 };

--- a/src/app/components/Explore/exploreConstants.js
+++ b/src/app/components/Explore/exploreConstants.js
@@ -41,3 +41,14 @@ export const regionFor = (country) => {
 };
 
 export const COUNTRY_COOKIE = 'tt_explore_countries';
+
+// TIEMPO-404 D.1: continent/region colors for mobile card stripes.
+// Category stays in chip; continent becomes primary visual region signal.
+export const CONTINENT_COLORS = {
+  Americas: '#3b82f6',
+  Europe: '#a855f7',
+  'Asia-Pacific': '#14b8a6',
+  Other: '#6b7280',
+};
+
+export const continentColorFor = (country) => CONTINENT_COLORS[regionFor(country)] || CONTINENT_COLORS.Other;

--- a/src/app/explore/page.js
+++ b/src/app/explore/page.js
@@ -48,14 +48,17 @@ export default function ExplorePage() {
       })
       .then((res) => {
         const list = res.data?.events || (Array.isArray(res.data) ? res.data : []);
-        setEvents(list.filter((e) => e.masteredCountryName));
+        // TIEMPO-404 D.1: keep ALL travelWorthy events for mobile card list.
+        // Desktop scatter will still filter to country-resolved at render time.
+        setEvents(list);
       })
       .catch((err) => setError(err.message || 'Failed to load events'));
   }, []);
 
   const availableCountries = useMemo(() => {
     if (!events) return [];
-    return Array.from(new Set(events.map((e) => e.masteredCountryName))).sort();
+    // Exclude null/undefined — only countries-resolved events contribute to the desktop filter.
+    return Array.from(new Set(events.map((e) => e.masteredCountryName).filter(Boolean))).sort();
   }, [events]);
 
   // Seed selection from cookie once events load; default to all available
@@ -126,17 +129,20 @@ export default function ExplorePage() {
 
         {events && events.length > 0 && selectedCountries !== null && (
           <>
-            <CountryFilter
-              availableCountries={availableCountries}
-              selected={selectedCountries}
-              onChange={handleCountryChange}
-              compact={isMobile}
-            />
+            {/* Country filter is a desktop affordance (country-as-Y-axis). Hidden on mobile. */}
+            {!isMobile && (
+              <CountryFilter
+                availableCountries={availableCountries}
+                selected={selectedCountries}
+                onChange={handleCountryChange}
+              />
+            )}
 
-            {filteredEvents.length === 0 ? (
+            {isMobile ? (
+              // Mobile: show ALL travelWorthy events, ignore country filter, infinite scroll
+              <ExploreCardList events={events} />
+            ) : filteredEvents.length === 0 ? (
               <Alert severity="info">No events match the selected countries. Try a different filter.</Alert>
-            ) : isMobile ? (
-              <ExploreCardList events={filteredEvents} />
             ) : (
               <Paper elevation={1} sx={{ p: 2, mt: 1 }}>
                 <ExploreTimeline


### PR DESCRIPTION
## Summary

Four direction tweaks from Toby after reviewing Milestone D mobile on his phone.

1. **More events**: drop country-resolved pre-filter → mobile gets ~459 events (was 25). Desktop scatter unchanged.
2. **Infinite scroll**: IntersectionObserver, 30 cards initial, +30 per intersect.
3. **Continent color stripe**: Americas blue, Europe purple, Asia-Pacific teal, Other grey. Category chip keeps its color — both signals present.
4. **AI badge**: "AI" chip on `isAiGenerated=true` events (Toby confirmed AI-flag = AI-discovered).

Cards compacted for 6+ visible above the fold on phone viewport. Country filter hidden on mobile (desktop-only affordance).

## Version
1.22.19 → 1.22.20

## Test plan

- [ ] Mobile viewport: see ~6+ cards without scrolling
- [ ] Scroll down → more cards auto-load (no button)
- [ ] Cards color-coded by continent on left stripe
- [ ] AI-discovered events show "AI" chip
- [ ] Desktop unchanged, scatter still works, country filter still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)