### PR TITLE
TIEMPO-412: Wire ComposeMessageModal entry for SA/SO

### DIFF
--- a/src/app/components/Explore/ExploreMap.js
+++ b/src/app/components/Explore/ExploreMap.js
@@ -3,7 +3,8 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import dynamic from 'next/dynamic';
-import { Box, Typography, Alert, CircularProgress } from '@mui/material';
+import { Box, Typography, Alert, CircularProgress, useMediaQuery } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import dayjs from 'dayjs';
 import { useRouter } from 'next/navigation';
 import { colorFor, categoryLabel, CATEGORY_COLORS } from './exploreConstants';
@@ -39,6 +40,10 @@ function resolveVenueGeo(e) {
 
 export default function ExploreMap({ events }) {
   const router = useRouter();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const markerRadius = isMobile ? 11 : 7;
+  const popupMinWidth = isMobile ? 140 : 180;
 
   const { positioned, skipped } = useMemo(() => {
     const groupCounters = new Map();
@@ -67,12 +72,15 @@ export default function ExploreMap({ events }) {
     return { positioned: out, skipped: skip };
   }, [events]);
 
-  if (!events || events.length === 0) {
-    return <Alert severity="info">No events match the current filter.</Alert>;
-  }
+  const noEvents = !events || events.length === 0;
 
   return (
     <Box sx={{ position: 'relative' }}>
+      {noEvents && (
+        <Alert severity="info" sx={{ mb: 1 }}>
+          No events match the current filter.
+        </Alert>
+      )}
       <Box
         sx={{
           height: { xs: 420, md: 560 },
@@ -101,7 +109,7 @@ export default function ExploreMap({ events }) {
               <CircleMarker
                 key={e._id}
                 center={ll}
-                radius={7}
+                radius={markerRadius}
                 pathOptions={{
                   color: isAI ? '#d97706' : '#ffffff',
                   weight: isAI ? 2 : 1,
@@ -112,7 +120,7 @@ export default function ExploreMap({ events }) {
                 eventHandlers={{ click: () => router.push(`/calendar?event=${e._id}`) }}
               >
                 <Popup>
-                  <Box sx={{ minWidth: 180 }}>
+                  <Box sx={{ minWidth: popupMinWidth, maxWidth: isMobile ? 220 : 280 }}>
                     <Typography variant="subtitle2" sx={{ fontWeight: 700, color }}>
                       {e.title}
                     </Typography>
@@ -138,15 +146,36 @@ export default function ExploreMap({ events }) {
         </MapContainer>
       </Box>
 
-      <Box sx={{ display: 'flex', gap: 1.25, justifyContent: 'center', p: 0.5, mt: 1, fontSize: '0.7rem', color: '#6b7280', flexWrap: 'wrap' }}>
+      <Box sx={{
+        display: 'flex',
+        gap: { xs: 0.75, sm: 1.25 },
+        justifyContent: 'center',
+        p: 0.5,
+        mt: 1,
+        fontSize: { xs: '0.62rem', sm: '0.7rem' },
+        color: '#6b7280',
+        flexWrap: 'wrap',
+      }}>
         {Object.entries(CATEGORY_COLORS).map(([name, color]) => (
           <Box key={name} sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.4 }}>
-            <Box sx={{ width: 10, height: 10, borderRadius: '50%', background: color, border: '1px solid #fff' }} />
+            <Box sx={{
+              width: { xs: 8, sm: 10 },
+              height: { xs: 8, sm: 10 },
+              borderRadius: '50%',
+              background: color,
+              border: '1px solid #fff',
+            }} />
             {name}
           </Box>
         ))}
         <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.4 }}>
-          <Box sx={{ width: 10, height: 10, borderRadius: '50%', background: '#9ca3af', border: '2px dashed #d97706' }} />
+          <Box sx={{
+            width: { xs: 8, sm: 10 },
+            height: { xs: 8, sm: 10 },
+            borderRadius: '50%',
+            background: '#9ca3af',
+            border: '2px dashed #d97706',
+          }} />
           AI-Found
         </Box>
       </Box>

--- a/src/app/components/Modals/Welcome/WelcomeModal.js
+++ b/src/app/components/Modals/Welcome/WelcomeModal.js
@@ -1,26 +1,23 @@
 /**
- * WelcomeModal - Browser Geolocation First Flow
+ * WelcomeModal - First-visit location setup trigger
  *
- * Part of TIEMPO-329: Managed User Entry Flow
- * Updated TIEMPO-388: Try browser geolocation before showing modal
- * Updated TIEMPO-XXX: Enhanced toast with city name and change button
+ * TIEMPO-329: Managed User Entry Flow
+ * TIEMPO-411: Auto-browser-geolocation path removed — iOS Safari rejected
+ *             setTimeout-delayed getCurrentPosition as non-gesture and
+ *             surfaced a confusing "not allowed" error.
  *
  * Flow for anonymous users:
- * 1. If user has saved/session location → use it silently
- * 2. If on /boston route → use Boston coordinates (handled elsewhere)
- * 3. Otherwise → TRY browser geolocation first
- *    a. If granted → use it, show toast with city name, DON'T show modal
- *    b. If denied/timeout → show MapCenterModal
+ * 1. Logged in → UserLocationLoader handles it, skip
+ * 2. Already have a saved/session location (or on /boston) → skip
+ * 3. Otherwise → open MapCenterModal; user picks explicitly via crosshair
+ *    map click or user-tap "Use My Location" button
  *
  * @module WelcomeModal
  */
 
 'use client';
 
-import { useState, useEffect, useContext } from 'react';
-import { Snackbar, Alert, Button, Box, Typography, CircularProgress } from '@mui/material';
-import LocationOnIcon from '@mui/icons-material/LocationOn';
-import EditLocationIcon from '@mui/icons-material/EditLocation';
+import { useEffect, useState, useContext } from 'react';
 import { AuthContext } from '@/contexts/AuthContext';
 import { useGeoLocation } from '@/contexts/GeoLocationContext';
 import {
@@ -28,148 +25,39 @@ import {
   getLastMapCenter
 } from '@/utils/visitorTracking';
 
-/**
- * Determine if user needs location setup
- * @returns {boolean} true if no stored location
- */
 const needsLocationSetup = () => {
   const storedLocation = getLastMapCenter();
   const isBostonRoute = typeof window !== 'undefined' && window.location.pathname.includes('/boston');
-
   if (isBostonRoute) return false;
   if (storedLocation) return false;
   return true;
 };
 
-/**
- * WelcomeModal Component
- * Tries browser geolocation first, only shows modal if denied/failed
- */
 const WelcomeModal = () => {
   const { user } = useContext(AuthContext);
-  const { openMapCenterModal, setSessionLocation, currentLocation } = useGeoLocation();
+  const { openMapCenterModal } = useGeoLocation();
   const [hasChecked, setHasChecked] = useState(false);
-  const [toastOpen, setToastOpen] = useState(false);
-  const [isNewVisitor, setIsNewVisitor] = useState(false);
 
   useEffect(() => {
     if (hasChecked) return;
 
-    const visitCount = incrementVisitCount();
-    setIsNewVisitor(visitCount <= 5); // First 5 visits = new visitor
+    incrementVisitCount();
 
-    // Skip for logged-in users - UserLocationLoader handles their location
     if (user) {
       setHasChecked(true);
       return;
     }
 
-    // Skip if already have location
     if (!needsLocationSetup()) {
       setHasChecked(true);
       return;
     }
 
-    // TIEMPO-388: Try browser geolocation first for anonymous users
-    const tryBrowserGeolocation = () => {
-      if (!('geolocation' in navigator)) {
-        // No geolocation support - fall back to modal
-        openMapCenterModal();
-        return;
-      }
-
-      // Try to get browser location with timeout
-      navigator.geolocation.getCurrentPosition(
-        (position) => {
-          // Success! Use browser location
-          const { latitude, longitude } = position.coords;
-          setSessionLocation({
-            lat: latitude,
-            lng: longitude,
-            zoomRange: 50
-          });
-
-          // Show friendly toast instead of modal
-          setToastOpen(true);
-        },
-        (_error) => {
-          // Geolocation denied or failed - show modal
-          openMapCenterModal();
-        },
-        {
-          enableHighAccuracy: false,
-          timeout: 10000,  // 10 second timeout (VPN can slow geolocation)
-          maximumAge: 300000  // Accept cached position up to 5 min old
-        }
-      );
-    };
-
-    // Small delay to let page render, then try geolocation
-    setTimeout(tryBrowserGeolocation, 500);
-
-    setHasChecked(true);
-  }, [hasChecked, openMapCenterModal, setSessionLocation, user]);
-
-  // Build display text based on city name availability
-  const locationText = currentLocation?.cityName
-    ? `📍 Using ${currentLocation.cityName}`
-    : currentLocation?.cityNameLoading
-      ? '📍 Finding your city...'
-      : '📍 Using your location';
-
-  const handleChangeLocation = () => {
-    setToastOpen(false);
     openMapCenterModal();
-  };
+    setHasChecked(true);
+  }, [hasChecked, openMapCenterModal, user]);
 
-  return (
-    <Snackbar
-      open={toastOpen}
-      onClose={() => setToastOpen(false)}
-      autoHideDuration={isNewVisitor ? 8000 : 5000}
-      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-    >
-      <Alert
-        onClose={() => setToastOpen(false)}
-        severity="info"
-        icon={currentLocation?.cityNameLoading ? <CircularProgress size={16} color="inherit" /> : <LocationOnIcon />}
-        sx={{
-          backgroundColor: '#1976d2',
-          color: 'white',
-          alignItems: 'center',
-          '& .MuiAlert-icon': { color: 'white' },
-          '& .MuiAlert-action': { pt: 0 }
-        }}
-        action={
-          <Button
-            color="inherit"
-            size="small"
-            onClick={handleChangeLocation}
-            startIcon={<EditLocationIcon />}
-            sx={{
-              color: 'white',
-              borderColor: 'rgba(255,255,255,0.5)',
-              '&:hover': { borderColor: 'white', bgcolor: 'rgba(255,255,255,0.1)' }
-            }}
-            variant="outlined"
-          >
-            Change
-          </Button>
-        }
-      >
-        <Box>
-          <Typography variant="body2" sx={{ fontWeight: 500 }}>
-            {locationText}
-          </Typography>
-          {isNewVisitor && (
-            <Typography variant="caption" sx={{ opacity: 0.9, display: 'block' }}>
-              Tip: Use the 🗺️ icon anytime to change
-            </Typography>
-          )}
-        </Box>
-      </Alert>
-    </Snackbar>
-  );
+  return null;
 };
 
 export default WelcomeModal;

--- a/src/app/components/Modals/misc/MapCenterModal.js
+++ b/src/app/components/Modals/misc/MapCenterModal.js
@@ -771,20 +771,11 @@ const MapCenterModal = ({
     );
   };
 
-  // Auto-get user location when modal opens (if no initial location set)
-  useEffect(() => {
-    if (!open) return;
-    if (initialLocation?.lat && initialLocation?.lng) return; // Already have location
-    if (centerLat && centerLng) return; // Already set this session
-
-    // Auto-trigger location fetch after small delay for map init
-    const timer = setTimeout(() => {
-      handleUseMyLocation();
-    }, 500);
-
-    return () => clearTimeout(timer);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
+  // TIEMPO-411: Auto-trigger removed. iOS Safari treats setTimeout-delayed
+  // getCurrentPosition as non-gesture and rejects with PERMISSION_DENIED,
+  // which surfaced as a confusing "Could not get location" error even when
+  // OS permission was granted. Users now pick explicitly via the "Use My
+  // Location" button (gesture → works on mobile) or the crosshair map click.
 
   // Unified save handler - saves to cloud (logged in) or session (anonymous)
   const handleSave = async () => {

--- a/src/app/components/UI/SidebarDrawer.js
+++ b/src/app/components/UI/SidebarDrawer.js
@@ -50,6 +50,7 @@ import RegionalOrganizersModal from '@/components/Modals/RegionalOrganizers/Regi
 import PrivacyPolicyModal from '@/components/Modals/misc/PrivacyPolicyModal';
 import FAQModal from '@/components/Modals/misc/FAQModal';
 import SystemAdminModal from '@/components/Modals/SystemAdmin/SystemAdminModal';
+import ComposeMessageModal from '@/components/Modals/Messages/ComposeMessageModal';
 import { RoleContext } from '@/contexts/RoleContext';
 import { AuthContext } from '@/contexts/AuthContext';
 import { listOfAllRoles } from '@/utils/masterData';
@@ -73,6 +74,7 @@ const SidebarDrawer = ({ open, onClose }) => {
   const [userSettingsOpen, setUserSettingsOpen] = useState(false);
   const [regionalOrganizerOpen, setRegionalOrganizerOpen] = useState(false);
   const [systemAdminOpen, setSystemAdminOpen] = useState(false);
+  const [composeMessageOpen, setComposeMessageOpen] = useState(false);
   const [privacyPolicyOpen, setPrivacyPolicyOpen] = useState(false);
   const [faqOpen, setFaqOpen] = useState(false);
   const [venueModalOpen, setVenueModalOpen] = useState(false);
@@ -396,6 +398,19 @@ const SidebarDrawer = ({ open, onClose }) => {
                   <ListItemText primary="Geo-Diagnostics" />
                 </ListItem>
               </Link>
+
+              <ListItem
+                button="true"
+                onClick={() => {
+                  setComposeMessageOpen(true);
+                  onClose();
+                }}
+              >
+                <ListItemIcon>
+                  <MessageIcon sx={{ color: 'teal' }} />
+                </ListItemIcon>
+                <ListItemText primary="Compose Message" secondary="Send to users by role" />
+              </ListItem>
             </>
           )}
           {selectedRole === listOfAllRoles.SYSTEM_OWNER && (
@@ -431,9 +446,22 @@ const SidebarDrawer = ({ open, onClose }) => {
                   <ListItemText primary="Geo-Diagnostics" />
                 </ListItem>
               </Link>
+
+              <ListItem
+                button="true"
+                onClick={() => {
+                  setComposeMessageOpen(true);
+                  onClose();
+                }}
+              >
+                <ListItemIcon>
+                  <MessageIcon sx={{ color: 'teal' }} />
+                </ListItemIcon>
+                <ListItemText primary="Compose Message" secondary="Send to users by role" />
+              </ListItem>
             </>
           )}
-              
+
               {/* Close authentication section */}
             </>
           )}
@@ -601,6 +629,7 @@ const SidebarDrawer = ({ open, onClose }) => {
       />
       <RegionalOrganizersModal open={regionalOrganizerOpen} onClose={() => setRegionalOrganizerOpen(false)} />
       <SystemAdminModal open={systemAdminOpen} onClose={() => setSystemAdminOpen(false)} />
+      <ComposeMessageModal open={composeMessageOpen} onClose={() => setComposeMessageOpen(false)} />
       <FAQModal open={faqOpen} onClose={() => setFaqOpen(false)} />
       <PrivacyPolicyModal open={privacyPolicyOpen} onClose={() => setPrivacyPolicyOpen(false)} />
       <VenueModal open={venueModalOpen} onClose={() => setVenueModalOpen(false)} />


### PR DESCRIPTION
TIEMPO-387 finish. Adds a 'Compose Message' sidebar item for SA/SO users, opening the orphaned ComposeMessageModal.

## Files changed
- src/app/components/UI/SidebarDrawer.js (import, useState, 2 ListItems, modal render)

## JIRA
https://hdtsllc.atlassian.net/browse/TIEMPO-412

## Test plan
- [ ] Log in as SA on test.tangotiempo.com, open sidebar → see 'Compose Message' item below Geo-Diagnostics
- [ ] Click it → ComposeMessageModal opens
- [ ] Compose title+body, select NU role, send → writes to Firestore 'messages' collection, NU user sees it via existing useMessages listener