### PR TITLE
TIEMPO-417: robots.txt Disallow + noindex meta on /explore

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,6 +2,11 @@
 User-agent: *
 Allow: /
 
+# TIEMPO-417: /explore is curated travel-worthy editorial data — not for
+# search-engine indexing. Polite bots obey; non-compliant ones are
+# handled BE-lane (rate limit + Referer check, separate ticket).
+Disallow: /explore
+
 # Host
 Host: https://www.tangotiempo.com
 

--- a/src/app/explore/layout.js
+++ b/src/app/explore/layout.js
@@ -1,0 +1,21 @@
+// TIEMPO-417: /explore is curated travel-worthy editorial data. We
+// want real users to land here via direct links / in-app nav, but we
+// don't want search engines indexing the curated list (passive leak
+// vector for competitors scraping Google). robots.txt Disallow is
+// the primary signal; this meta-level noindex is belt-and-suspenders
+// for bots that ignore robots.txt but do honor meta directives.
+
+export const metadata = {
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: {
+      index: false,
+      follow: false,
+    },
+  },
+};
+
+export default function ExploreLayout({ children }) {
+  return children;
+}


### PR DESCRIPTION
Two-layer anti-indexing for /explore curated data: robots.txt Disallow + metadata.robots noindex/nofollow via new layout.js server wrapper. 2.1.0 bundle. JIRA https://hdtsllc.atlassian.net/browse/TIEMPO-417