### PR TITLE
TIEMPO-408 T1 polish: 2-row chrome, modern ModeToggle, banner+dup-pill removed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ cypress/videos/
 cypress/reports/
 cypress/reports/*.json
 cypress/reports/html/
+.mcp.json

--- a/src/app/calendar/page.js
+++ b/src/app/calendar/page.js
@@ -16,7 +16,6 @@ import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import ListIcon from '@mui/icons-material/List';
 import MapIcon from '@mui/icons-material/Map';
 
-import SiteHeader from '@/components/UI/SiteHeader';
 import SiteMenuBar from '@/components/UI/SiteMenuBar';
 import { useCalendarPage } from '@/hooks/useCalendarPage';
 import CalendarSubMenu from '@/components/UI/CalendarSubMenu';
@@ -1197,7 +1196,6 @@ const CalendarPage = () => {
 
   return (
     <div style={{ width: '100%', maxWidth: '100vw', overflowX: 'hidden' }}>
-      <SiteHeader />
       <SiteMenuBar
         activeCategories={activeCategories}
         handleCategoryChange={handleCategoryChange}
@@ -1648,42 +1646,7 @@ const CalendarPage = () => {
         }}
       />
 
-      {/* TIEMPO-311: Floating map icon button - shows when no modals are open */}
-      {!isCreateModalOpen && !isViewDetailModalOpen && !isAIDetailModalOpen && (
-        <div
-          className="map-icon-button"
-          onClick={() => openMapCenterModal()}
-          title="Click to explore other locations"
-          style={{
-            position: 'fixed',
-            bottom: '20px',
-            right: '20px',
-            backgroundColor: 'white',
-            color: 'black',
-            padding: '8px',
-            borderRadius: '50%',
-            width: '36px',
-            height: '36px',
-            boxShadow: '0px 2px 5px rgba(0, 0, 0, 0.2)',
-            cursor: 'pointer',
-            transition: 'all 0.2s ease',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 1000,
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.backgroundColor = '#f0f0f0';
-            e.currentTarget.style.boxShadow = '0px 3px 8px rgba(0, 0, 0, 0.3)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.backgroundColor = 'white';
-            e.currentTarget.style.boxShadow = '0px 2px 5px rgba(0, 0, 0, 0.2)';
-          }}
-        >
-          <MapIcon style={{ fontSize: '20px', color: '#1976d2' }} />
-        </div>
-      )}
+      {/* TIEMPO-408: floating map icon removed — CityPill in chrome replaces it. */}
     </div>
   );
 };

--- a/src/app/components/UI/ModeToggle.js
+++ b/src/app/components/UI/ModeToggle.js
@@ -1,8 +1,11 @@
 'use client';
 
 import React from 'react';
-import { Box, ToggleButton, ToggleButtonGroup } from '@mui/material';
+import { Box } from '@mui/material';
 import { useMode } from '@/hooks/useMode';
