### PR TITLE
feat(beginner): Phase 5 MVP — wire Beginner mode (TIEMPO-406)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
-  "version": "1.22.23",
+  "version": "1.22.24",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/beginner/page.js
+++ b/src/app/beginner/page.js
@@ -1,0 +1,63 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Box, Container, Typography, CircularProgress, Alert } from '@mui/material';
+import SiteMenuBar from '@/components/UI/SiteMenuBar';
+import ExploreCardList from '@/components/Explore/ExploreCardList';
+import { getApiBaseUrl } from '@/utils/apiUrlResolver';
+
+// TIEMPO-406 (Phase 5 MVP pulled forward): Beginner mode.
+// Filtered view of forBeginners=true events. Card list pattern
+// reused from Explore mobile. No onboarding prompt yet — that
+// lands in the full Phase 5 polish pass.
+export default function BeginnerPage() {
+  const [events, setEvents] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const appId = process.env.NEXT_PUBLIC_APPLICATION_ID || '1';
+    axios
+      .get(`${getApiBaseUrl()}/api/events`, {
+        params: { forBeginners: true, appId, limit: 500 },
+      })
+      .then((res) => {
+        const list = res.data?.events || (Array.isArray(res.data) ? res.data : []);
+        setEvents(list);
+      })
+      .catch((err) => setError(err.message || 'Failed to load events'));
+  }, []);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <SiteMenuBar
+        activeCategories={[]}
+        handleCategoryChange={() => {}}
+        categories={[]}
+        searchTerm=""
+        onSearchChange={() => {}}
+        showDiscovered={false}
+        onDiscoveredToggle={() => {}}
+      />
+      <Container maxWidth="md" sx={{ mt: 3, mb: 6 }}>
+        <Typography variant="h4" gutterBottom>
+          Beginner
+        </Typography>
+        <Typography variant="body2" color="textSecondary" paragraph>
+          Classes, practicas, and welcoming events for dancers new to tango.
+        </Typography>
+
+        {events === null && !error && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', mt: 6 }}>
+            <CircularProgress />
+          </Box>
+        )}
+        {error && <Alert severity="error">Failed to load events: {error}</Alert>}
+        {events && events.length === 0 && (
+          <Alert severity="info">No beginner-friendly events found yet.</Alert>
+        )}
+        {events && events.length > 0 && <ExploreCardList events={events} />}
+      </Container>
+    </Box>
+  );
+}

--- a/src/app/components/UI/ModeToggle.js
+++ b/src/app/components/UI/ModeToggle.js
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Box, ToggleButton, ToggleButtonGroup, Alert } from '@mui/material';
+import { Box, ToggleButton, ToggleButtonGroup } from '@mui/material';
 import { useMode } from '@/hooks/useMode';
 
 const OPTIONS = [
@@ -33,11 +33,6 @@ export default function ModeToggle() {
           </ToggleButton>
         ))}
       </ToggleButtonGroup>
-      {mode === 'beginner' && (
-        <Alert severity="info" sx={{ mt: 1, py: 0, fontSize: '0.8rem' }}>
-          Beginner mode coming soon — showing Local calendar for now.
-        </Alert>
-      )}
     </Box>
   );
 }

--- a/src/app/hooks/useMode.js
+++ b/src/app/hooks/useMode.js
@@ -24,6 +24,7 @@ export function useMode() {
 
   const mode = useMemo(() => {
     if (pathname?.startsWith('/explore')) return 'explore';
+    if (pathname?.startsWith('/beginner')) return 'beginner';
     return urlMode || userMode || cookieMode || DEFAULT_MODE;
   }, [pathname, urlMode, userMode, cookieMode]);
 
@@ -42,14 +43,15 @@ export function useMode() {
       return;
     }
 
+    if (target === 'beginner') {
+      // TIEMPO-406: Beginner has its own route now.
+      router.push('/beginner');
+      return;
+    }
+
     const onBoston = pathname?.startsWith('/calendar/boston');
     const baseRoute = onBoston ? '/calendar/boston' : '/calendar';
-
-    if (target === 'local') {
-      router.push(baseRoute);
-    } else {
-      router.push(`${baseRoute}?mode=beginner`);
-    }
+    router.push(baseRoute);
   }, [pathname, router]);
 
   return { mode, setMode };


### PR DESCRIPTION
Pull Phase 5 forward per Toby+Quinn. New /beginner route, forBeginners=true filter, ExploreCardList reused. Drops 'coming soon' banner. v1.22.23→1.22.24.