### PR TITLE
TIEMPO-408 T2: Local excludes forBeginners events

### DIFF
--- a/src/app/hooks/useCalendarPage.js
+++ b/src/app/hooks/useCalendarPage.js
@@ -222,7 +222,14 @@ export const useCalendarPage = () => {
     selectedRole // Pass selectedRole for RO filtering
   );
 
-  const coloredFilteredEvents = (filteredEvents || []).map((event) => {
+  // TIEMPO-408 T2: Local tab excludes forBeginners=true events — they live
+  // exclusively on /beginner now. beginnerFriendly events STAY on Local (they
+  // welcome beginners but aren't exclusively for them).
+  const localOnlyEvents = (filteredEvents || []).filter(
+    (e) => !e?.extendedProps?.forBeginners
+  );
+
+  const coloredFilteredEvents = localOnlyEvents.map((event) => {
     const categoryColor = categoryColors[event.extendedProps.categoryFirst] || 'lightGrey';
     return {
       ...event,

--- a/src/app/utils/transformEvents.js
+++ b/src/app/utils/transformEvents.js
@@ -84,6 +84,10 @@ export function transformEvents(events) {
         // Add shortTitle and ownerOrganizerShortName for calendar display
         shortTitle: event.shortTitle || event.shortName || '',
         ownerOrganizerShortName: event.ownerOrganizerShortName || event.shortName || '',
+        // TIEMPO-408 / CALBEAF-109: beginner classification fields
+        forBeginners: event.forBeginners === true,
+        beginnerFriendly: event.beginnerFriendly === true,
+        travelWorthy: event.travelWorthy === true,
         // Add AI event detection
         isDiscovered: event.isDiscovered || false,
         // AI discovery metadata - source URL and discovery date


### PR DESCRIPTION
Per spec §6 — forBeginners=true events live on /beginner only; beginnerFriendly stays on Local.