### PR TITLE
TIEMPO-407: hotfix calendar sort + AI-modal bundle + Boston 125mi

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
-  "version": "1.22.10",
+  "version": "1.22.24",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/calendar/boston/page.js
+++ b/src/app/calendar/boston/page.js
@@ -34,7 +34,7 @@ import { AuthContext } from '@/contexts/AuthContext';
 const BOSTON_CONFIG = {
   lat: 42.3601,
   lng: -71.0589,
-  zoomRange: 200, // 200 mile radius - covers all New England
+  zoomRange: 125, // 125 mile radius - covers New England core, excludes NYC metro
   cityName: 'Boston',
   source: 'legacy-boston',
   locked: true
@@ -999,7 +999,7 @@ const BostonCalendarPage = () => {
           title="Click to explore other regions at TangoTiempo.com"
         >
           <span style={{ fontSize: '12px' }}>📍</span>
-          <span>Boston ± 200mi</span>
+          <span>Boston ± 125mi</span>
         </a>
       </div>
 
@@ -1164,11 +1164,15 @@ const BostonCalendarPage = () => {
             initialView={currentViewType}
             events={coloredFilteredEvents}
             eventClick={handleEventClick}
-            // Sort isDiscovered events after regular events (within same time)
+            // Sort isDiscovered events after regular events, then by start time, then title
             eventOrder={(a, b) => {
               const aDiscovered = a.extendedProps?.isDiscovered ? 1 : 0;
               const bDiscovered = b.extendedProps?.isDiscovered ? 1 : 0;
-              return aDiscovered - bDiscovered;
+              if (aDiscovered !== bDiscovered) return aDiscovered - bDiscovered;
+              const aStart = a.start ? new Date(a.start).getTime() : 0;
+              const bStart = b.start ? new Date(b.start).getTime() : 0;
+              if (aStart !== bStart) return aStart - bStart;
+              return (a.title || '').localeCompare(b.title || '');
             }}
             // Remove dateClick for read-only view
             headerToolbar={false}
@@ -1329,7 +1333,7 @@ const BostonCalendarPage = () => {
         <ViewAIEventDetails
           open={isViewAIEventModalOpen}
           onClose={() => handleAIModalClose(false)}
-          aiEventDetails={selectedAIEvent}
+          eventDetails={selectedAIEvent}
         />
       )}
 

--- a/src/app/calendar/page.js
+++ b/src/app/calendar/page.js
@@ -1363,11 +1363,15 @@ const CalendarPage = () => {
           //        initialView="dayGridMonth"
           initialView={getInitialView()}
           events={eventsWithPlaceholders}
-          // Sort isDiscovered events after regular events (within same time)
+          // Sort isDiscovered events after regular events, then by start time, then title
           eventOrder={(a, b) => {
             const aDiscovered = a.extendedProps?.isDiscovered ? 1 : 0;
             const bDiscovered = b.extendedProps?.isDiscovered ? 1 : 0;
-            return aDiscovered - bDiscovered;
+            if (aDiscovered !== bDiscovered) return aDiscovered - bDiscovered;
+            const aStart = a.start ? new Date(a.start).getTime() : 0;
+            const bStart = b.start ? new Date(b.start).getTime() : 0;
+            if (aStart !== bStart) return aStart - bStart;
+            return (a.title || '').localeCompare(b.title || '');
           }}
           // TIEMPO-288: Custom date cell content with month abbreviations
           dayCellContent={(arg) => {

--- a/src/app/components/Modals/ViewEvents/ViewAIEventDetailsTab.js
+++ b/src/app/components/Modals/ViewEvents/ViewAIEventDetailsTab.js
@@ -107,6 +107,29 @@ const ViewAIEventDetailsTab = ({ eventDetails }) => {
         </Box>
       )}
 
+      {/* Title */}
+      <Typography variant="h5" sx={{ fontWeight: 'bold', mb: 2 }}>
+        {eventDetails.title || 'Untitled Event'}
+      </Typography>
+
+      {/* Description */}
+      {ext.eventDescription && (
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: 'bold', color: '#666', mb: 1 }}>
+            Description
+          </Typography>
+          <Typography
+            variant="body1"
+            sx={{
+              whiteSpace: 'pre-wrap',
+              lineHeight: 1.6,
+            }}
+          >
+            {ext.eventDescription}
+          </Typography>
+        </Box>
+      )}
+
       {/* Category */}
       {ext.categoryFirst && (
         <Box sx={{ mb: 2 }}>
@@ -196,11 +219,6 @@ const ViewAIEventDetailsTab = ({ eventDetails }) => {
         </Typography>
       </Box>
 
-      {/* Title */}
-      <Typography variant="h5" sx={{ fontWeight: 'bold', mb: 2 }}>
-        {eventDetails.title || 'Untitled Event'}
-      </Typography>
-
       <Divider sx={{ mb: 3 }} />
 
       {/* Event Image - with error handling for broken images */}
@@ -218,24 +236,6 @@ const ViewAIEventDetailsTab = ({ eventDetails }) => {
             }}
             onError={() => setImageError(true)}
           />
-        </Box>
-      )}
-
-      {/* Description */}
-      {ext.eventDescription && (
-        <Box sx={{ mb: 3 }}>
-          <Typography variant="subtitle2" sx={{ fontWeight: 'bold', color: '#666', mb: 1 }}>
-            Description
-          </Typography>
-          <Typography
-            variant="body1"
-            sx={{
-              whiteSpace: 'pre-wrap',
-              lineHeight: 1.6,
-            }}
-          >
-            {ext.eventDescription}
-          </Typography>
         </Box>
       )}
 
@@ -294,8 +294,35 @@ const ViewAIEventDetailsTab = ({ eventDetails }) => {
 
       <Divider sx={{ mb: 2 }} />
 
-      {/* Links Section: Source + Host Links */}
+      {/* Links Section: Event + Source + Host Links */}
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+        {/* Event Link (TangoTiempo event page) */}
+        {(ext._id || eventDetails.id) && (
+          <Box>
+            <Typography variant="caption" sx={{ color: '#666', display: 'block', mb: 0.5 }}>
+              Permalink to this event on TangoTiempo:
+            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <LinkIcon sx={{ color: '#1976d2', fontSize: 18 }} />
+              <Link
+                href={`/event/${ext._id || eventDetails.id}`}
+                rel="noopener noreferrer"
+                sx={{
+                  color: '#1976d2',
+                  textDecoration: 'none',
+                  fontSize: '0.875rem',
+                  fontWeight: 'medium',
+                  '&:hover': {
+                    textDecoration: 'underline',
+                  },
+                }}
+              >
+                🔗 https://tangotiempo.com/event/{ext._id || eventDetails.id}
+              </Link>
+            </Box>
+          </Box>
+        )}
+
         {/* Source Link */}
         {ext.sourceLink && (
           <Box>


### PR DESCRIPTION
## Hotfix — bundled PROD fixes

Branch rooted at PROD; cherry-picked from sandbox `sandbox/2026-04-17-TIEMPO-407-calendar-sort-fix`. TEST holds unshipped features so normal DEVL→TEST→PROD flow would drag them in.

## What's included

**1. Calendar day-cell event sort (the primary fix)**
Custom eventOrder comparator in `/calendar/page.js:1367` and `/calendar/boston/page.js:1168` only compared `isDiscovered` and returned 0 for all non-AI pairs, overriding FullCalendar's default start/duration/title sort. Non-AI events were rendered in API array order, not start-time order. Comparator now: `isDiscovered (AI sinks) → start ascending → title`. Applied identically to both routes.

**2. Boston AI modal click (bug)**
`/calendar/boston/page.js:1336` passed `aiEventDetails=` but `ViewAIEventDetails.js:7` expects `eventDetails=`. AI event clicks on Boston route silently no-op'd. Fixed.

**3. AI detail modal field reorder (UX regression restore)**
Title was buried at position 7 (below disclaimer/category/location/venue/date). Restores title-on-top ordering: Title → Description → Category → Location → Venue → Date → Image → Hosts → Links. Restores intent of orphaned commit e249b64f (2026-04-08, sandbox/2026-04-08-ai-modal-reorder) which was never merged forward.

**4. AI detail modal: permalink row added**
Plain link row above Source Link in the AI modal Links section. Shows full canonical URL https://tangotiempo.com/event/{id} with relative href. No share button.

**5. Boston radius 200→125 miles**
BOSTON_CONFIG.zoomRange was pulling NYC metro into the Boston embed. 125mi keeps New England core (Providence, Hartford, Springfield, Portland) and cleanly excludes NYC. Label on :1002 updated.

## Tier / CR

T1 CORE affected (calendar rendering sort). DEPLOY-PROD gate is CR approval.

## Version

Bumped 1.22.10 → 1.22.24 (stays ahead of DEVL @ 1.22.23).

## Post-merge

- Deploy: vercel --prod for tangotiempo-com
- Phase C: cherry-pick onto TEST and DEVL (non-destructive)

## JIRA
TIEMPO-407 — https://hdtsllc.atlassian.net/browse/TIEMPO-407

🤖 Generated with [Claude Code](https://claude.com/claude-code)