### PR TITLE
TIEMPO-407: backport hotfix to TEST (non-destructive cherry-pick)

### DIFF
--- a/src/app/calendar/boston/page.js
+++ b/src/app/calendar/boston/page.js
@@ -34,7 +34,7 @@ import { AuthContext } from '@/contexts/AuthContext';
 const BOSTON_CONFIG = {
   lat: 42.3601,
   lng: -71.0589,
-  zoomRange: 200, // 200 mile radius - covers all New England
+  zoomRange: 125, // 125 mile radius - covers New England core, excludes NYC metro
   cityName: 'Boston',
   source: 'legacy-boston',
   locked: true
@@ -999,7 +999,7 @@ const BostonCalendarPage = () => {
           title="Click to explore other regions at TangoTiempo.com"
         >
           <span style={{ fontSize: '12px' }}>📍</span>
-          <span>Boston ± 200mi</span>
+          <span>Boston ± 125mi</span>
         </a>
       </div>
 
@@ -1164,11 +1164,15 @@ const BostonCalendarPage = () => {
             initialView={currentViewType}
             events={coloredFilteredEvents}
             eventClick={handleEventClick}
-            // Sort isDiscovered events after regular events (within same time)
+            // Sort isDiscovered events after regular events, then by start time, then title
             eventOrder={(a, b) => {
               const aDiscovered = a.extendedProps?.isDiscovered ? 1 : 0;
               const bDiscovered = b.extendedProps?.isDiscovered ? 1 : 0;
-              return aDiscovered - bDiscovered;
+              if (aDiscovered !== bDiscovered) return aDiscovered - bDiscovered;
+              const aStart = a.start ? new Date(a.start).getTime() : 0;
+              const bStart = b.start ? new Date(b.start).getTime() : 0;
+              if (aStart !== bStart) return aStart - bStart;
+              return (a.title || '').localeCompare(b.title || '');
             }}
             // Remove dateClick for read-only view
             headerToolbar={false}
@@ -1329,7 +1333,7 @@ const BostonCalendarPage = () => {
         <ViewAIEventDetails
           open={isViewAIEventModalOpen}
           onClose={() => handleAIModalClose(false)}
-          aiEventDetails={selectedAIEvent}
+          eventDetails={selectedAIEvent}
         />
       )}
 

--- a/src/app/calendar/page.js
+++ b/src/app/calendar/page.js
@@ -1363,11 +1363,15 @@ const CalendarPage = () => {
           //        initialView="dayGridMonth"
           initialView={getInitialView()}
           events={eventsWithPlaceholders}
-          // Sort isDiscovered events after regular events (within same time)
+          // Sort isDiscovered events after regular events, then by start time, then title
           eventOrder={(a, b) => {
             const aDiscovered = a.extendedProps?.isDiscovered ? 1 : 0;
             const bDiscovered = b.extendedProps?.isDiscovered ? 1 : 0;
-            return aDiscovered - bDiscovered;
+            if (aDiscovered !== bDiscovered) return aDiscovered - bDiscovered;
+            const aStart = a.start ? new Date(a.start).getTime() : 0;
+            const bStart = b.start ? new Date(b.start).getTime() : 0;
+            if (aStart !== bStart) return aStart - bStart;
+            return (a.title || '').localeCompare(b.title || '');
           }}
           // TIEMPO-288: Custom date cell content with month abbreviations
           dayCellContent={(arg) => {

--- a/src/app/components/Modals/ViewEvents/ViewAIEventDetailsTab.js
+++ b/src/app/components/Modals/ViewEvents/ViewAIEventDetailsTab.js
@@ -107,6 +107,29 @@ const ViewAIEventDetailsTab = ({ eventDetails }) => {
         </Box>
       )}
 
+      {/* Title */}
+      <Typography variant="h5" sx={{ fontWeight: 'bold', mb: 2 }}>
+        {eventDetails.title || 'Untitled Event'}
+      </Typography>
+
+      {/* Description */}
+      {ext.eventDescription && (
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: 'bold', color: '#666', mb: 1 }}>
+            Description
+          </Typography>
+          <Typography
+            variant="body1"
+            sx={{
+              whiteSpace: 'pre-wrap',
+              lineHeight: 1.6,
+            }}
+          >
+            {ext.eventDescription}
+          </Typography>
+        </Box>
+      )}
+
       {/* Category */}
       {ext.categoryFirst && (
         <Box sx={{ mb: 2 }}>
@@ -196,11 +219,6 @@ const ViewAIEventDetailsTab = ({ eventDetails }) => {
         </Typography>
       </Box>
 
-      {/* Title */}
-      <Typography variant="h5" sx={{ fontWeight: 'bold', mb: 2 }}>
-        {eventDetails.title || 'Untitled Event'}
-      </Typography>
-
       <Divider sx={{ mb: 3 }} />
 
       {/* Event Image - with error handling for broken images */}
@@ -218,24 +236,6 @@ const ViewAIEventDetailsTab = ({ eventDetails }) => {
             }}
             onError={() => setImageError(true)}
           />
-        </Box>
-      )}
-
-      {/* Description */}
-      {ext.eventDescription && (
-        <Box sx={{ mb: 3 }}>
-          <Typography variant="subtitle2" sx={{ fontWeight: 'bold', color: '#666', mb: 1 }}>
-            Description
-          </Typography>
-          <Typography
-            variant="body1"
-            sx={{
-              whiteSpace: 'pre-wrap',
-              lineHeight: 1.6,
-            }}
-          >
-            {ext.eventDescription}
-          </Typography>
         </Box>
       )}
 
@@ -294,8 +294,35 @@ const ViewAIEventDetailsTab = ({ eventDetails }) => {
 
       <Divider sx={{ mb: 2 }} />
 
-      {/* Links Section: Source + Host Links */}
+      {/* Links Section: Event + Source + Host Links */}
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+        {/* Event Link (TangoTiempo event page) */}
+        {(ext._id || eventDetails.id) && (
+          <Box>
+            <Typography variant="caption" sx={{ color: '#666', display: 'block', mb: 0.5 }}>
+              Permalink to this event on TangoTiempo:
+            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <LinkIcon sx={{ color: '#1976d2', fontSize: 18 }} />
+              <Link
+                href={`/event/${ext._id || eventDetails.id}`}
+                rel="noopener noreferrer"
+                sx={{
+                  color: '#1976d2',
+                  textDecoration: 'none',
+                  fontSize: '0.875rem',
+                  fontWeight: 'medium',
+                  '&:hover': {
+                    textDecoration: 'underline',
+                  },
+                }}
+              >
+                🔗 https://tangotiempo.com/event/{ext._id || eventDetails.id}
+              </Link>
+            </Box>
+          </Box>
+        )}
+
         {/* Source Link */}
         {ext.sourceLink && (
           <Box>


### PR DESCRIPTION
Cherry-pick of the TIEMPO-407 hotfix (shipped to PROD as v1.22.24) onto TEST.

Non-destructive — adds the fix commit on top of TEST's existing accumulated features. Version bump intentionally not included (TEST gets bumped at its own promotion time).

Cherry-picked SHA: 98b1c9c4 (from PROD)

## What's in the fix

1. Calendar day-cell event sort (start-time ascending + AI sinks to bottom)
2. Boston AI modal prop fix (clicks now work)
3. AI modal: Title/Description moved to top, section reorder
4. AI modal: permalink row added above Source Link
5. Boston radius 200 → 125 miles (excludes NYC metro)

See PR #203 for full description.

## JIRA
TIEMPO-407 — https://hdtsllc.atlassian.net/browse/TIEMPO-407

🤖 Generated with [Claude Code](https://claude.com/claude-code)