+
+// TIEMPO-408: custom pill segmented control — less MUI-default, more modern.
+// Single rounded track, animated selected indicator, clean type.
 
 const OPTIONS = [
   { value: 'beginner', label: 'Beginner' },
@@ -12,27 +15,83 @@ const OPTIONS = [
 
 export default function ModeToggle() {
   const { mode, setMode } = useMode();
-
-  const handleChange = (_event, newMode) => {
-    if (newMode && newMode !== mode) setMode(newMode);
-  };
+  const activeIdx = Math.max(0, OPTIONS.findIndex((o) => o.value === mode));
+  const count = OPTIONS.length;
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%', my: 0.5 }}>
-      <ToggleButtonGroup
-        value={mode}
-        exclusive
-        onChange={handleChange}
-        size="small"
-        color="primary"
-        aria-label="display mode"
-      >
-        {OPTIONS.map(({ value, label }) => (
-          <ToggleButton key={value} value={value} sx={{ px: 2, textTransform: 'none' }}>
+    <Box
+      role="tablist"
+      aria-label="display mode"
+      sx={{
+        position: 'relative',
+        display: 'inline-flex',
+        p: '3px',
+        borderRadius: 999,
+        background: 'rgba(0, 0, 0, 0.06)',
+        height: 36,
+        minWidth: 260,
+      }}
+    >
+      {/* Sliding selected indicator */}
+      <Box
+        aria-hidden
+        sx={{
+          position: 'absolute',
+          top: 3,
+          bottom: 3,
+          left: 3,
+          width: `calc((100% - 6px) / ${count})`,
+          transform: `translateX(${activeIdx * 100}%)`,
+          transition: 'transform 220ms cubic-bezier(.2,.8,.2,1)',
+          background: '#ffffff',
+          borderRadius: 999,
+          boxShadow: '0 1px 2px rgba(0,0,0,.08), 0 2px 8px rgba(0,0,0,.06)',
+          zIndex: 0,
+        }}
+      />
+      {OPTIONS.map(({ value, label }, i) => {
+        const selected = i === activeIdx;
+        return (
+          <Box
+            key={value}
+            role="tab"
+            aria-selected={selected}
+            tabIndex={0}
+            onClick={() => !selected && setMode(value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                if (!selected) setMode(value);
+              }
+            }}
+            sx={{
+              position: 'relative',
+              zIndex: 1,
+              flex: 1,
+              minWidth: 80,
+              height: 30,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '0.82rem',
+              fontWeight: selected ? 600 : 500,
+              letterSpacing: 0.1,
+              color: selected ? '#111' : 'rgba(0,0,0,0.62)',
+              cursor: selected ? 'default' : 'pointer',
+              userSelect: 'none',
+              transition: 'color 180ms ease',
+              '&:hover': { color: selected ? '#111' : 'rgba(0,0,0,0.82)' },
+              outline: 'none',
+              '&:focus-visible': {
+                boxShadow: '0 0 0 2px rgba(25,118,210,.5)',
+                borderRadius: 999,
+              },
+            }}
+          >
             {label}
-          </ToggleButton>
-        ))}
-      </ToggleButtonGroup>
+          </Box>
+        );
+      })}
     </Box>
   );
 }

--- a/src/app/components/UI/SiteMenuBar.js
+++ b/src/app/components/UI/SiteMenuBar.js
@@ -63,10 +63,34 @@ const SiteMenuBar = ({ activeCategories, handleCategoryChange, categories, searc
     );
 
   return (
-    <Box sx={{ width: '100%', display: 'flex', flexDirection: 'column' }}>
-      {/* TIEMPO-402: 3-mode segmented control (Beginner | Local | Explore) */}
-      <ModeToggle />
+    <Box sx={{ width: '100%', display: 'flex', flexDirection: 'column', borderBottom: '1px solid rgba(0,0,0,0.06)' }}>
+      {/* TIEMPO-408 Row 1 (primary chrome): brand · city · mode tabs.
+          Boston embed skips the new chrome and shows only ModeToggle as-was. */}
+      {!isBoston ? (
+        <Box
+          sx={{
+            width: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 1,
+            px: 1,
+            py: 0.75,
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, minWidth: 0, flexShrink: 1 }}>
+            <BrandMark size={36} />
+            <CityPill />
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', flexShrink: 0 }}>
+            <ModeToggle />
+          </Box>
+        </Box>
+      ) : (
+        <ModeToggle />
+      )}
 
+      {/* TIEMPO-408 Row 2 (utility): menu · search · filter · ai · messages · user */}
       <Box
         sx={{
           width: '100%',
@@ -76,8 +100,7 @@ const SiteMenuBar = ({ activeCategories, handleCategoryChange, categories, searc
           justifyContent: 'space-between',
         }}
       >
-      {/* Left: menu + (non-Boston: BrandMark + CityPill) */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center' }}>
         <IconButton
           edge="start"
           color="inherit"
@@ -86,8 +109,6 @@ const SiteMenuBar = ({ activeCategories, handleCategoryChange, categories, searc
         >
           <MenuIcon />
         </IconButton>
-        {!isBoston && <BrandMark size={36} />}
-        {!isBoston && <CityPill />}
       </Box>
 
       {/* Center: Search field when open */}


### PR DESCRIPTION
Per Toby TEST feedback:
- Remove SiteHeader banner + duplicate location pill from /calendar
- Remove floating MapIcon (TIEMPO-311 dup)
- Two-row SiteMenuBar: brand+city+tabs on top, utility icons below
- Modern pill ModeToggle with sliding indicator (less MUI-default)
- Boston unchanged