### PR TITLE
TIEMPO-408: beginner copy align with Thread 1 eligibility

### DIFF
--- a/docs/BEGINNER-TAB-DESIGN.md
+++ b/docs/BEGINNER-TAB-DESIGN.md
@@ -34,6 +34,12 @@ Two related but **distinct** backend flags:
 
 **Rule for Beginner tab:** fetch `forBeginners=true` only. (Optional future: a "show also beginner-friendly" toggle that expands to include `beginnerFriendly=true`.)
 
+**Category eligibility for `forBeginners=true`** (Thread 1 sign-off 2026-04-18, Class/Workshop/DayWorkshop/Festival per Quinn proposal, strict gate both layers):
+- Eligible: Class, Workshop, DayWorkshop, Festival
+- Ineligible: Practica, Milonga, Marathon, Encuentro, Trip, Other
+- A beginner-focused practica should be categorized as Class (the instructional intent dominates)
+- Beginner page copy reflects this — mentions "classes, workshops" (not practicas)
+
 ---
 
 ## 3. What exists today (TIEMPO-406 MVP on TEST)

--- a/src/app/beginner/page.js
+++ b/src/app/beginner/page.js
@@ -76,7 +76,7 @@ export default function BeginnerPage() {
       <Container maxWidth="md" sx={{ mt: 3, mb: 6 }}>
         {/* TIEMPO-408: page title removed — mode toggle already labels this view */}
         <Typography variant="body2" color="textSecondary" paragraph sx={{ mt: 1 }}>
-          Beginner classes, practicas, and welcoming events in the next {WINDOW_DAYS} days — {radiusLabel}.
+          Beginner classes, workshops, and welcoming events in the next {WINDOW_DAYS} days — {radiusLabel}.
         </Typography>
 
         {!isInitialized || events === null ? (


### PR DESCRIPTION
Drop 'practicas' from subtitle — ineligible for forBeginners per Thread 1.