### PR TITLE
feat(explore): D.2 category filter + mobile region filter + country chip (TIEMPO-404)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
-  "version": "1.22.20",
+  "version": "1.22.21",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/components/Explore/CategoryFilter.js
+++ b/src/app/components/Explore/CategoryFilter.js
@@ -1,0 +1,33 @@
+'use client';
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Box, Button, ButtonGroup } from '@mui/material';
+
+// TIEMPO-404 D.2: category preset filter. Shared by desktop + mobile.
+// "All" = no category filter. Others narrow to that single category.
+
+const PRESETS = ['Festival', 'Marathon', 'Encuentro', 'Workshop', 'All'];
+
+export default function CategoryFilter({ selected, onChange }) {
+  return (
+    <Box sx={{ mb: 1 }}>
+      <ButtonGroup size="small" variant="outlined" sx={{ flexWrap: 'wrap' }}>
+        {PRESETS.map((p) => (
+          <Button
+            key={p}
+            onClick={() => onChange(p === 'All' ? null : p)}
+            variant={(p === 'All' && selected === null) || selected === p ? 'contained' : 'outlined'}
+          >
+            {p}
+          </Button>
+        ))}
+      </ButtonGroup>
+    </Box>
+  );
+}
+
+CategoryFilter.propTypes = {
+  selected: PropTypes.string, // category name or null for "All"
+  onChange: PropTypes.func.isRequired,
+};

--- a/src/app/components/Explore/ExploreCardList.js
+++ b/src/app/components/Explore/ExploreCardList.js
@@ -68,7 +68,6 @@ export default function ExploreCardList({ events }) {
           const stripeColor = continentColorFor(e.masteredCountryName);
           const categoryColor = colorFor(e.categoryFirst);
           const cat = categoryLabel(e.categoryFirst);
-          const location = [e.masteredCityName, e.masteredCountryName].filter(Boolean).join(', ');
           return (
             <Paper
               key={e._id}
@@ -88,7 +87,7 @@ export default function ExploreCardList({ events }) {
                 </Typography>
                 <Typography variant="caption" color="textSecondary" sx={{ display: 'block', lineHeight: 1.3 }}>
                   {formatDateRange(e.startDate, e.endDate)}
-                  {location && ` · ${location}`}
+                  {e.masteredCityName && ` · ${e.masteredCityName}`}
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 0.5, mt: 0.5, flexWrap: 'wrap', alignItems: 'center' }}>
                   <Chip
@@ -96,6 +95,14 @@ export default function ExploreCardList({ events }) {
                     size="small"
                     sx={{ bgcolor: categoryColor, color: '#fff', fontSize: '0.65rem', height: 18 }}
                   />
+                  {e.masteredCountryName && (
+                    <Chip
+                      label={e.masteredCountryName}
+                      size="small"
+                      variant="outlined"
+                      sx={{ fontSize: '0.65rem', height: 18, borderColor: stripeColor, color: stripeColor }}
+                    />
+                  )}
                   {e.cost && (
                     <Chip
                       label={e.cost}

--- a/src/app/explore/page.js
+++ b/src/app/explore/page.js
@@ -9,8 +9,9 @@ import SiteMenuBar from '@/components/UI/SiteMenuBar';
 import ExploreTimeline from '@/components/Explore/ExploreTimeline';
 import ExploreCardList from '@/components/Explore/ExploreCardList';
 import CountryFilter from '@/components/Explore/CountryFilter';
+import CategoryFilter from '@/components/Explore/CategoryFilter';
 import DensityBar from '@/components/Explore/DensityBar';
-import { COUNTRY_COOKIE } from '@/components/Explore/exploreConstants';
+import { COUNTRY_COOKIE, categoryLabel } from '@/components/Explore/exploreConstants';
 import { getApiBaseUrl } from '@/utils/apiUrlResolver';
 import dayjs from 'dayjs';
 
@@ -38,6 +39,7 @@ export default function ExplorePage() {
   const [events, setEvents] = useState(null);
   const [error, setError] = useState(null);
   const [selectedCountries, setSelectedCountries] = useState(null); // null = not yet seeded
+  const [selectedCategory, setSelectedCategory] = useState(null); // null = All
   const [xInfo, setXInfo] = useState(null); // { xScale, width, leftMargin, rightMargin }
 
   useEffect(() => {
@@ -76,11 +78,31 @@ export default function ExplorePage() {
     writeCookieCountries(next);
   }, []);
 
+  // Desktop filter: matches country selection + category
   const filteredEvents = useMemo(() => {
     if (!events || !selectedCountries) return [];
-    const set = new Set(selectedCountries);
-    return events.filter((e) => set.has(e.masteredCountryName));
-  }, [events, selectedCountries]);
+    const countrySet = new Set(selectedCountries);
+    return events.filter((e) => {
+      if (!countrySet.has(e.masteredCountryName)) return false;
+      if (selectedCategory && categoryLabel(e.categoryFirst) !== selectedCategory) return false;
+      return true;
+    });
+  }, [events, selectedCountries, selectedCategory]);
+
+  // Mobile filter: category only (country filter optional on mobile — presets still work)
+  const mobileFilteredEvents = useMemo(() => {
+    if (!events) return [];
+    let out = events;
+    if (selectedCountries && selectedCountries.length && selectedCountries.length < availableCountries.length) {
+      const countrySet = new Set(selectedCountries);
+      // Keep country-null events visible when any country filter is active only if user hasn't narrowed hard
+      out = out.filter((e) => !e.masteredCountryName || countrySet.has(e.masteredCountryName));
+    }
+    if (selectedCategory) {
+      out = out.filter((e) => categoryLabel(e.categoryFirst) === selectedCategory);
+    }
+    return out;
+  }, [events, selectedCountries, selectedCategory, availableCountries.length]);
 
   const sortedActiveCountries = useMemo(
     () => Array.from(new Set(filteredEvents.map((e) => e.masteredCountryName))).sort(),
@@ -129,18 +151,16 @@ export default function ExplorePage() {
 
         {events && events.length > 0 && selectedCountries !== null && (
           <>
-            {/* Country filter is a desktop affordance (country-as-Y-axis). Hidden on mobile. */}
-            {!isMobile && (
-              <CountryFilter
-                availableCountries={availableCountries}
-                selected={selectedCountries}
-                onChange={handleCountryChange}
-              />
-            )}
+            <CategoryFilter selected={selectedCategory} onChange={setSelectedCategory} />
+            <CountryFilter
+              availableCountries={availableCountries}
+              selected={selectedCountries}
+              onChange={handleCountryChange}
+              compact={isMobile}
+            />
 
             {isMobile ? (
-              // Mobile: show ALL travelWorthy events, ignore country filter, infinite scroll
-              <ExploreCardList events={events} />
+              <ExploreCardList events={mobileFilteredEvents} />
             ) : filteredEvents.length === 0 ? (
               <Alert severity="info">No events match the selected countries. Try a different filter.</Alert>
             ) : (


### PR DESCRIPTION
Toby's 3 D.1 tweaks: (1) new CategoryFilter (Festival/Marathon/Encuentro/Workshop/All), shared by desktop+mobile. (2) CountryFilter restored on mobile in compact mode (region presets only). (3) Country shown as outlined continent-colored chip next to category chip on cards. v1.22.20→1.22.21.