### PR TITLE
fix(beginner): 30d window + drop-on-RRULE-parse-error

### DIFF
--- a/src/app/beginner/page.js
+++ b/src/app/beginner/page.js
@@ -14,7 +14,7 @@ import { useGeoLocation } from '@/contexts/GeoLocationContext';
 // MapCenter pill in chrome drives what shows here, matching how users
 // think of "my area." 60-day server-side window — beginners plan short-term.
 
-const WINDOW_DAYS = 60;
+const WINDOW_DAYS = 30;
 
 export default function BeginnerPage() {
   const [events, setEvents] = useState(null);

--- a/src/app/components/Beginner/BeginnerOrganizerList.js
+++ b/src/app/components/Beginner/BeginnerOrganizerList.js
@@ -13,7 +13,7 @@ import { RRule } from 'rrule';
 // Non-AI events render full-strength; AI-discovered events render de-emphasized
 // AND sort below non-AI within each organizer group (matches Local's pattern).
 
-const WINDOW_DAYS = 60;
+const WINDOW_DAYS = 30;
 
 function isAIish(e) {
   return Boolean(e?.isDiscovered || e?.isAiGenerated);
@@ -62,9 +62,9 @@ function firstInstanceInWindow(e, fromMs, toMs) {
     const windows = rule.between(new Date(fromMs), new Date(toMs), true);
     return windows.length ? windows[0] : null;
   } catch (err) {
-    // rrule parse failed — trust the BE that it's in the window, use base startDate
-    // (best effort — keeps event visible rather than silently hiding it)
-    return baseStart;
+    // RRULE unparseable — drop (don't show a stale past date). This avoids
+    // "ghost" rows for events whose recurrence metadata is malformed.
+    return null;
   }
 }
 


### PR DESCRIPTION
Window 60d→30d per Toby. Refinement #1 (Quinn green-lit): stop fallback-to-historical on parse error; drop instead.