### PR TITLE
TIEMPO-415: Hide ModeToggle on /calendar/boston

### DIFF
--- a/src/app/components/UI/SiteMenuBar.js
+++ b/src/app/components/UI/SiteMenuBar.js
@@ -65,8 +65,10 @@ const SiteMenuBar = ({ activeCategories, handleCategoryChange, categories, searc
   return (
     <Box sx={{ width: '100%', display: 'flex', flexDirection: 'column', borderBottom: '1px solid rgba(0,0,0,0.06)' }}>
       {/* TIEMPO-408 Row 1 (primary chrome): brand · city · mode tabs.
-          Boston embed skips the new chrome and shows only ModeToggle as-was. */}
-      {!isBoston ? (
+          TIEMPO-415: Boston embed hides Row 1 entirely — legacy audience
+          stays in their owned space; the TT email campaign pulls them
+          forward. They still have sidebar/search via Row 2. */}
+      {!isBoston && (
         <Box
           sx={{
             width: '100%',
@@ -86,8 +88,6 @@ const SiteMenuBar = ({ activeCategories, handleCategoryChange, categories, searc
             <ModeToggle />
           </Box>
         </Box>
-      ) : (
-        <ModeToggle />
       )}
 
       {/* TIEMPO-408 Row 2 (utility): menu · search · filter · ai · messages · user */}


### PR DESCRIPTION
Per Toby 2026-04-21: Boston legacy audience keeps their minimal chrome. No 4-tab pill on /calendar/boston. Row 2 utility icons stay.

Single-file change (SiteMenuBar.js). Part of 2.1.0 bundle.

JIRA: https://hdtsllc.atlassian.net/browse/TIEMPO-415