### PR TITLE
TIEMPO-408: card click → /calendar?event=id (skip summary)

### DIFF
--- a/src/app/components/Beginner/BeginnerOrganizerList.js
+++ b/src/app/components/Beginner/BeginnerOrganizerList.js
@@ -125,7 +125,7 @@ export default function BeginnerOrganizerList({ events }) {
               return (
                 <Box
                   key={e._id}
-                  onClick={() => router.push(`/event/${e._id}`)}
+                  onClick={() => router.push(`/calendar?event=${e._id}`)}
                   sx={{
                     display: 'flex',
                     alignItems: 'center',

--- a/src/app/components/Explore/ExploreCardList.js
+++ b/src/app/components/Explore/ExploreCardList.js
@@ -74,7 +74,7 @@ export default function ExploreCardList({ events }) {
             <Paper
               key={e._id}
               elevation={1}
-              onClick={() => router.push(`/event/${e._id}`)}
+              onClick={() => router.push(`/calendar?event=${e._id}`)}
               sx={{
                 display: 'flex',
                 cursor: 'pointer',

--- a/src/app/components/Explore/ExploreMap.js
+++ b/src/app/components/Explore/ExploreMap.js
@@ -109,7 +109,7 @@ export default function ExploreMap({ events }) {
                   fillColor: color,
                   fillOpacity: 0.92,
                 }}
-                eventHandlers={{ click: () => router.push(`/event/${e._id}`) }}
+                eventHandlers={{ click: () => router.push(`/calendar?event=${e._id}`) }}
               >
                 <Popup>
                   <Box sx={{ minWidth: 180 }}>

--- a/src/app/components/Explore/ExploreTimeline.js
+++ b/src/app/components/Explore/ExploreTimeline.js
@@ -98,7 +98,7 @@ export default function ExploreTimeline({ events, countries, dateRange, onXScale
   };
 
   const handleClick = (datum) => {
-    if (datum?._id) router.push(`/event/${datum._id}`);
+    if (datum?._id) router.push(`/calendar?event=${datum._id}`);
   };
 
   return (


### PR DESCRIPTION
Cards navigate to calendar with modal auto-open via existing TIEMPO-256 deep-link.