### PR TITLE
TIEMPO-413: /organizer route + 4-tab reorder

### DIFF
--- a/src/app/components/Explore/ExploreMap.js
+++ b/src/app/components/Explore/ExploreMap.js
@@ -3,7 +3,8 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import dynamic from 'next/dynamic';
-import { Box, Typography, Alert, CircularProgress } from '@mui/material';
+import { Box, Typography, Alert, CircularProgress, useMediaQuery } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import dayjs from 'dayjs';
 import { useRouter } from 'next/navigation';
 import { colorFor, categoryLabel, CATEGORY_COLORS } from './exploreConstants';
@@ -39,6 +40,10 @@ function resolveVenueGeo(e) {
 
 export default function ExploreMap({ events }) {
   const router = useRouter();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const markerRadius = isMobile ? 11 : 7;
+  const popupMinWidth = isMobile ? 140 : 180;
 
   const { positioned, skipped } = useMemo(() => {
     const groupCounters = new Map();
@@ -67,12 +72,15 @@ export default function ExploreMap({ events }) {
     return { positioned: out, skipped: skip };
   }, [events]);
 
-  if (!events || events.length === 0) {
-    return <Alert severity="info">No events match the current filter.</Alert>;
-  }
+  const noEvents = !events || events.length === 0;
 
   return (
     <Box sx={{ position: 'relative' }}>
+      {noEvents && (
+        <Alert severity="info" sx={{ mb: 1 }}>
+          No events match the current filter.
+        </Alert>
+      )}
       <Box
         sx={{
           height: { xs: 420, md: 560 },
@@ -101,7 +109,7 @@ export default function ExploreMap({ events }) {
               <CircleMarker
                 key={e._id}
                 center={ll}
-                radius={7}
+                radius={markerRadius}
                 pathOptions={{
                   color: isAI ? '#d97706' : '#ffffff',
                   weight: isAI ? 2 : 1,
@@ -112,7 +120,7 @@ export default function ExploreMap({ events }) {
                 eventHandlers={{ click: () => router.push(`/calendar?event=${e._id}`) }}
               >
                 <Popup>
-                  <Box sx={{ minWidth: 180 }}>
+                  <Box sx={{ minWidth: popupMinWidth, maxWidth: isMobile ? 220 : 280 }}>
                     <Typography variant="subtitle2" sx={{ fontWeight: 700, color }}>
                       {e.title}
                     </Typography>
@@ -138,15 +146,36 @@ export default function ExploreMap({ events }) {
         </MapContainer>
       </Box>
 
-      <Box sx={{ display: 'flex', gap: 1.25, justifyContent: 'center', p: 0.5, mt: 1, fontSize: '0.7rem', color: '#6b7280', flexWrap: 'wrap' }}>
+      <Box sx={{
+        display: 'flex',
+        gap: { xs: 0.75, sm: 1.25 },
+        justifyContent: 'center',
+        p: 0.5,
+        mt: 1,
+        fontSize: { xs: '0.62rem', sm: '0.7rem' },
+        color: '#6b7280',
+        flexWrap: 'wrap',
+      }}>
         {Object.entries(CATEGORY_COLORS).map(([name, color]) => (
           <Box key={name} sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.4 }}>
-            <Box sx={{ width: 10, height: 10, borderRadius: '50%', background: color, border: '1px solid #fff' }} />
+            <Box sx={{
+              width: { xs: 8, sm: 10 },
+              height: { xs: 8, sm: 10 },
+              borderRadius: '50%',
+              background: color,
+              border: '1px solid #fff',
+            }} />
             {name}
           </Box>
         ))}
         <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.4 }}>
-          <Box sx={{ width: 10, height: 10, borderRadius: '50%', background: '#9ca3af', border: '2px dashed #d97706' }} />
+          <Box sx={{
+            width: { xs: 8, sm: 10 },
+            height: { xs: 8, sm: 10 },
+            borderRadius: '50%',
+            background: '#9ca3af',
+            border: '2px dashed #d97706',
+          }} />
           AI-Found
         </Box>
       </Box>

--- a/src/app/components/Modals/Welcome/WelcomeModal.js
+++ b/src/app/components/Modals/Welcome/WelcomeModal.js
@@ -1,26 +1,23 @@
 /**
- * WelcomeModal - Browser Geolocation First Flow
+ * WelcomeModal - First-visit location setup trigger
  *
- * Part of TIEMPO-329: Managed User Entry Flow
- * Updated TIEMPO-388: Try browser geolocation before showing modal
- * Updated TIEMPO-XXX: Enhanced toast with city name and change button
+ * TIEMPO-329: Managed User Entry Flow
+ * TIEMPO-411: Auto-browser-geolocation path removed — iOS Safari rejected
+ *             setTimeout-delayed getCurrentPosition as non-gesture and
+ *             surfaced a confusing "not allowed" error.
  *
  * Flow for anonymous users:
- * 1. If user has saved/session location → use it silently
- * 2. If on /boston route → use Boston coordinates (handled elsewhere)
- * 3. Otherwise → TRY browser geolocation first
- *    a. If granted → use it, show toast with city name, DON'T show modal
- *    b. If denied/timeout → show MapCenterModal
+ * 1. Logged in → UserLocationLoader handles it, skip
+ * 2. Already have a saved/session location (or on /boston) → skip
+ * 3. Otherwise → open MapCenterModal; user picks explicitly via crosshair
+ *    map click or user-tap "Use My Location" button
  *
  * @module WelcomeModal
  */
 
 'use client';
 
-import { useState, useEffect, useContext } from 'react';
-import { Snackbar, Alert, Button, Box, Typography, CircularProgress } from '@mui/material';
-import LocationOnIcon from '@mui/icons-material/LocationOn';
-import EditLocationIcon from '@mui/icons-material/EditLocation';
+import { useEffect, useState, useContext } from 'react';
 import { AuthContext } from '@/contexts/AuthContext';
 import { useGeoLocation } from '@/contexts/GeoLocationContext';
 import {
@@ -28,148 +25,39 @@ import {
   getLastMapCenter
 } from '@/utils/visitorTracking';
 
-/**
- * Determine if user needs location setup
- * @returns {boolean} true if no stored location
- */
 const needsLocationSetup = () => {
   const storedLocation = getLastMapCenter();
   const isBostonRoute = typeof window !== 'undefined' && window.location.pathname.includes('/boston');
-
   if (isBostonRoute) return false;
   if (storedLocation) return false;
   return true;
 };
 
-/**
- * WelcomeModal Component
- * Tries browser geolocation first, only shows modal if denied/failed
- */
 const WelcomeModal = () => {
   const { user } = useContext(AuthContext);
-  const { openMapCenterModal, setSessionLocation, currentLocation } = useGeoLocation();
+  const { openMapCenterModal } = useGeoLocation();
   const [hasChecked, setHasChecked] = useState(false);
-  const [toastOpen, setToastOpen] = useState(false);
-  const [isNewVisitor, setIsNewVisitor] = useState(false);
 
   useEffect(() => {
     if (hasChecked) return;
 
-    const visitCount = incrementVisitCount();
-    setIsNewVisitor(visitCount <= 5); // First 5 visits = new visitor
+    incrementVisitCount();
 
-    // Skip for logged-in users - UserLocationLoader handles their location
     if (user) {
       setHasChecked(true);
       return;
     }
 
-    // Skip if already have location
     if (!needsLocationSetup()) {
       setHasChecked(true);
       return;
     }
 
-    // TIEMPO-388: Try browser geolocation first for anonymous users
-    const tryBrowserGeolocation = () => {
-      if (!('geolocation' in navigator)) {
-        // No geolocation support - fall back to modal
-        openMapCenterModal();
-        return;
-      }
-
-      // Try to get browser location with timeout
-      navigator.geolocation.getCurrentPosition(
-        (position) => {
-          // Success! Use browser location
-          const { latitude, longitude } = position.coords;
-          setSessionLocation({
-            lat: latitude,
-            lng: longitude,
-            zoomRange: 50
-          });
-
-          // Show friendly toast instead of modal
-          setToastOpen(true);
-        },
-        (_error) => {
-          // Geolocation denied or failed - show modal
-          openMapCenterModal();
-        },
-        {
-          enableHighAccuracy: false,
-          timeout: 10000,  // 10 second timeout (VPN can slow geolocation)
-          maximumAge: 300000  // Accept cached position up to 5 min old
-        }
-      );
-    };
-
-    // Small delay to let page render, then try geolocation
-    setTimeout(tryBrowserGeolocation, 500);
-
-    setHasChecked(true);
-  }, [hasChecked, openMapCenterModal, setSessionLocation, user]);
-
-  // Build display text based on city name availability
-  const locationText = currentLocation?.cityName
-    ? `📍 Using ${currentLocation.cityName}`
-    : currentLocation?.cityNameLoading
-      ? '📍 Finding your city...'
-      : '📍 Using your location';
-
-  const handleChangeLocation = () => {
-    setToastOpen(false);
     openMapCenterModal();
-  };
+    setHasChecked(true);
+  }, [hasChecked, openMapCenterModal, user]);
 
-  return (
-    <Snackbar
-      open={toastOpen}
-      onClose={() => setToastOpen(false)}
-      autoHideDuration={isNewVisitor ? 8000 : 5000}
-      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-    >
-      <Alert
-        onClose={() => setToastOpen(false)}
-        severity="info"
-        icon={currentLocation?.cityNameLoading ? <CircularProgress size={16} color="inherit" /> : <LocationOnIcon />}
-        sx={{
-          backgroundColor: '#1976d2',
-          color: 'white',
-          alignItems: 'center',
-          '& .MuiAlert-icon': { color: 'white' },
-          '& .MuiAlert-action': { pt: 0 }
-        }}
-        action={
-          <Button
-            color="inherit"
-            size="small"
-            onClick={handleChangeLocation}
-            startIcon={<EditLocationIcon />}
-            sx={{
-              color: 'white',
-              borderColor: 'rgba(255,255,255,0.5)',
-              '&:hover': { borderColor: 'white', bgcolor: 'rgba(255,255,255,0.1)' }
-            }}
-            variant="outlined"
-          >
-            Change
-          </Button>
-        }
-      >
-        <Box>
-          <Typography variant="body2" sx={{ fontWeight: 500 }}>
-            {locationText}
-          </Typography>
-          {isNewVisitor && (
-            <Typography variant="caption" sx={{ opacity: 0.9, display: 'block' }}>
-              Tip: Use the 🗺️ icon anytime to change
-            </Typography>
-          )}
-        </Box>
-      </Alert>
-    </Snackbar>
-  );
+  return null;
 };
 
 export default WelcomeModal;

--- a/src/app/components/Modals/misc/MapCenterModal.js
+++ b/src/app/components/Modals/misc/MapCenterModal.js
@@ -771,20 +771,11 @@ const MapCenterModal = ({
     );
   };
 
-  // Auto-get user location when modal opens (if no initial location set)
-  useEffect(() => {
-    if (!open) return;
-    if (initialLocation?.lat && initialLocation?.lng) return; // Already have location
-    if (centerLat && centerLng) return; // Already set this session
-
-    // Auto-trigger location fetch after small delay for map init
-    const timer = setTimeout(() => {
-      handleUseMyLocation();
-    }, 500);
-
-    return () => clearTimeout(timer);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
+  // TIEMPO-411: Auto-trigger removed. iOS Safari treats setTimeout-delayed
+  // getCurrentPosition as non-gesture and rejects with PERMISSION_DENIED,
+  // which surfaced as a confusing "Could not get location" error even when
+  // OS permission was granted. Users now pick explicitly via the "Use My
+  // Location" button (gesture → works on mobile) or the crosshair map click.
 
   // Unified save handler - saves to cloud (logged in) or session (anonymous)
   const handleSave = async () => {

--- a/src/app/components/Organizer/OrganizerGroupedList.js
+++ b/src/app/components/Organizer/OrganizerGroupedList.js
@@ -1,0 +1,275 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { useRouter } from 'next/navigation';
+import { Box, Typography, Chip, Stack, Divider, Tooltip, Accordion, AccordionSummary, AccordionDetails } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import RepeatIcon from '@mui/icons-material/Repeat';
+import dayjs from 'dayjs';
+import { firstInstanceInWindow } from '@/utils/nextInstance';
+
+// TIEMPO-413: Organizer tab — grouped by ownerOrganizerName, all local
+// events within mapcenter radius over 90-day window. Groups render as
+// MUI Accordion, collapsed by default, sorted by event count descending
+// (most active organizers first). Future: favorited organizers float to
+// the top of the list — not in this scope.
+
+const WINDOW_DAYS = 90;
+
+function isAIish(e) {
+  return Boolean(e?.isDiscovered || e?.isAiGenerated);
+}
+
+function groupKey(e) {
+  return (
+    e.ownerOrganizerID ||
+    e.ownerOrganizerName ||
+    e.ownerOrganizerShortName ||
+    '__none__'
+  );
+}
+
+function formatEventLine(displayDate, e) {
+  const start = dayjs(displayDate);
+  const date = start.format('ddd MMM D');
+  const time = start.format('h:mm A');
+  return { date, time, title: e.title };
+}
+
+export default function OrganizerGroupedList({ events }) {
+  const router = useRouter();
+
+  const groups = useMemo(() => {
+    if (!events?.length) return [];
+    const now = dayjs().startOf('day');
+    const cutoff = dayjs().add(WINDOW_DAYS, 'day');
+    const fromMs = now.valueOf();
+    const toMs = cutoff.valueOf();
+
+    // Recurring masters need next-instance expansion — a weekly milonga's
+    // base startDate can be years old; rrule finds the next instance in
+    // the 90-day window. Events with no hit in the window are dropped.
+    const windowed = [];
+    for (const e of events) {
+      const nextDate = firstInstanceInWindow(e, fromMs, toMs);
+      if (!nextDate) continue;
+      windowed.push({ ...e, _displayDate: nextDate });
+    }
+
+    // Group by organizer
+    const map = new Map();
+    for (const e of windowed) {
+      const k = groupKey(e);
+      if (!map.has(k)) {
+        const fullName = e.ownerOrganizerName || '';
+        const shortName = e.ownerOrganizerShortName || '';
+        const headerPrimary = fullName || shortName || 'Unknown organizer';
+        const headerSecondary = shortName && fullName && fullName !== shortName ? shortName : null;
+        map.set(k, {
+          key: k,
+          headerPrimary,
+          headerSecondary,
+          organizerId: e.ownerOrganizerID,
+          events: [],
+        });
+      }
+      map.get(k).events.push(e);
+    }
+
+    // Sort events within group chronologically (AI still de-emphasized to bottom)
+    const byDisplayDate = (a, b) => {
+      const aAI = isAIish(a) ? 1 : 0;
+      const bAI = isAIish(b) ? 1 : 0;
+      if (aAI !== bAI) return aAI - bAI;
+      return a._displayDate.getTime() - b._displayDate.getTime();
+    };
+
+    // Sort groups by event count descending — most active first.
+    // Tiebreak: alphabetical on headerPrimary.
+    return Array.from(map.values())
+      .map((g) => ({ ...g, events: [...g.events].sort(byDisplayDate) }))
+      .sort((a, b) => {
+        if (b.events.length !== a.events.length) return b.events.length - a.events.length;
+        return a.headerPrimary.localeCompare(b.headerPrimary);
+      });
+  }, [events]);
+
+  if (!groups.length) {
+    return (
+      <Typography variant="body2" color="textSecondary" sx={{ mt: 2 }}>
+        No events in the next {WINDOW_DAYS} days in this area.
+      </Typography>
+    );
+  }
+
+  return (
+    <Stack spacing={0.75} sx={{ mt: 1 }}>
+      {groups.map((g) => (
+        <Accordion
+          key={g.key}
+          defaultExpanded={false}
+          disableGutters
+          elevation={0}
+          sx={{
+            border: '1px solid rgba(0,0,0,0.08)',
+            borderRadius: '8px !important',
+            overflow: 'hidden',
+            '&:before': { display: 'none' },
+          }}
+        >
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            sx={{
+              px: 1.5,
+              py: 0.25,
+              background: 'rgba(25,118,210,0.06)',
+              '& .MuiAccordionSummary-content': { my: 0.75 },
+            }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%', minWidth: 0 }}>
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography variant="subtitle1" sx={{ fontWeight: 700, lineHeight: 1.2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {g.headerPrimary}
+                </Typography>
+                {g.headerSecondary && (
+                  <Typography variant="caption" color="textSecondary" sx={{ display: 'block', lineHeight: 1.25 }}>
+                    {g.headerSecondary}
+                  </Typography>
+                )}
+              </Box>
+              <Chip
+                label={g.events.length}
+                size="small"
+                sx={{
+                  fontSize: '0.7rem',
+                  height: 20,
+                  fontWeight: 600,
+                  bgcolor: 'rgba(25,118,210,0.12)',
+                  color: '#1976d2',
+                  flexShrink: 0,
+                }}
+              />
+            </Box>
+          </AccordionSummary>
+          <AccordionDetails sx={{ p: 0 }}>
+            <Stack divider={<Divider flexItem />}>
+              {g.events.map((e) => {
+                const ai = isAIish(e);
+                const { date, time, title } = formatEventLine(e._displayDate, e);
+                return (
+                  <Box
+                    key={e._id}
+                    onClick={() => router.push(`/calendar?event=${e._id}`)}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
+                      px: 1.5,
+                      py: 0.85,
+                      cursor: 'pointer',
+                      opacity: ai ? 0.55 : 1,
+                      background: ai ? 'rgba(0,0,0,0.015)' : 'transparent',
+                      transition: 'background 120ms ease',
+                      '&:hover': { background: 'rgba(25,118,210,0.04)' },
+                    }}
+                  >
+                    <Box sx={{ minWidth: 92, flexShrink: 0 }}>
+                      <Typography variant="caption" sx={{ display: 'flex', alignItems: 'center', gap: 0.4, fontWeight: 600, color: ai ? 'text.secondary' : 'text.primary' }}>
+                        {date}
+                        {e.isRepeating && (
+                          <Tooltip title="Recurring series — next upcoming session shown" arrow>
+                            <RepeatIcon sx={{ fontSize: 12, color: '#64748b' }} aria-label="recurring" />
+                          </Tooltip>
+                        )}
+                      </Typography>
+                      <Typography variant="caption" color="textSecondary">
+                        {time}
+                      </Typography>
+                    </Box>
+                    <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                          fontWeight: ai ? 400 : 500,
+                          color: ai ? 'text.secondary' : 'text.primary',
+                        }}
+                      >
+                        {title}
+                      </Typography>
+                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, alignItems: 'center' }}>
+                        {e.categoryFirst && (
+                          <Chip
+                            label={e.categoryFirst}
+                            size="small"
+                            sx={{
+                              fontSize: '0.6rem',
+                              height: 18,
+                              bgcolor: ai ? '#f8fafc' : 'rgba(0,0,0,0.05)',
+                              color: ai ? '#94a3b8' : '#475569',
+                              border: '1px solid',
+                              borderColor: ai ? '#e2e8f0' : 'rgba(0,0,0,0.08)',
+                            }}
+                          />
+                        )}
+                        {e.masteredCityName && (
+                          <Chip
+                            label={e.masteredCityName}
+                            size="small"
+                            sx={{
+                              fontSize: '0.6rem',
+                              height: 18,
+                              bgcolor: ai ? '#f8fafc' : 'rgba(25,118,210,0.08)',
+                              color: ai ? '#94a3b8' : '#1976d2',
+                              border: '1px solid',
+                              borderColor: ai ? '#e2e8f0' : 'rgba(25,118,210,0.2)',
+                            }}
+                          />
+                        )}
+                      </Box>
+                    </Box>
+                    {ai && (
+                      <Chip
+                        label="AI"
+                        size="small"
+                        sx={{
+                          fontSize: '0.58rem',
+                          height: 16,
+                          bgcolor: '#f1f5f9',
+                          color: '#94a3b8',
+                          border: '1px solid #e2e8f0',
+                          flexShrink: 0,
+                        }}
+                        title="AI-discovered event"
+                      />
+                    )}
+                  </Box>
+                );
+              })}
+            </Stack>
+          </AccordionDetails>
+        </Accordion>
+      ))}
+    </Stack>
+  );
+}
+
+OrganizerGroupedList.propTypes = {
+  events: PropTypes.arrayOf(
+    PropTypes.shape({
+      _id: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+      startDate: PropTypes.string.isRequired,
+      ownerOrganizerName: PropTypes.string,
+      ownerOrganizerShortName: PropTypes.string,
+      ownerOrganizerID: PropTypes.string,
+      masteredCityName: PropTypes.string,
+      categoryFirst: PropTypes.string,
+      isDiscovered: PropTypes.bool,
+      isAiGenerated: PropTypes.bool,
+    })
+  ).isRequired,
+};

--- a/src/app/components/UI/ModeToggle.js
+++ b/src/app/components/UI/ModeToggle.js
@@ -6,14 +6,16 @@ import { useTheme } from '@mui/material/styles';
 import { useMode } from '@/hooks/useMode';
 
 // TIEMPO-408: custom pill segmented control with sliding indicator.
+// TIEMPO-413: 4-wide — order is LOCAL -> ORG -> EXPLORE -> BEGINNER.
 // Each mode has its own color; selected state uses the color prominently.
 // Mobile: bigger abbreviation + tiny full-word caption below.
 // Desktop: full label only.
 
 const OPTIONS = [
-  { value: 'beginner', label: 'Beginner', short: 'BEG', color: '#22c55e' }, // green — welcoming
-  { value: 'local',    label: 'Local',    short: 'LOC', color: '#3b82f6' }, // blue — home/familiar
-  { value: 'explore',  label: 'Explore',  short: 'EXP', color: '#f59e0b' }, // amber — travel/adventure
+  { value: 'local',     label: 'Local',     short: 'LOC', color: '#3b82f6' }, // blue — home/familiar
+  { value: 'organizer', label: 'Organizer', short: 'ORG', color: '#8b5cf6' }, // purple — community/who
+  { value: 'explore',   label: 'Explore',   short: 'EXP', color: '#f59e0b' }, // amber — travel/adventure
+  { value: 'beginner',  label: 'Beginner',  short: 'BEG', color: '#22c55e' }, // green — welcoming
 ];
 
 export default function ModeToggle() {
@@ -37,7 +39,7 @@ export default function ModeToggle() {
         borderRadius: 999,
         background: 'rgba(0, 0, 0, 0.06)',
         height: isMobile ? 44 : 34,
-        minWidth: isMobile ? 180 : 260,
+        minWidth: isMobile ? 240 : 340,
       }}
     >
       {/* Sliding white pill. Hidden when no tab is active (non-mode route). */}
@@ -79,7 +81,7 @@ export default function ModeToggle() {
               position: 'relative',
               zIndex: 1,
               flex: 1,
-              minWidth: isMobile ? 58 : 80,
+              minWidth: isMobile ? 54 : 78,
               display: 'flex',
               flexDirection: 'column',
               alignItems: 'center',

--- a/src/app/components/UI/SidebarDrawer.js
+++ b/src/app/components/UI/SidebarDrawer.js
@@ -50,6 +50,7 @@ import RegionalOrganizersModal from '@/components/Modals/RegionalOrganizers/Regi
 import PrivacyPolicyModal from '@/components/Modals/misc/PrivacyPolicyModal';
 import FAQModal from '@/components/Modals/misc/FAQModal';
 import SystemAdminModal from '@/components/Modals/SystemAdmin/SystemAdminModal';
+import ComposeMessageModal from '@/components/Modals/Messages/ComposeMessageModal';
 import { RoleContext } from '@/contexts/RoleContext';
 import { AuthContext } from '@/contexts/AuthContext';
 import { listOfAllRoles } from '@/utils/masterData';
@@ -73,6 +74,7 @@ const SidebarDrawer = ({ open, onClose }) => {
   const [userSettingsOpen, setUserSettingsOpen] = useState(false);
   const [regionalOrganizerOpen, setRegionalOrganizerOpen] = useState(false);
   const [systemAdminOpen, setSystemAdminOpen] = useState(false);
+  const [composeMessageOpen, setComposeMessageOpen] = useState(false);
   const [privacyPolicyOpen, setPrivacyPolicyOpen] = useState(false);
   const [faqOpen, setFaqOpen] = useState(false);
   const [venueModalOpen, setVenueModalOpen] = useState(false);
@@ -396,6 +398,19 @@ const SidebarDrawer = ({ open, onClose }) => {
                   <ListItemText primary="Geo-Diagnostics" />
                 </ListItem>
               </Link>
+
+              <ListItem
+                button="true"
+                onClick={() => {
+                  setComposeMessageOpen(true);
+                  onClose();
+                }}
+              >
+                <ListItemIcon>
+                  <MessageIcon sx={{ color: 'teal' }} />
+                </ListItemIcon>
+                <ListItemText primary="Compose Message" secondary="Send to users by role" />
+              </ListItem>
             </>
           )}
           {selectedRole === listOfAllRoles.SYSTEM_OWNER && (
@@ -431,9 +446,22 @@ const SidebarDrawer = ({ open, onClose }) => {
                   <ListItemText primary="Geo-Diagnostics" />
                 </ListItem>
               </Link>
+
+              <ListItem
+                button="true"
+                onClick={() => {
+                  setComposeMessageOpen(true);
+                  onClose();
+                }}
+              >
+                <ListItemIcon>
+                  <MessageIcon sx={{ color: 'teal' }} />
+                </ListItemIcon>
+                <ListItemText primary="Compose Message" secondary="Send to users by role" />
+              </ListItem>
             </>
           )}
-              
+
               {/* Close authentication section */}
             </>
           )}
@@ -601,6 +629,7 @@ const SidebarDrawer = ({ open, onClose }) => {
       />
       <RegionalOrganizersModal open={regionalOrganizerOpen} onClose={() => setRegionalOrganizerOpen(false)} />
       <SystemAdminModal open={systemAdminOpen} onClose={() => setSystemAdminOpen(false)} />
+      <ComposeMessageModal open={composeMessageOpen} onClose={() => setComposeMessageOpen(false)} />
       <FAQModal open={faqOpen} onClose={() => setFaqOpen(false)} />
       <PrivacyPolicyModal open={privacyPolicyOpen} onClose={() => setPrivacyPolicyOpen(false)} />
       <VenueModal open={venueModalOpen} onClose={() => setVenueModalOpen(false)} />

--- a/src/app/hooks/useMode.js
+++ b/src/app/hooks/useMode.js
@@ -15,7 +15,7 @@ import { AuthContext } from '@/contexts/AuthContext';
 // Fix: pathname is authoritative. Cookie/userPref only influence navigation
 // DECISIONS in setMode (where to land on fresh arrival), not current state.
 
-const MODES = ['beginner', 'local', 'explore'];
+const MODES = ['local', 'organizer', 'explore', 'beginner'];
 const DEFAULT_MODE = 'local';
 const COOKIE_NAME = 'tt_mode';
 
@@ -33,6 +33,7 @@ export function useMode() {
     if (!pathname) return null;
     if (pathname.startsWith('/explore')) return 'explore';
     if (pathname.startsWith('/beginner')) return 'beginner';
+    if (pathname.startsWith('/organizer')) return 'organizer';
     if (pathname.startsWith('/calendar')) return 'local'; // includes /calendar/boston
     return null;
   }, [pathname]);
@@ -56,6 +57,10 @@ export function useMode() {
     }
     if (target === 'beginner') {
       router.push('/beginner');
+      return;
+    }
+    if (target === 'organizer') {
+      router.push('/organizer');
       return;
     }
     // Local: if already on Boston variant, stay there; otherwise use /calendar.

--- a/src/app/organizer/page.js
+++ b/src/app/organizer/page.js
@@ -1,0 +1,94 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Box, Container, Typography, CircularProgress, Alert } from '@mui/material';
+import dayjs from 'dayjs';
+import SiteMenuBar from '@/components/UI/SiteMenuBar';
+import OrganizerGroupedList from '@/components/Organizer/OrganizerGroupedList';
+import { getApiBaseUrl } from '@/utils/apiUrlResolver';
+import { useGeoLocation } from '@/contexts/GeoLocationContext';
+
+// TIEMPO-413: Organizer page — mapcenter-scoped, 90-day windowed GET.
+// Shows ALL local events grouped by organizer long name. Wider window
+// than Beginner/Local so less-frequent organizers still surface.
+
+const WINDOW_DAYS = 90;
+
+export default function OrganizerPage() {
+  const [events, setEvents] = useState(null);
+  const [error, setError] = useState(null);
+  const { currentLocation, isInitialized } = useGeoLocation();
+
+  const hasLocation = !!(currentLocation?.lat && currentLocation?.lng);
+
+  useEffect(() => {
+    if (!isInitialized) return;
+
+    const appId = process.env.NEXT_PUBLIC_APPLICATION_ID || '1';
+    const params = {
+      appId,
+      limit: 1000,
+      start: dayjs().startOf('day').toISOString(),
+      end: dayjs().add(WINDOW_DAYS, 'day').endOf('day').toISOString(),
+      includeAiGenerated: true,
+    };
+
+    if (hasLocation) {
+      params.useGeoSearch = true;
+      params.lat = currentLocation.lat;
+      params.lng = currentLocation.lng;
+      const radiusMi = currentLocation.zoomRange || 50;
+      params.radius = `${Math.round(radiusMi * 1.60934)}km`;
+      params.sortByDistance = true;
+    }
+
+    setEvents(null);
+    setError(null);
+    axios
+      .get(`${getApiBaseUrl()}/api/events`, { params })
+      .then((res) => {
+        const list = res.data?.events || (Array.isArray(res.data) ? res.data : []);
+        setEvents(list);
+      })
+      .catch((err) => setError(err.message || 'Failed to load events'));
+  }, [isInitialized, hasLocation, currentLocation?.lat, currentLocation?.lng, currentLocation?.zoomRange]);
+
+  const radiusLabel = hasLocation
+    ? `within ${currentLocation.zoomRange || 50} mi of ${currentLocation.cityName || 'your map center'}`
+    : 'near your selected location';
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <SiteMenuBar
+        activeCategories={[]}
+        handleCategoryChange={() => {}}
+        categories={[]}
+        searchTerm=""
+        onSearchChange={() => {}}
+        showDiscovered={false}
+        onDiscoveredToggle={() => {}}
+      />
+      <Container maxWidth="md" sx={{ mt: 3, mb: 6 }}>
+        <Typography variant="body2" color="textSecondary" paragraph sx={{ mt: 1 }}>
+          Organizers hosting events in the next {WINDOW_DAYS} days — {radiusLabel}. Tap a name to see their schedule.
+        </Typography>
+
+        {!isInitialized || events === null ? (
+          !error && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 6 }}>
+              <CircularProgress />
+            </Box>
+          )
+        ) : null}
+        {error && <Alert severity="error">Failed to load events: {error}</Alert>}
+        {events && events.length === 0 && (
+          <Alert severity="info">
+            No events found in the next {WINDOW_DAYS} days near this location. Try widening your map radius.
+          </Alert>
+        )}
+        {events && events.length > 0 && <OrganizerGroupedList events={events} />}
+      </Container>
+    </Box>
+  );
+}


### PR DESCRIPTION
Adds Organizer tab/route; reorders ModeToggle to LOC/ORG/EXP/BEG. Part of the 2.0 bundle for single PROD release as v2.1.0.

## Summary
- New `/organizer` route mirrors `/beginner` shell but 90d window, mapcenter-scoped, no filters
- New `OrganizerGroupedList` component: forked from BeginnerOrganizerList, uses MUI Accordion, collapsed by default, groups sorted by event count desc with count chip in header
- ModeToggle reordered + widened for 4-wide; path-first derivation in useMode.js updated

## JIRA
https://hdtsllc.atlassian.net/browse/TIEMPO-413

## Test plan
- [ ] Navigate to /organizer, confirm groups render collapsed with count chips, most-active first
- [ ] Tap group header, confirm expand reveals chronological events
- [ ] Click event, confirm deep-link to /calendar?event=X works
- [ ] ModeToggle on mobile (iPhone SE): all 4 pills fit, ORG/BEG/etc abbrevs readable
- [ ] Mode toggle path-first: visiting /organizer highlights ORG pill
- [ ] Test with no mapcenter set (initial anon visit): works w/ global fallback
- [ ] Narrow radius with sparse events: 'No events...' message shows