### PR TITLE
feat(explore): mobile toggle, timeline lanes, continent filter, MapCenter jump (TIEMPO-424) v1.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
-  "version": "1.22.24",
+  "version": "1.23.0",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,6 +2,11 @@
 User-agent: *
 Allow: /
 
+# TIEMPO-417: /explore is curated travel-worthy editorial data — not for
+# search-engine indexing. Polite bots obey; non-compliant ones are
+# handled BE-lane (rate limit + Referer check, separate ticket).
+Disallow: /explore
+
 # Host
 Host: https://www.tangotiempo.com
 

--- a/src/app/components/Explore/ExploreCardList.js
+++ b/src/app/components/Explore/ExploreCardList.js
@@ -6,7 +6,19 @@ import { useRouter } from 'next/navigation';
 import { Box, Paper, Typography, Chip, Stack, Tooltip } from '@mui/material';
 import SmartToyIcon from '@mui/icons-material/SmartToy';
 import dayjs from 'dayjs';
-import { colorFor, categoryLabel, continentColorFor } from './exploreConstants';
+import { colorFor, categoryLabel, continentColorFor, regionFor } from './exploreConstants';
+import { useGeoLocation } from '@/contexts/GeoLocationContext';
+
+function resolveVenueLL(e) {
+  const vg = e.venueGeolocation;
+  if (!vg) return null;
+  if (Array.isArray(vg.coordinates) && vg.coordinates.length >= 2) {
+    const [lng, lat] = vg.coordinates;
+    if (Number.isFinite(lat) && Number.isFinite(lng)) return [lat, lng];
+  }
+  if (Number.isFinite(vg.lat) && Number.isFinite(vg.lng)) return [vg.lat, vg.lng];
+  return null;
+}
 
 // TIEMPO-404 Milestone D.1: compact mobile cards with continent color stripe,
 // infinite scroll via IntersectionObserver.
@@ -30,6 +42,7 @@ function formatDateRange(start, end) {
 
 export default function ExploreCardList({ events }) {
   const router = useRouter();
+  const { setSessionLocation } = useGeoLocation();
   const [visibleCount, setVisibleCount] = React.useState(PAGE_SIZE);
   const sentinelRef = React.useRef(null);
 
@@ -74,7 +87,13 @@ export default function ExploreCardList({ events }) {
             <Paper
               key={e._id}
               elevation={1}
-              onClick={() => router.push(`/calendar?event=${e._id}`)}
+              onClick={() => {
+                if (e.venueGeolocation) {
+                  const ll = resolveVenueLL(e);
+                  if (ll) setSessionLocation({ lat: ll[0], lng: ll[1], zoomRange: 50 });
+                }
+                router.push(`/calendar?event=${e._id}`);
+              }}
               sx={{
                 display: 'flex',
                 cursor: 'pointer',
@@ -106,6 +125,7 @@ export default function ExploreCardList({ events }) {
                 <Typography variant="caption" color="textSecondary" sx={{ display: 'block', lineHeight: 1.3 }}>
                   {formatDateRange(e.startDate, e.endDate)}
                   {e.masteredCityName && ` · ${e.masteredCityName}`}
+                  {e.masteredCountryName && ` · ${e.masteredCountryName}`}
                 </Typography>
                 {/* Pills row: Category on LEFT, Country on RIGHT (Toby rule). Cost tucked to left. */}
                 <Box sx={{ display: 'flex', gap: 0.5, mt: 0.5, flexWrap: 'wrap', alignItems: 'center' }}>
@@ -125,7 +145,7 @@ export default function ExploreCardList({ events }) {
                   <Box sx={{ flex: 1 }} />
                   {e.masteredCountryName && (
                     <Chip
-                      label={e.masteredCountryName}
+                      label={regionFor(e.masteredCountryName)}
                       size="small"
                       variant="outlined"
                       sx={{ fontSize: '0.65rem', height: 18, borderColor: stripeColor, color: stripeColor }}
@@ -159,6 +179,7 @@ ExploreCardList.propTypes = {
       masteredCityName: PropTypes.string,
       cost: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       isAiGenerated: PropTypes.bool,
+      venueGeolocation: PropTypes.object,
     })
   ).isRequired,
 };

--- a/src/app/components/Explore/ExploreFilters.js
+++ b/src/app/components/Explore/ExploreFilters.js
@@ -5,12 +5,10 @@ import PropTypes from 'prop-types';
 import { Box, IconButton, Tooltip, Popper, Paper, ClickAwayListener, Grow, Checkbox } from '@mui/material';
 import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 import PublicIcon from '@mui/icons-material/Public';
-import { CATEGORY_COLORS, continentColorFor } from './exploreConstants';
+import { CATEGORY_COLORS, CONTINENT_COLORS } from './exploreConstants';
 
-// TIEMPO-408 pass 2: Left filter = Category multi-select. Right filter = Country.
-// TIEMPO-416: Country is now multi-select too, symmetric with Category.
-
-const CATEGORY_PRESETS = ['Festival', 'Marathon', 'Encuentro', 'Workshop'];
+// TIEMPO-408 pass 2: Left filter = Category multi-select. Right filter = Region.
+// TIEMPO-416: Country was multi-select; now replaced with Continent/Region filter.
 
 function Dropdown({ icon: Icon, tooltip, active, children }) {
   const [open, setOpen] = useState(false);
@@ -97,14 +95,15 @@ Row.propTypes = {
 export default function ExploreFilters({
   selectedCategories,
   onCategoriesChange,
-  availableCountries,
-  selectedCountries,
-  onCountriesChange,
+  availableCategories,
+  availableRegions,
+  selectedRegions,
+  onRegionsChange,
 }) {
   const catCount = selectedCategories.size;
   const catActive = catCount > 0;
-  const countryCount = selectedCountries.size;
-  const countryActive = countryCount > 0;
+  const regionCount = selectedRegions.size;
+  const regionActive = regionCount > 0;
 
   const toggleCategory = (c) => {
     const next = new Set(selectedCategories);
@@ -112,10 +111,10 @@ export default function ExploreFilters({
     onCategoriesChange(next);
   };
 
-  const toggleCountry = (c) => {
-    const next = new Set(selectedCountries);
+  const toggleRegion = (c) => {
+    const next = new Set(selectedRegions);
     if (next.has(c)) next.delete(c); else next.add(c);
-    onCountriesChange(next);
+    onRegionsChange(next);
   };
 
   return (
@@ -124,7 +123,7 @@ export default function ExploreFilters({
         {() => (
           <>
             <Row onClick={() => onCategoriesChange(new Set())} selected={!catActive}>All categories</Row>
-            {CATEGORY_PRESETS.map((c) => (
+            {availableCategories.map((c) => (
               <Row
                 key={c}
                 selected={selectedCategories.has(c)}
@@ -138,21 +137,21 @@ export default function ExploreFilters({
         )}
       </Dropdown>
 
-      <Dropdown icon={PublicIcon} tooltip={countryActive ? `${countryCount} countr${countryCount === 1 ? 'y' : 'ies'} selected` : 'Country'} active={countryActive}>
+      <Dropdown icon={PublicIcon} tooltip={regionActive ? `${regionCount} region${regionCount === 1 ? '' : 's'} selected` : 'Continent / Region'} active={regionActive}>
         {() => (
           <>
             <Row
-              selected={!countryActive}
-              onClick={() => onCountriesChange(new Set())}
+              selected={!regionActive}
+              onClick={() => onRegionsChange(new Set())}
             >
-              All countries
+              All regions
             </Row>
-            {availableCountries.map((c) => (
+            {availableRegions.map((c) => (
               <Row
                 key={c}
-                selected={selectedCountries.has(c)}
-                color={continentColorFor(c)}
-                onClick={() => toggleCountry(c)}
+                selected={selectedRegions.has(c)}
+                color={CONTINENT_COLORS[c]}
+                onClick={() => toggleRegion(c)}
               >
                 {c}
               </Row>
@@ -162,7 +161,7 @@ export default function ExploreFilters({
       </Dropdown>
 
       {/* Active-chip summary to reinforce current filter state (desktop+mobile) */}
-      {(catActive || countryActive) && (
+      {(catActive || regionActive) && (
         <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center', flexWrap: 'wrap' }}>
           {catActive && (
             <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.25, flexWrap: 'wrap' }}>
@@ -182,16 +181,16 @@ export default function ExploreFilters({
               ))}
             </Box>
           )}
-          {countryActive && (
+          {regionActive && (
             <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.25, flexWrap: 'wrap' }}>
-              {Array.from(selectedCountries).map((c) => (
+              {Array.from(selectedRegions).map((c) => (
                 <Box
                   key={c}
                   sx={{
                     px: 0.75, py: 0.15, borderRadius: 999,
                     border: '1px solid',
-                    borderColor: continentColorFor(c),
-                    color: continentColorFor(c),
+                    borderColor: CONTINENT_COLORS[c] || '#6b7280',
+                    color: CONTINENT_COLORS[c] || '#6b7280',
                     fontSize: '0.65rem',
                     fontWeight: 600,
                   }}
@@ -210,7 +209,8 @@ export default function ExploreFilters({
 ExploreFilters.propTypes = {
   selectedCategories: PropTypes.instanceOf(Set).isRequired,
   onCategoriesChange: PropTypes.func.isRequired,
-  availableCountries: PropTypes.arrayOf(PropTypes.string).isRequired,
-  selectedCountries: PropTypes.instanceOf(Set).isRequired,
-  onCountriesChange: PropTypes.func.isRequired,
+  availableCategories: PropTypes.arrayOf(PropTypes.string).isRequired,
+  availableRegions: PropTypes.arrayOf(PropTypes.string).isRequired,
+  selectedRegions: PropTypes.instanceOf(Set).isRequired,
+  onRegionsChange: PropTypes.func.isRequired,
 };

--- a/src/app/components/Explore/ExploreFilters.js
+++ b/src/app/components/Explore/ExploreFilters.js
@@ -2,13 +2,13 @@
 
 import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Box, IconButton, Tooltip, Popper, Paper, ClickAwayListener, Grow, Checkbox, Radio } from '@mui/material';
+import { Box, IconButton, Tooltip, Popper, Paper, ClickAwayListener, Grow, Checkbox } from '@mui/material';
 import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 import PublicIcon from '@mui/icons-material/Public';
-import { CATEGORY_COLORS, CONTINENT_COLORS, continentColorFor } from './exploreConstants';
+import { CATEGORY_COLORS, continentColorFor } from './exploreConstants';
 
-// TIEMPO-408 pass 2: Left filter = Category multi-select. Right filter = Country single-select.
-// Per Toby guidance — pill UX, rule 3.
+// TIEMPO-408 pass 2: Left filter = Category multi-select. Right filter = Country.
+// TIEMPO-416: Country is now multi-select too, symmetric with Category.
 
 const CATEGORY_PRESETS = ['Festival', 'Marathon', 'Encuentro', 'Workshop'];
 
@@ -61,8 +61,7 @@ Dropdown.propTypes = {
   children: PropTypes.func.isRequired,
 };
 
-function Row({ onClick, selected, color, children, mode = 'check' }) {
-  const Control = mode === 'radio' ? Radio : Checkbox;
+function Row({ onClick, selected, color, children }) {
   return (
     <Box
       onClick={onClick}
@@ -77,7 +76,7 @@ function Row({ onClick, selected, color, children, mode = 'check' }) {
         '&:hover': { background: 'rgba(0,0,0,0.04)' },
       }}
     >
-      <Control checked={selected} size="small" sx={{ p: 0.5 }} />
+      <Checkbox checked={selected} size="small" sx={{ p: 0.5 }} />
       {color && (
         <Box sx={{ width: 10, height: 10, borderRadius: '2px', background: color, flexShrink: 0 }} />
       )}
@@ -93,19 +92,19 @@ Row.propTypes = {
   selected: PropTypes.bool,
   color: PropTypes.string,
   children: PropTypes.node,
-  mode: PropTypes.oneOf(['check', 'radio']),
 };
 
 export default function ExploreFilters({
   selectedCategories,
   onCategoriesChange,
   availableCountries,
-  selectedCountry,
-  onCountryChange,
+  selectedCountries,
+  onCountriesChange,
 }) {
   const catCount = selectedCategories.size;
   const catActive = catCount > 0;
-  const countryActive = selectedCountry !== null;
+  const countryCount = selectedCountries.size;
+  const countryActive = countryCount > 0;
 
   const toggleCategory = (c) => {
     const next = new Set(selectedCategories);
@@ -113,12 +112,18 @@ export default function ExploreFilters({
     onCategoriesChange(next);
   };
 
+  const toggleCountry = (c) => {
+    const next = new Set(selectedCountries);
+    if (next.has(c)) next.delete(c); else next.add(c);
+    onCountriesChange(next);
+  };
+
   return (
     <Box sx={{ display: 'flex', gap: 1, mb: 2, alignItems: 'center' }}>
       <Dropdown icon={LocalOfferIcon} tooltip={catActive ? `${catCount} categor${catCount === 1 ? 'y' : 'ies'} selected` : 'Categories'} active={catActive}>
         {() => (
           <>
-            <Row onClick={() => onCategoriesChange(new Set())} selected={!catActive} mode="check">All categories</Row>
+            <Row onClick={() => onCategoriesChange(new Set())} selected={!catActive}>All categories</Row>
             {CATEGORY_PRESETS.map((c) => (
               <Row
                 key={c}
@@ -133,23 +138,21 @@ export default function ExploreFilters({
         )}
       </Dropdown>
 
-      <Dropdown icon={PublicIcon} tooltip={selectedCountry || 'Country'} active={countryActive}>
-        {(close) => (
+      <Dropdown icon={PublicIcon} tooltip={countryActive ? `${countryCount} countr${countryCount === 1 ? 'y' : 'ies'} selected` : 'Country'} active={countryActive}>
+        {() => (
           <>
             <Row
-              selected={selectedCountry === null}
-              onClick={() => { onCountryChange(null); close(); }}
-              mode="radio"
+              selected={!countryActive}
+              onClick={() => onCountriesChange(new Set())}
             >
               All countries
             </Row>
             {availableCountries.map((c) => (
               <Row
                 key={c}
-                selected={selectedCountry === c}
+                selected={selectedCountries.has(c)}
                 color={continentColorFor(c)}
-                onClick={() => { onCountryChange(c); close(); }}
-                mode="radio"
+                onClick={() => toggleCountry(c)}
               >
                 {c}
               </Row>
@@ -162,7 +165,7 @@ export default function ExploreFilters({
       {(catActive || countryActive) && (
         <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center', flexWrap: 'wrap' }}>
           {catActive && (
-            <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.25, fontSize: '0.72rem', color: 'text.secondary' }}>
+            <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.25, flexWrap: 'wrap' }}>
               {Array.from(selectedCategories).map((c) => (
                 <Box
                   key={c}
@@ -180,17 +183,22 @@ export default function ExploreFilters({
             </Box>
           )}
           {countryActive && (
-            <Box
-              sx={{
-                px: 0.75, py: 0.15, borderRadius: 999,
-                border: '1px solid',
-                borderColor: continentColorFor(selectedCountry),
-                color: continentColorFor(selectedCountry),
-                fontSize: '0.65rem',
-                fontWeight: 600,
-              }}
-            >
-              {selectedCountry}
+            <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.25, flexWrap: 'wrap' }}>
+              {Array.from(selectedCountries).map((c) => (
+                <Box
+                  key={c}
+                  sx={{
+                    px: 0.75, py: 0.15, borderRadius: 999,
+                    border: '1px solid',
+                    borderColor: continentColorFor(c),
+                    color: continentColorFor(c),
+                    fontSize: '0.65rem',
+                    fontWeight: 600,
+                  }}
+                >
+                  {c}
+                </Box>
+              ))}
             </Box>
           )}
         </Box>
@@ -203,6 +211,6 @@ ExploreFilters.propTypes = {
   selectedCategories: PropTypes.instanceOf(Set).isRequired,
   onCategoriesChange: PropTypes.func.isRequired,
   availableCountries: PropTypes.arrayOf(PropTypes.string).isRequired,
-  selectedCountry: PropTypes.string,
-  onCountryChange: PropTypes.func.isRequired,
+  selectedCountries: PropTypes.instanceOf(Set).isRequired,
+  onCountriesChange: PropTypes.func.isRequired,
 };

--- a/src/app/components/Explore/ExploreMap.js
+++ b/src/app/components/Explore/ExploreMap.js
@@ -9,6 +9,7 @@ import dayjs from 'dayjs';
 import { useRouter } from 'next/navigation';
 import { colorFor, categoryLabel, CATEGORY_COLORS } from './exploreConstants';
 import { centroidFor, jitterPosition } from './countryCentroids';
+import { useGeoLocation } from '@/contexts/GeoLocationContext';
 
 // TIEMPO-408 item 6: world map of travelWorthy events — respects rules 1-5.
 // Category = marker fill color.
@@ -48,6 +49,7 @@ function truncate(str, n) {
 
 export default function ExploreMap({ events }) {
   const router = useRouter();
+  const { setSessionLocation } = useGeoLocation();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const markerRadius = isMobile ? 11 : 7;
@@ -160,7 +162,11 @@ export default function ExploreMap({ events }) {
                     <Button
                       size="small"
                       variant="contained"
-                      onClick={() => router.push(`/calendar?event=${e._id}`)}
+                      onClick={() => {
+                        const ll = resolveVenueGeo(e) || (e.masteredCountryName && centroidFor(e.masteredCountryName));
+                        if (ll) setSessionLocation({ lat: ll[0], lng: ll[1], zoomRange: 50 });
+                        router.push(`/calendar?event=${e._id}`);
+                      }}
                       sx={{
                         mt: 1,
                         bgcolor: color,

--- a/src/app/components/Explore/ExploreMap.js
+++ b/src/app/components/Explore/ExploreMap.js
@@ -3,7 +3,7 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import dynamic from 'next/dynamic';
-import { Box, Typography, Alert, CircularProgress, useMediaQuery } from '@mui/material';
+import { Box, Typography, Alert, CircularProgress, Button, useMediaQuery } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import dayjs from 'dayjs';
 import { useRouter } from 'next/navigation';
@@ -29,13 +29,21 @@ const Popup = dynamic(() => import('react-leaflet').then((m) => m.Popup), { ssr:
 function resolveVenueGeo(e) {
   const vg = e.venueGeolocation;
   if (!vg) return null;
+  // TIEMPO-414: Number.isFinite catches NaN / Infinity / null / undefined that
+  // `typeof x === 'number'` silently lets through for `NaN`.
   // MongoDB GeoJSON: { type: 'Point', coordinates: [lng, lat] }
   if (Array.isArray(vg.coordinates) && vg.coordinates.length >= 2) {
     const [lng, lat] = vg.coordinates;
-    if (typeof lat === 'number' && typeof lng === 'number') return [lat, lng];
+    if (Number.isFinite(lat) && Number.isFinite(lng)) return [lat, lng];
   }
-  if (typeof vg.lat === 'number' && typeof vg.lng === 'number') return [vg.lat, vg.lng];
+  if (Number.isFinite(vg.lat) && Number.isFinite(vg.lng)) return [vg.lat, vg.lng];
   return null;
+}
+
+function truncate(str, n) {
+  if (!str) return '';
+  const clean = String(str).replace(/\s+/g, ' ').trim();
+  return clean.length > n ? `${clean.slice(0, n).trim()}…` : clean;
 }
 
 export default function ExploreMap({ events }) {
@@ -112,32 +120,60 @@ export default function ExploreMap({ events }) {
                 radius={markerRadius}
                 pathOptions={{
                   color: isAI ? '#d97706' : '#ffffff',
-                  weight: isAI ? 2 : 1,
+                  weight: isAI ? 2 : 2,
                   dashArray: isAI ? '3 2' : undefined,
                   fillColor: color,
                   fillOpacity: 0.92,
                 }}
-                eventHandlers={{ click: () => router.push(`/calendar?event=${e._id}`) }}
               >
                 <Popup>
-                  <Box sx={{ minWidth: popupMinWidth, maxWidth: isMobile ? 220 : 280 }}>
-                    <Typography variant="subtitle2" sx={{ fontWeight: 700, color }}>
+                  <Box sx={{ minWidth: popupMinWidth, maxWidth: isMobile ? 240 : 300 }}>
+                    <Typography variant="subtitle2" sx={{ fontWeight: 700, color, lineHeight: 1.3, mb: 0.25 }}>
                       {e.title}
                     </Typography>
-                    <Typography variant="caption" sx={{ display: 'block' }}>
+                    <Typography variant="caption" sx={{ display: 'block', color: 'text.primary' }}>
                       {dayjs(e.startDate).format('MMM D')} – {dayjs(e.endDate).format('MMM D, YYYY')}
                     </Typography>
-                    <Typography variant="caption" color="textSecondary" sx={{ display: 'block' }}>
-                      {[e.masteredCityName, e.masteredCountryName].filter(Boolean).join(', ')}
-                    </Typography>
-                    <Typography variant="caption" sx={{ display: 'block', mt: 0.5, fontWeight: 600, color }}>
-                      {categoryLabel(e.categoryFirst)}
-                    </Typography>
-                    {isAI && (
-                      <Typography variant="caption" sx={{ display: 'block', mt: 0.25, color: '#d97706', fontWeight: 700 }}>
-                        🤖 AI-Found
+                    {(e.masteredCityName || e.masteredCountryName) && (
+                      <Typography variant="caption" color="textSecondary" sx={{ display: 'block' }}>
+                        {[e.masteredCityName, e.masteredCountryName].filter(Boolean).join(', ')}
                       </Typography>
                     )}
+                    <Typography variant="caption" sx={{ display: 'block', mt: 0.5, fontWeight: 600, color }}>
+                      {categoryLabel(e.categoryFirst)}
+                      {isAI && <span style={{ marginLeft: 6, color: '#d97706', fontWeight: 700 }}>🤖 AI-Found</span>}
+                    </Typography>
+                    {e.description && (
+                      <Typography
+                        variant="caption"
+                        color="textSecondary"
+                        sx={{
+                          display: 'block',
+                          mt: 0.75,
+                          lineHeight: 1.4,
+                          fontStyle: 'italic',
+                        }}
+                      >
+                        {truncate(e.description, 180)}
+                      </Typography>
+                    )}
+                    <Button
+                      size="small"
+                      variant="contained"
+                      onClick={() => router.push(`/calendar?event=${e._id}`)}
+                      sx={{
+                        mt: 1,
+                        bgcolor: color,
+                        color: '#fff',
+                        fontSize: '0.7rem',
+                        textTransform: 'none',
+                        py: 0.25,
+                        '&:hover': { bgcolor: color, filter: 'brightness(0.9)' },
+                      }}
+                      fullWidth
+                    >
+                      View full event →
+                    </Button>
                   </Box>
                 </Popup>
               </CircleMarker>

--- a/src/app/components/Explore/ExploreMap.js
+++ b/src/app/components/Explore/ExploreMap.js
@@ -3,7 +3,8 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import dynamic from 'next/dynamic';
-import { Box, Typography, Alert, CircularProgress } from '@mui/material';
+import { Box, Typography, Alert, CircularProgress, useMediaQuery } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import dayjs from 'dayjs';
 import { useRouter } from 'next/navigation';
 import { colorFor, categoryLabel, CATEGORY_COLORS } from './exploreConstants';
@@ -39,6 +40,10 @@ function resolveVenueGeo(e) {
 
 export default function ExploreMap({ events }) {
   const router = useRouter();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const markerRadius = isMobile ? 11 : 7;
+  const popupMinWidth = isMobile ? 140 : 180;
 
   const { positioned, skipped } = useMemo(() => {
     const groupCounters = new Map();
@@ -67,12 +72,15 @@ export default function ExploreMap({ events }) {
     return { positioned: out, skipped: skip };
   }, [events]);
 
-  if (!events || events.length === 0) {
-    return <Alert severity="info">No events match the current filter.</Alert>;
-  }
+  const noEvents = !events || events.length === 0;
 
   return (
     <Box sx={{ position: 'relative' }}>
+      {noEvents && (
+        <Alert severity="info" sx={{ mb: 1 }}>
+          No events match the current filter.
+        </Alert>
+      )}
       <Box
         sx={{
           height: { xs: 420, md: 560 },
@@ -101,7 +109,7 @@ export default function ExploreMap({ events }) {
               <CircleMarker
                 key={e._id}
                 center={ll}
-                radius={7}
+                radius={markerRadius}
                 pathOptions={{
                   color: isAI ? '#d97706' : '#ffffff',
                   weight: isAI ? 2 : 1,
@@ -112,7 +120,7 @@ export default function ExploreMap({ events }) {
                 eventHandlers={{ click: () => router.push(`/calendar?event=${e._id}`) }}
               >
                 <Popup>
-                  <Box sx={{ minWidth: 180 }}>
+                  <Box sx={{ minWidth: popupMinWidth, maxWidth: isMobile ? 220 : 280 }}>
                     <Typography variant="subtitle2" sx={{ fontWeight: 700, color }}>
                       {e.title}
                     </Typography>
@@ -138,15 +146,36 @@ export default function ExploreMap({ events }) {
         </MapContainer>
       </Box>
 
-      <Box sx={{ display: 'flex', gap: 1.25, justifyContent: 'center', p: 0.5, mt: 1, fontSize: '0.7rem', color: '#6b7280', flexWrap: 'wrap' }}>
+      <Box sx={{
+        display: 'flex',
+        gap: { xs: 0.75, sm: 1.25 },
+        justifyContent: 'center',
+        p: 0.5,
+        mt: 1,
+        fontSize: { xs: '0.62rem', sm: '0.7rem' },
+        color: '#6b7280',
+        flexWrap: 'wrap',
+      }}>
         {Object.entries(CATEGORY_COLORS).map(([name, color]) => (
           <Box key={name} sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.4 }}>
-            <Box sx={{ width: 10, height: 10, borderRadius: '50%', background: color, border: '1px solid #fff' }} />
+            <Box sx={{
+              width: { xs: 8, sm: 10 },
+              height: { xs: 8, sm: 10 },
+              borderRadius: '50%',
+              background: color,
+              border: '1px solid #fff',
+            }} />
             {name}
           </Box>
         ))}
         <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.4 }}>
-          <Box sx={{ width: 10, height: 10, borderRadius: '50%', background: '#9ca3af', border: '2px dashed #d97706' }} />
+          <Box sx={{
+            width: { xs: 8, sm: 10 },
+            height: { xs: 8, sm: 10 },
+            borderRadius: '50%',
+            background: '#9ca3af',
+            border: '2px dashed #d97706',
+          }} />
           AI-Found
         </Box>
       </Box>

--- a/src/app/components/Explore/ExploreTimeline.js
+++ b/src/app/components/Explore/ExploreTimeline.js
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useRouter } from 'next/navigation';
 import { Group } from '@visx/group';
-import { scaleTime, scaleBand } from '@visx/scale';
+import { scaleTime, scaleOrdinal } from '@visx/scale';
 import { AxisBottom, AxisLeft } from '@visx/axis';
 import { Zoom } from '@visx/zoom';
 import { useTooltip, TooltipWithBounds, defaultStyles } from '@visx/tooltip';
@@ -17,9 +17,10 @@ import { CATEGORY_COLORS, colorFor } from './exploreConstants';
 
 const MARGIN = { top: 16, right: 32, bottom: 44, left: 160 };
 const MIN_BAR_WIDTH = 10;
-const ROW_PADDING = 0.3;
 const DEFAULT_WIDTH = 1100;
 const DEFAULT_HEIGHT_BASE = 480;
+const LANE_H = 24;   // px per sub-lane within a country band
+const LANE_GAP = 8;  // px gap between country bands
 
 const SCALE_X_MIN = 0.5;
 const SCALE_X_MAX = 8;
@@ -51,6 +52,40 @@ function formatDateRange(start, end) {
 
 const INITIAL_MATRIX = { scaleX: 1, scaleY: 1, translateX: 0, translateY: 0, skewX: 0, skewY: 0 };
 
+function assignEventLanes(events) {
+  const byCountry = new Map();
+  for (const e of events) {
+    const c = e.masteredCountryName || 'Other';
+    if (!byCountry.has(c)) byCountry.set(c, []);
+    byCountry.get(c).push(e);
+  }
+  const laneOf = new Map();   // _id → lane index (0-based)
+  const laneCount = new Map(); // country → number of lanes needed
+  for (const [country, evts] of byCountry) {
+    const sorted = [...evts].sort((a, b) => new Date(a.startDate) - new Date(b.startDate));
+    const laneEnd = []; // laneEnd[i] = end-ms of the last event placed in lane i
+    for (const e of sorted) {
+      const start = new Date(e.startDate).getTime();
+      const end   = new Date(e.endDate).getTime();
+      let placed = false;
+      for (let i = 0; i < laneEnd.length; i++) {
+        if (start >= laneEnd[i]) {
+          laneEnd[i] = end;
+          laneOf.set(e._id, i);
+          placed = true;
+          break;
+        }
+      }
+      if (!placed) {
+        laneOf.set(e._id, laneEnd.length);
+        laneEnd.push(end);
+      }
+    }
+    laneCount.set(country, Math.max(1, laneEnd.length));
+  }
+  return { laneOf, laneCount };
+}
+
 export default function ExploreTimeline({ events, countries, dateRange, onXScaleReady }) {
   const router = useRouter();
   const { tooltipData, tooltipLeft, tooltipTop, tooltipOpen, showTooltip, hideTooltip } = useTooltip();
@@ -68,18 +103,46 @@ export default function ExploreTimeline({ events, countries, dateRange, onXScale
     return () => ro.disconnect();
   }, [width]);
 
-  const rowCount = Math.max(1, countries.length);
-  const height = Math.max(DEFAULT_HEIGHT_BASE, MARGIN.top + MARGIN.bottom + rowCount * 44);
   const xMax = width - MARGIN.left - MARGIN.right;
-  const yMax = height - MARGIN.top - MARGIN.bottom;
 
   const baseXScale = React.useMemo(
     () => scaleTime({ domain: dateRange, range: [0, xMax] }),
     [dateRange, xMax]
   );
-  const yScale = React.useMemo(
-    () => scaleBand({ domain: countries, range: [0, yMax], padding: ROW_PADDING }),
-    [countries, yMax]
+
+  const { laneOf, laneCount } = React.useMemo(() => assignEventLanes(events), [events]);
+
+  // yLayout[country] = { y: number (top of band), height: number, center: number }
+  const yLayout = React.useMemo(() => {
+    const layout = {};
+    let y = 0;
+    for (const country of countries) {
+      const lanes = laneCount.get(country) || 1;
+      const h = lanes * LANE_H;
+      layout[country] = { y, height: h, center: y + h / 2, lanes };
+      y += h + LANE_GAP;
+    }
+    return layout;
+  }, [countries, laneCount]);
+
+  const totalContentH = React.useMemo(() => {
+    if (!countries.length) return DEFAULT_HEIGHT_BASE - MARGIN.top - MARGIN.bottom;
+    const last = yLayout[countries[countries.length - 1]];
+    return last ? last.y + last.height : 200;
+  }, [countries, yLayout]);
+
+  const yMax = totalContentH;
+  const height = Math.max(DEFAULT_HEIGHT_BASE, MARGIN.top + yMax + MARGIN.bottom + 44);
+
+  // Y-axis scale: ordinal scale mapping country → center Y of its band
+  // Used by AxisLeft so labels appear centered in each (possibly expanded) band.
+  const yAxisScale = React.useMemo(
+    () =>
+      scaleOrdinal({
+        domain: countries,
+        range: countries.map((c) => yLayout[c]?.center ?? 0),
+      }),
+    [countries, yLayout]
   );
 
   // Parent gets the (un-transformed) xScale + width for DensityBar alignment
@@ -139,7 +202,7 @@ export default function ExploreTimeline({ events, countries, dateRange, onXScale
                 {/* Y-axis (fixed, outside zoom transform) */}
                 <Group left={MARGIN.left} top={MARGIN.top}>
                   <AxisLeft
-                    scale={yScale}
+                    scale={yAxisScale}
                     stroke="#9ca3af"
                     tickStroke="#9ca3af"
                     tickLabelProps={() => ({ fill: '#374151', fontSize: 12, textAnchor: 'end', dx: -4, dy: '0.33em' })}
@@ -158,6 +221,9 @@ export default function ExploreTimeline({ events, countries, dateRange, onXScale
                   onMouseMove={zoom.dragMove}
                   onMouseUp={zoom.dragEnd}
                   onMouseLeave={() => { if (zoom.isDragging) zoom.dragEnd(); }}
+                  onTouchStart={zoom.dragStart}
+                  onTouchMove={zoom.dragMove}
+                  onTouchEnd={zoom.dragEnd}
                   onDoubleClick={zoom.reset}
                   onWheel={(e) => {
                     e.preventDefault();
@@ -168,16 +234,16 @@ export default function ExploreTimeline({ events, countries, dateRange, onXScale
 
                 {/* Zoomed content — gridlines, x-axis, bars — clipped to chart area */}
                 <Group left={MARGIN.left} top={MARGIN.top} clipPath="url(#tt-timeline-clip)">
-                  {/* Horizontal gridlines per country */}
+                  {/* Horizontal gridlines at bottom edge of each country band */}
                   {countries.map((country) => {
-                    const y = yScale(country) + yScale.bandwidth() / 2;
+                    const ly = yLayout[country];
+                    if (!ly) return null;
                     return (
                       <line
                         key={country}
-                        x1={0}
-                        x2={xMax}
-                        y1={y}
-                        y2={y}
+                        x1={0} x2={xMax}
+                        y1={ly.y + ly.height + LANE_GAP / 2}
+                        y2={ly.y + ly.height + LANE_GAP / 2}
                         stroke="#e5e7eb"
                         strokeDasharray="2 4"
                       />
@@ -195,51 +261,34 @@ export default function ExploreTimeline({ events, countries, dateRange, onXScale
 
                   {events.map((e) => {
                     const start = new Date(e.startDate);
-                    const end = new Date(e.endDate);
+                    const end   = new Date(e.endDate);
                     const x1 = zoomedXScale(start);
                     const x2 = zoomedXScale(end);
                     const barW = Math.max(MIN_BAR_WIDTH, x2 - x1);
-                    const rowY = yScale(e.masteredCountryName);
-                    if (rowY === undefined) return null;
+                    const ly = yLayout[e.masteredCountryName];
+                    if (!ly) return null;
                     if (x1 + barW < -10 || x1 > xMax + 10) return null;
-                    const barH = yScale.bandwidth();
+                    const lane = laneOf.get(e._id) ?? 0;
+                    const barY = ly.y + lane * LANE_H + 1;   // 1px top padding within lane
+                    const barH = LANE_H - 2;                  // 2px bottom gap within lane
                     const isAI = Boolean(e.isAiGenerated || e.isDiscovered);
                     const categoryColor = colorFor(e.categoryFirst);
                     const commonProps = {
-                      x: x1,
-                      y: rowY,
-                      width: barW,
-                      height: barH,
-                      rx: 3,
-                      ry: 3,
+                      x: x1, y: barY, width: barW, height: barH, rx: 3, ry: 3,
                       style: { cursor: 'pointer' },
                       onMouseMove: (evt) => handleBarMove(evt, e),
                       onMouseLeave: hideTooltip,
                       onClick: (evt) => { evt.stopPropagation(); handleClick(e); },
                       onMouseDown: (evt) => evt.stopPropagation(),
+                      onTouchStart: zoom.dragStart,
+                      onTouchMove: zoom.dragMove,
+                      onTouchEnd: zoom.dragEnd,
                     };
                     return (
                       <g key={e._id}>
-                        {/* Category color base */}
-                        <rect
-                          {...commonProps}
-                          fill={categoryColor}
-                          stroke={isAI ? '#d97706' : '#fff'}
-                          strokeWidth={isAI ? 1.5 : 1}
-                          strokeDasharray={isAI ? '3 2' : undefined}
-                        />
-                        {/* AI-Found overlay: diagonal stripes make AI bars visually distinct */}
+                        <rect {...commonProps} fill={categoryColor} stroke={isAI ? '#d97706' : '#fff'} strokeWidth={isAI ? 1.5 : 1} strokeDasharray={isAI ? '3 2' : undefined} />
                         {isAI && (
-                          <rect
-                            x={x1}
-                            y={rowY}
-                            width={barW}
-                            height={barH}
-                            rx={3}
-                            ry={3}
-                            fill="url(#tt-ai-stripes)"
-                            style={{ pointerEvents: 'none' }}
-                          />
+                          <rect x={x1} y={barY} width={barW} height={barH} rx={3} ry={3} fill="url(#tt-ai-stripes)" style={{ pointerEvents: 'none' }} />
                         )}
                       </g>
                     );

--- a/src/app/components/Explore/ExploreViewToggle.js
+++ b/src/app/components/Explore/ExploreViewToggle.js
@@ -5,11 +5,12 @@ import PropTypes from 'prop-types';
 import { Box, ToggleButton, ToggleButtonGroup, Tooltip } from '@mui/material';
 import TimelineIcon from '@mui/icons-material/Timeline';
 import PublicIcon from '@mui/icons-material/Public';
+import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
 
 // TIEMPO-408 item 6: desktop toggle between the visx Gantt timeline and the
 // new Leaflet world-map view.
 
-export default function ExploreViewToggle({ view, onChange }) {
+export default function ExploreViewToggle({ view, onChange, showList = false }) {
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
       <ToggleButtonGroup
@@ -28,6 +29,14 @@ export default function ExploreViewToggle({ view, onChange }) {
           },
         }}
       >
+        {showList && (
+          <Tooltip title="List view" arrow>
+            <ToggleButton value="list" aria-label="list view">
+              <FormatListBulletedIcon fontSize="small" />
+              List
+            </ToggleButton>
+          </Tooltip>
+        )}
         <Tooltip title="Timeline (Gantt)" arrow>
           <ToggleButton value="timeline" aria-label="timeline view">
             <TimelineIcon fontSize="small" />
@@ -46,6 +55,7 @@ export default function ExploreViewToggle({ view, onChange }) {
 }
 
 ExploreViewToggle.propTypes = {
-  view: PropTypes.oneOf(['timeline', 'map']).isRequired,
+  view: PropTypes.oneOf(['timeline', 'map', 'list']).isRequired,
   onChange: PropTypes.func.isRequired,
+  showList: PropTypes.bool,
 };

--- a/src/app/components/Explore/exploreConstants.js
+++ b/src/app/components/Explore/exploreConstants.js
@@ -4,12 +4,15 @@
 
 // TIEMPO-404 D.4: Trip + Class removed per Toby. Class is already excluded
 // by the backend travelWorthy rule; Trip events now render as Other grey.
+// TIEMPO-414: Repalette for higher hue-distance — Festival was pink-red and
+// Workshop was pink, nearly indistinguishable on the map. Now red / orange /
+// green / purple / grey spans the hue wheel cleanly.
 export const CATEGORY_COLORS = {
-  Festival: '#e94560',
-  Marathon: '#f97316',
-  Encuentro: '#22c55e',
-  Workshop: '#ec4899',
-  Other: '#6b7280',
+  Festival: '#dc2626',  // red
+  Marathon: '#f97316',  // orange
+  Encuentro: '#22c55e', // green
+  Workshop: '#8b5cf6',  // purple
+  Other: '#6b7280',     // grey
 };
 
 export const categoryLabel = (c) => (c && c !== 'unknown' ? c : 'Other');

--- a/src/app/components/Modals/Welcome/WelcomeModal.js
+++ b/src/app/components/Modals/Welcome/WelcomeModal.js
@@ -1,26 +1,23 @@
 /**
- * WelcomeModal - Browser Geolocation First Flow
+ * WelcomeModal - First-visit location setup trigger
  *
- * Part of TIEMPO-329: Managed User Entry Flow
- * Updated TIEMPO-388: Try browser geolocation before showing modal
- * Updated TIEMPO-XXX: Enhanced toast with city name and change button
+ * TIEMPO-329: Managed User Entry Flow
+ * TIEMPO-411: Auto-browser-geolocation path removed — iOS Safari rejected
+ *             setTimeout-delayed getCurrentPosition as non-gesture and
+ *             surfaced a confusing "not allowed" error.
  *
  * Flow for anonymous users:
- * 1. If user has saved/session location → use it silently
- * 2. If on /boston route → use Boston coordinates (handled elsewhere)
- * 3. Otherwise → TRY browser geolocation first
- *    a. If granted → use it, show toast with city name, DON'T show modal
- *    b. If denied/timeout → show MapCenterModal
+ * 1. Logged in → UserLocationLoader handles it, skip
+ * 2. Already have a saved/session location (or on /boston) → skip
+ * 3. Otherwise → open MapCenterModal; user picks explicitly via crosshair
+ *    map click or user-tap "Use My Location" button
  *
  * @module WelcomeModal
  */
 
 'use client';
 
-import { useState, useEffect, useContext } from 'react';
-import { Snackbar, Alert, Button, Box, Typography, CircularProgress } from '@mui/material';
-import LocationOnIcon from '@mui/icons-material/LocationOn';
-import EditLocationIcon from '@mui/icons-material/EditLocation';
+import { useEffect, useState, useContext } from 'react';
 import { AuthContext } from '@/contexts/AuthContext';
 import { useGeoLocation } from '@/contexts/GeoLocationContext';
 import {
@@ -28,148 +25,39 @@ import {
   getLastMapCenter
 } from '@/utils/visitorTracking';
 
-/**
- * Determine if user needs location setup
- * @returns {boolean} true if no stored location
- */
 const needsLocationSetup = () => {
   const storedLocation = getLastMapCenter();
   const isBostonRoute = typeof window !== 'undefined' && window.location.pathname.includes('/boston');
-
   if (isBostonRoute) return false;
   if (storedLocation) return false;
   return true;
 };
 
-/**
- * WelcomeModal Component
- * Tries browser geolocation first, only shows modal if denied/failed
- */
 const WelcomeModal = () => {
   const { user } = useContext(AuthContext);
-  const { openMapCenterModal, setSessionLocation, currentLocation } = useGeoLocation();
+  const { openMapCenterModal } = useGeoLocation();
   const [hasChecked, setHasChecked] = useState(false);
-  const [toastOpen, setToastOpen] = useState(false);
-  const [isNewVisitor, setIsNewVisitor] = useState(false);
 
   useEffect(() => {
     if (hasChecked) return;
 
-    const visitCount = incrementVisitCount();
-    setIsNewVisitor(visitCount <= 5); // First 5 visits = new visitor
+    incrementVisitCount();
 
-    // Skip for logged-in users - UserLocationLoader handles their location
     if (user) {
       setHasChecked(true);
       return;
     }
 
-    // Skip if already have location
     if (!needsLocationSetup()) {
       setHasChecked(true);
       return;
     }
 
-    // TIEMPO-388: Try browser geolocation first for anonymous users
-    const tryBrowserGeolocation = () => {
-      if (!('geolocation' in navigator)) {
-        // No geolocation support - fall back to modal
-        openMapCenterModal();
-        return;
-      }
-
-      // Try to get browser location with timeout
-      navigator.geolocation.getCurrentPosition(
-        (position) => {
-          // Success! Use browser location
-          const { latitude, longitude } = position.coords;
-          setSessionLocation({
-            lat: latitude,
-            lng: longitude,
-            zoomRange: 50
-          });
-
-          // Show friendly toast instead of modal
-          setToastOpen(true);
-        },
-        (_error) => {
-          // Geolocation denied or failed - show modal
-          openMapCenterModal();
-        },
-        {
-          enableHighAccuracy: false,
-          timeout: 10000,  // 10 second timeout (VPN can slow geolocation)
-          maximumAge: 300000  // Accept cached position up to 5 min old
-        }
-      );
-    };
-
-    // Small delay to let page render, then try geolocation
-    setTimeout(tryBrowserGeolocation, 500);
-
-    setHasChecked(true);
-  }, [hasChecked, openMapCenterModal, setSessionLocation, user]);
-
-  // Build display text based on city name availability
-  const locationText = currentLocation?.cityName
-    ? `📍 Using ${currentLocation.cityName}`
-    : currentLocation?.cityNameLoading
-      ? '📍 Finding your city...'
-      : '📍 Using your location';
-
-  const handleChangeLocation = () => {
-    setToastOpen(false);
     openMapCenterModal();
-  };
+    setHasChecked(true);
+  }, [hasChecked, openMapCenterModal, user]);
 
-  return (
-    <Snackbar
-      open={toastOpen}
-      onClose={() => setToastOpen(false)}
-      autoHideDuration={isNewVisitor ? 8000 : 5000}
-      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-    >
-      <Alert
-        onClose={() => setToastOpen(false)}
-        severity="info"
-        icon={currentLocation?.cityNameLoading ? <CircularProgress size={16} color="inherit" /> : <LocationOnIcon />}
-        sx={{
-          backgroundColor: '#1976d2',
-          color: 'white',
-          alignItems: 'center',
-          '& .MuiAlert-icon': { color: 'white' },
-          '& .MuiAlert-action': { pt: 0 }
-        }}
-        action={
-          <Button
-            color="inherit"
-            size="small"
-            onClick={handleChangeLocation}
-            startIcon={<EditLocationIcon />}
-            sx={{
-              color: 'white',
-              borderColor: 'rgba(255,255,255,0.5)',
-              '&:hover': { borderColor: 'white', bgcolor: 'rgba(255,255,255,0.1)' }
-            }}
-            variant="outlined"
-          >
-            Change
-          </Button>
-        }
-      >
-        <Box>
-          <Typography variant="body2" sx={{ fontWeight: 500 }}>
-            {locationText}
-          </Typography>
-          {isNewVisitor && (
-            <Typography variant="caption" sx={{ opacity: 0.9, display: 'block' }}>
-              Tip: Use the 🗺️ icon anytime to change
-            </Typography>
-          )}
-        </Box>
-      </Alert>
-    </Snackbar>
-  );
+  return null;
 };
 
 export default WelcomeModal;

--- a/src/app/components/Modals/misc/MapCenterModal.js
+++ b/src/app/components/Modals/misc/MapCenterModal.js
@@ -771,20 +771,11 @@ const MapCenterModal = ({
     );
   };
 
-  // Auto-get user location when modal opens (if no initial location set)
-  useEffect(() => {
-    if (!open) return;
-    if (initialLocation?.lat && initialLocation?.lng) return; // Already have location
-    if (centerLat && centerLng) return; // Already set this session
-
-    // Auto-trigger location fetch after small delay for map init
-    const timer = setTimeout(() => {
-      handleUseMyLocation();
-    }, 500);
-
-    return () => clearTimeout(timer);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
+  // TIEMPO-411: Auto-trigger removed. iOS Safari treats setTimeout-delayed
+  // getCurrentPosition as non-gesture and rejects with PERMISSION_DENIED,
+  // which surfaced as a confusing "Could not get location" error even when
+  // OS permission was granted. Users now pick explicitly via the "Use My
+  // Location" button (gesture → works on mobile) or the crosshair map click.
 
   // Unified save handler - saves to cloud (logged in) or session (anonymous)
   const handleSave = async () => {

--- a/src/app/components/Organizer/OrganizerGroupedList.js
+++ b/src/app/components/Organizer/OrganizerGroupedList.js
@@ -6,6 +6,8 @@ import { useRouter } from 'next/navigation';
 import { Box, Typography, Chip, Stack, Divider, Tooltip, Accordion, AccordionSummary, AccordionDetails } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import RepeatIcon from '@mui/icons-material/Repeat';
+import SchoolIcon from '@mui/icons-material/School';
+import WavingHandIcon from '@mui/icons-material/WavingHand';
 import dayjs from 'dayjs';
 import { firstInstanceInWindow } from '@/utils/nextInstance';
 
@@ -16,6 +18,25 @@ import { firstInstanceInWindow } from '@/utils/nextInstance';
 // the top of the list — not in this scope.
 
 const WINDOW_DAYS = 90;
+
+// Broader category palette than Explore's 5-color filtered set — Local
+// events cover Milonga/Practica/Class that don't appear in Explore. Kept
+// local to this file so Explore's legend stays lean.
+const CATEGORY_COLORS = {
+  Milonga: '#ef4444',     // red
+  Practica: '#14b8a6',    // teal
+  Class: '#3b82f6',       // blue
+  Workshop: '#ec4899',    // pink
+  DayWorkshop: '#d946ef', // magenta
+  Festival: '#e94560',    // pink-red
+  Marathon: '#f97316',    // orange
+  Encuentro: '#22c55e',   // green
+  Concert: '#a855f7',     // purple
+  Show: '#f59e0b',        // amber
+  Trip: '#0ea5e9',        // sky
+  Other: '#6b7280',       // grey
+};
+const categoryColor = (c) => (c && CATEGORY_COLORS[c]) || CATEGORY_COLORS.Other;
 
 function isAIish(e) {
   return Boolean(e?.isDiscovered || e?.isAiGenerated);
@@ -200,34 +221,82 @@ export default function OrganizerGroupedList({ events }) {
                       >
                         {title}
                       </Typography>
-                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, alignItems: 'center' }}>
-                        {e.categoryFirst && (
+                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, alignItems: 'center', width: '100%' }}>
+                        {[e.categoryFirst, e.categorySecond, e.categoryThird]
+                          .filter(Boolean)
+                          .map((cat, idx) => (
+                            <Chip
+                              key={`cat-${idx}`}
+                              label={cat}
+                              size="small"
+                              sx={{
+                                fontSize: '0.6rem',
+                                height: 18,
+                                bgcolor: ai ? '#f8fafc' : categoryColor(cat),
+                                color: ai ? '#94a3b8' : '#fff',
+                                fontWeight: 600,
+                                border: ai ? '1px solid #e2e8f0' : 'none',
+                              }}
+                            />
+                          ))}
+                        {(e.venueAbbr || e.venueName) && (
                           <Chip
-                            label={e.categoryFirst}
+                            label={e.venueAbbr || e.venueName}
                             size="small"
+                            variant="outlined"
                             sx={{
                               fontSize: '0.6rem',
                               height: 18,
-                              bgcolor: ai ? '#f8fafc' : 'rgba(0,0,0,0.05)',
+                              maxWidth: 160,
                               color: ai ? '#94a3b8' : '#475569',
-                              border: '1px solid',
-                              borderColor: ai ? '#e2e8f0' : 'rgba(0,0,0,0.08)',
+                              borderColor: ai ? '#e2e8f0' : 'rgba(0,0,0,0.15)',
+                              '& .MuiChip-label': {
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                              },
                             }}
                           />
                         )}
-                        {e.masteredCityName && (
-                          <Chip
-                            label={e.masteredCityName}
-                            size="small"
-                            sx={{
-                              fontSize: '0.6rem',
-                              height: 18,
-                              bgcolor: ai ? '#f8fafc' : 'rgba(25,118,210,0.08)',
-                              color: ai ? '#94a3b8' : '#1976d2',
-                              border: '1px solid',
-                              borderColor: ai ? '#e2e8f0' : 'rgba(25,118,210,0.2)',
-                            }}
-                          />
+                        {/* Right-side beginner markers — distinct square-ish shape, green palette */}
+                        <Box sx={{ flex: 1 }} />
+                        {e.forBeginners && (
+                          <Tooltip title="Organizer has flagged this as a dedicated beginner event" arrow>
+                            <Chip
+                              icon={<SchoolIcon sx={{ fontSize: 12, color: ai ? '#94a3b8' : '#15803d !important' }} />}
+                              label="For Beg"
+                              size="small"
+                              sx={{
+                                fontSize: '0.58rem',
+                                height: 18,
+                                borderRadius: '4px',
+                                bgcolor: ai ? '#f8fafc' : 'rgba(34,197,94,0.18)',
+                                color: ai ? '#94a3b8' : '#15803d',
+                                fontWeight: 700,
+                                border: '1px solid',
+                                borderColor: ai ? '#e2e8f0' : 'rgba(34,197,94,0.4)',
+                                '& .MuiChip-icon': { ml: '3px', mr: '-3px' },
+                              }}
+                            />
+                          </Tooltip>
+                        )}
+                        {e.beginnerFriendly && (
+                          <Tooltip title="Welcoming to beginners (not exclusively beginner)" arrow>
+                            <Chip
+                              icon={<WavingHandIcon sx={{ fontSize: 12, color: ai ? '#94a3b8' : '#64748b !important' }} />}
+                              label="Beg-friendly"
+                              size="small"
+                              variant="outlined"
+                              sx={{
+                                fontSize: '0.58rem',
+                                height: 18,
+                                borderRadius: '4px',
+                                color: ai ? '#94a3b8' : '#64748b',
+                                borderColor: ai ? '#e2e8f0' : '#cbd5e1',
+                                '& .MuiChip-icon': { ml: '3px', mr: '-3px' },
+                              }}
+                            />
+                          </Tooltip>
                         )}
                       </Box>
                     </Box>
@@ -266,8 +335,13 @@ OrganizerGroupedList.propTypes = {
       ownerOrganizerName: PropTypes.string,
       ownerOrganizerShortName: PropTypes.string,
       ownerOrganizerID: PropTypes.string,
-      masteredCityName: PropTypes.string,
+      venueName: PropTypes.string,
+      venueAbbr: PropTypes.string,
       categoryFirst: PropTypes.string,
+      categorySecond: PropTypes.string,
+      categoryThird: PropTypes.string,
+      forBeginners: PropTypes.bool,
+      beginnerFriendly: PropTypes.bool,
       isDiscovered: PropTypes.bool,
       isAiGenerated: PropTypes.bool,
     })

--- a/src/app/components/Organizer/OrganizerGroupedList.js
+++ b/src/app/components/Organizer/OrganizerGroupedList.js
@@ -1,0 +1,275 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { useRouter } from 'next/navigation';
+import { Box, Typography, Chip, Stack, Divider, Tooltip, Accordion, AccordionSummary, AccordionDetails } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import RepeatIcon from '@mui/icons-material/Repeat';
+import dayjs from 'dayjs';
+import { firstInstanceInWindow } from '@/utils/nextInstance';
+
+// TIEMPO-413: Organizer tab — grouped by ownerOrganizerName, all local
+// events within mapcenter radius over 90-day window. Groups render as
+// MUI Accordion, collapsed by default, sorted by event count descending
+// (most active organizers first). Future: favorited organizers float to
+// the top of the list — not in this scope.
+
+const WINDOW_DAYS = 90;
+
+function isAIish(e) {
+  return Boolean(e?.isDiscovered || e?.isAiGenerated);
+}
+
+function groupKey(e) {
+  return (
+    e.ownerOrganizerID ||
+    e.ownerOrganizerName ||
+    e.ownerOrganizerShortName ||
+    '__none__'
+  );
+}
+
+function formatEventLine(displayDate, e) {
+  const start = dayjs(displayDate);
+  const date = start.format('ddd MMM D');
+  const time = start.format('h:mm A');
+  return { date, time, title: e.title };
+}
+
+export default function OrganizerGroupedList({ events }) {
+  const router = useRouter();
+
+  const groups = useMemo(() => {
+    if (!events?.length) return [];
+    const now = dayjs().startOf('day');
+    const cutoff = dayjs().add(WINDOW_DAYS, 'day');
+    const fromMs = now.valueOf();
+    const toMs = cutoff.valueOf();
+
+    // Recurring masters need next-instance expansion — a weekly milonga's
+    // base startDate can be years old; rrule finds the next instance in
+    // the 90-day window. Events with no hit in the window are dropped.
+    const windowed = [];
+    for (const e of events) {
+      const nextDate = firstInstanceInWindow(e, fromMs, toMs);
+      if (!nextDate) continue;
+      windowed.push({ ...e, _displayDate: nextDate });
+    }
+
+    // Group by organizer
+    const map = new Map();
+    for (const e of windowed) {
+      const k = groupKey(e);
+      if (!map.has(k)) {
+        const fullName = e.ownerOrganizerName || '';
+        const shortName = e.ownerOrganizerShortName || '';
+        const headerPrimary = fullName || shortName || 'Unknown organizer';
+        const headerSecondary = shortName && fullName && fullName !== shortName ? shortName : null;
+        map.set(k, {
+          key: k,
+          headerPrimary,
+          headerSecondary,
+          organizerId: e.ownerOrganizerID,
+          events: [],
+        });
+      }
+      map.get(k).events.push(e);
+    }
+
+    // Sort events within group chronologically (AI still de-emphasized to bottom)
+    const byDisplayDate = (a, b) => {
+      const aAI = isAIish(a) ? 1 : 0;
+      const bAI = isAIish(b) ? 1 : 0;
+      if (aAI !== bAI) return aAI - bAI;
+      return a._displayDate.getTime() - b._displayDate.getTime();
+    };
+
+    // Sort groups by event count descending — most active first.
+    // Tiebreak: alphabetical on headerPrimary.
+    return Array.from(map.values())
+      .map((g) => ({ ...g, events: [...g.events].sort(byDisplayDate) }))
+      .sort((a, b) => {
+        if (b.events.length !== a.events.length) return b.events.length - a.events.length;
+        return a.headerPrimary.localeCompare(b.headerPrimary);
+      });
+  }, [events]);
+
+  if (!groups.length) {
+    return (
+      <Typography variant="body2" color="textSecondary" sx={{ mt: 2 }}>
+        No events in the next {WINDOW_DAYS} days in this area.
+      </Typography>
+    );
+  }
+
+  return (
+    <Stack spacing={0.75} sx={{ mt: 1 }}>
+      {groups.map((g) => (
+        <Accordion
+          key={g.key}
+          defaultExpanded={false}
+          disableGutters
+          elevation={0}
+          sx={{
+            border: '1px solid rgba(0,0,0,0.08)',
+            borderRadius: '8px !important',
+            overflow: 'hidden',
+            '&:before': { display: 'none' },
+          }}
+        >
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            sx={{
+              px: 1.5,
+              py: 0.25,
+              background: 'rgba(25,118,210,0.06)',
+              '& .MuiAccordionSummary-content': { my: 0.75 },
+            }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%', minWidth: 0 }}>
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography variant="subtitle1" sx={{ fontWeight: 700, lineHeight: 1.2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {g.headerPrimary}
+                </Typography>
+                {g.headerSecondary && (
+                  <Typography variant="caption" color="textSecondary" sx={{ display: 'block', lineHeight: 1.25 }}>
+                    {g.headerSecondary}
+                  </Typography>
+                )}
+              </Box>
+              <Chip
+                label={g.events.length}
+                size="small"
+                sx={{
+                  fontSize: '0.7rem',
+                  height: 20,
+                  fontWeight: 600,
+                  bgcolor: 'rgba(25,118,210,0.12)',
+                  color: '#1976d2',
+                  flexShrink: 0,
+                }}
+              />
+            </Box>
+          </AccordionSummary>
+          <AccordionDetails sx={{ p: 0 }}>
+            <Stack divider={<Divider flexItem />}>
+              {g.events.map((e) => {
+                const ai = isAIish(e);
+                const { date, time, title } = formatEventLine(e._displayDate, e);
+                return (
+                  <Box
+                    key={e._id}
+                    onClick={() => router.push(`/calendar?event=${e._id}`)}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
+                      px: 1.5,
+                      py: 0.85,
+                      cursor: 'pointer',
+                      opacity: ai ? 0.55 : 1,
+                      background: ai ? 'rgba(0,0,0,0.015)' : 'transparent',
+                      transition: 'background 120ms ease',
+                      '&:hover': { background: 'rgba(25,118,210,0.04)' },
+                    }}
+                  >
+                    <Box sx={{ minWidth: 92, flexShrink: 0 }}>
+                      <Typography variant="caption" sx={{ display: 'flex', alignItems: 'center', gap: 0.4, fontWeight: 600, color: ai ? 'text.secondary' : 'text.primary' }}>
+                        {date}
+                        {e.isRepeating && (
+                          <Tooltip title="Recurring series — next upcoming session shown" arrow>
+                            <RepeatIcon sx={{ fontSize: 12, color: '#64748b' }} aria-label="recurring" />
+                          </Tooltip>
+                        )}
+                      </Typography>
+                      <Typography variant="caption" color="textSecondary">
+                        {time}
+                      </Typography>
+                    </Box>
+                    <Box sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                          fontWeight: ai ? 400 : 500,
+                          color: ai ? 'text.secondary' : 'text.primary',
+                        }}
+                      >
+                        {title}
+                      </Typography>
+                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, alignItems: 'center' }}>
+                        {e.categoryFirst && (
+                          <Chip
+                            label={e.categoryFirst}
+                            size="small"
+                            sx={{
+                              fontSize: '0.6rem',
+                              height: 18,
+                              bgcolor: ai ? '#f8fafc' : 'rgba(0,0,0,0.05)',
+                              color: ai ? '#94a3b8' : '#475569',
+                              border: '1px solid',
+                              borderColor: ai ? '#e2e8f0' : 'rgba(0,0,0,0.08)',
+                            }}
+                          />
+                        )}
+                        {e.masteredCityName && (
+                          <Chip
+                            label={e.masteredCityName}
+                            size="small"
+                            sx={{
+                              fontSize: '0.6rem',
+                              height: 18,
+                              bgcolor: ai ? '#f8fafc' : 'rgba(25,118,210,0.08)',
+                              color: ai ? '#94a3b8' : '#1976d2',
+                              border: '1px solid',
+                              borderColor: ai ? '#e2e8f0' : 'rgba(25,118,210,0.2)',
+                            }}
+                          />
+                        )}
+                      </Box>
+                    </Box>
+                    {ai && (
+                      <Chip
+                        label="AI"
+                        size="small"
+                        sx={{
+                          fontSize: '0.58rem',
+                          height: 16,
+                          bgcolor: '#f1f5f9',
+                          color: '#94a3b8',
+                          border: '1px solid #e2e8f0',
+                          flexShrink: 0,
+                        }}
+                        title="AI-discovered event"
+                      />
+                    )}
+                  </Box>
+                );
+              })}
+            </Stack>
+          </AccordionDetails>
+        </Accordion>
+      ))}
+    </Stack>
+  );
+}
+
+OrganizerGroupedList.propTypes = {
+  events: PropTypes.arrayOf(
+    PropTypes.shape({
+      _id: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+      startDate: PropTypes.string.isRequired,
+      ownerOrganizerName: PropTypes.string,
+      ownerOrganizerShortName: PropTypes.string,
+      ownerOrganizerID: PropTypes.string,
+      masteredCityName: PropTypes.string,
+      categoryFirst: PropTypes.string,
+      isDiscovered: PropTypes.bool,
+      isAiGenerated: PropTypes.bool,
+    })
+  ).isRequired,
+};

--- a/src/app/components/UI/ModeToggle.js
+++ b/src/app/components/UI/ModeToggle.js
@@ -6,14 +6,16 @@ import { useTheme } from '@mui/material/styles';
 import { useMode } from '@/hooks/useMode';
 
 // TIEMPO-408: custom pill segmented control with sliding indicator.
+// TIEMPO-413: 4-wide — order is LOCAL -> ORG -> EXPLORE -> BEGINNER.
 // Each mode has its own color; selected state uses the color prominently.
 // Mobile: bigger abbreviation + tiny full-word caption below.
 // Desktop: full label only.
 
 const OPTIONS = [
-  { value: 'beginner', label: 'Beginner', short: 'BEG', color: '#22c55e' }, // green — welcoming
-  { value: 'local',    label: 'Local',    short: 'LOC', color: '#3b82f6' }, // blue — home/familiar
-  { value: 'explore',  label: 'Explore',  short: 'EXP', color: '#f59e0b' }, // amber — travel/adventure
+  { value: 'local',     label: 'Local',     short: 'LOC', color: '#3b82f6' }, // blue — home/familiar
+  { value: 'organizer', label: 'Organizer', short: 'ORG', color: '#8b5cf6' }, // purple — community/who
+  { value: 'explore',   label: 'Explore',   short: 'EXP', color: '#f59e0b' }, // amber — travel/adventure
+  { value: 'beginner',  label: 'Beginner',  short: 'BEG', color: '#22c55e' }, // green — welcoming
 ];
 
 export default function ModeToggle() {
@@ -37,7 +39,7 @@ export default function ModeToggle() {
         borderRadius: 999,
         background: 'rgba(0, 0, 0, 0.06)',
         height: isMobile ? 44 : 34,
-        minWidth: isMobile ? 180 : 260,
+        minWidth: isMobile ? 240 : 340,
       }}
     >
       {/* Sliding white pill. Hidden when no tab is active (non-mode route). */}
@@ -79,7 +81,7 @@ export default function ModeToggle() {
               position: 'relative',
               zIndex: 1,
               flex: 1,
-              minWidth: isMobile ? 58 : 80,
+              minWidth: isMobile ? 54 : 78,
               display: 'flex',
               flexDirection: 'column',
               alignItems: 'center',

--- a/src/app/components/UI/SidebarDrawer.js
+++ b/src/app/components/UI/SidebarDrawer.js
@@ -50,6 +50,7 @@ import RegionalOrganizersModal from '@/components/Modals/RegionalOrganizers/Regi
 import PrivacyPolicyModal from '@/components/Modals/misc/PrivacyPolicyModal';
 import FAQModal from '@/components/Modals/misc/FAQModal';
 import SystemAdminModal from '@/components/Modals/SystemAdmin/SystemAdminModal';
+import ComposeMessageModal from '@/components/Modals/Messages/ComposeMessageModal';
 import { RoleContext } from '@/contexts/RoleContext';
 import { AuthContext } from '@/contexts/AuthContext';
 import { listOfAllRoles } from '@/utils/masterData';
@@ -73,6 +74,7 @@ const SidebarDrawer = ({ open, onClose }) => {
   const [userSettingsOpen, setUserSettingsOpen] = useState(false);
   const [regionalOrganizerOpen, setRegionalOrganizerOpen] = useState(false);
   const [systemAdminOpen, setSystemAdminOpen] = useState(false);
+  const [composeMessageOpen, setComposeMessageOpen] = useState(false);
   const [privacyPolicyOpen, setPrivacyPolicyOpen] = useState(false);
   const [faqOpen, setFaqOpen] = useState(false);
   const [venueModalOpen, setVenueModalOpen] = useState(false);
@@ -396,6 +398,19 @@ const SidebarDrawer = ({ open, onClose }) => {
                   <ListItemText primary="Geo-Diagnostics" />
                 </ListItem>
               </Link>
+
+              <ListItem
+                button="true"
+                onClick={() => {
+                  setComposeMessageOpen(true);
+                  onClose();
+                }}
+              >
+                <ListItemIcon>
+                  <MessageIcon sx={{ color: 'teal' }} />
+                </ListItemIcon>
+                <ListItemText primary="Compose Message" secondary="Send to users by role" />
+              </ListItem>
             </>
           )}
           {selectedRole === listOfAllRoles.SYSTEM_OWNER && (
@@ -431,9 +446,22 @@ const SidebarDrawer = ({ open, onClose }) => {
                   <ListItemText primary="Geo-Diagnostics" />
                 </ListItem>
               </Link>
+
+              <ListItem
+                button="true"
+                onClick={() => {
+                  setComposeMessageOpen(true);
+                  onClose();
+                }}
+              >
+                <ListItemIcon>
+                  <MessageIcon sx={{ color: 'teal' }} />
+                </ListItemIcon>
+                <ListItemText primary="Compose Message" secondary="Send to users by role" />
+              </ListItem>
             </>
           )}
-              
+
               {/* Close authentication section */}
             </>
           )}
@@ -601,6 +629,7 @@ const SidebarDrawer = ({ open, onClose }) => {
       />
       <RegionalOrganizersModal open={regionalOrganizerOpen} onClose={() => setRegionalOrganizerOpen(false)} />
       <SystemAdminModal open={systemAdminOpen} onClose={() => setSystemAdminOpen(false)} />
+      <ComposeMessageModal open={composeMessageOpen} onClose={() => setComposeMessageOpen(false)} />
       <FAQModal open={faqOpen} onClose={() => setFaqOpen(false)} />
       <PrivacyPolicyModal open={privacyPolicyOpen} onClose={() => setPrivacyPolicyOpen(false)} />
       <VenueModal open={venueModalOpen} onClose={() => setVenueModalOpen(false)} />

--- a/src/app/components/UI/SiteMenuBar.js
+++ b/src/app/components/UI/SiteMenuBar.js
@@ -65,8 +65,10 @@ const SiteMenuBar = ({ activeCategories, handleCategoryChange, categories, searc
   return (
     <Box sx={{ width: '100%', display: 'flex', flexDirection: 'column', borderBottom: '1px solid rgba(0,0,0,0.06)' }}>
       {/* TIEMPO-408 Row 1 (primary chrome): brand · city · mode tabs.
-          Boston embed skips the new chrome and shows only ModeToggle as-was. */}
-      {!isBoston ? (
+          TIEMPO-415: Boston embed hides Row 1 entirely — legacy audience
+          stays in their owned space; the TT email campaign pulls them
+          forward. They still have sidebar/search via Row 2. */}
+      {!isBoston && (
         <Box
           sx={{
             width: '100%',
@@ -86,8 +88,6 @@ const SiteMenuBar = ({ activeCategories, handleCategoryChange, categories, searc
             <ModeToggle />
           </Box>
         </Box>
-      ) : (
-        <ModeToggle />
       )}
 
       {/* TIEMPO-408 Row 2 (utility): menu · search · filter · ai · messages · user */}

--- a/src/app/components/UI/SiteMenuBar.js
+++ b/src/app/components/UI/SiteMenuBar.js
@@ -30,6 +30,7 @@ const SiteMenuBar = ({ activeCategories, handleCategoryChange, categories, searc
   const pathname = usePathname();
   // TIEMPO-408: /calendar/boston is a legacy iframe embed — keep its chrome as-is.
   const isBoston = pathname?.startsWith('/calendar/boston');
+  const isExplorePage = pathname === '/explore';
 
   const [sidebarDrawerOpen, setSidebarDrawerOpen] = useState(false);
   const [userDrawerOpen, setUserDrawerOpen] = useState(false);
@@ -81,8 +82,8 @@ const SiteMenuBar = ({ activeCategories, handleCategoryChange, categories, searc
           }}
         >
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, minWidth: 0, flexShrink: 1 }}>
-            <BrandMark size={36} />
-            <CityPill />
+            <BrandMark size={isExplorePage ? 44 : 36} />
+            {!isExplorePage && <CityPill />}
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', flexShrink: 0 }}>
             <ModeToggle />

--- a/src/app/explore/layout.js
+++ b/src/app/explore/layout.js
@@ -1,0 +1,21 @@
+// TIEMPO-417: /explore is curated travel-worthy editorial data. We
+// want real users to land here via direct links / in-app nav, but we
+// don't want search engines indexing the curated list (passive leak
+// vector for competitors scraping Google). robots.txt Disallow is
+// the primary signal; this meta-level noindex is belt-and-suspenders
+// for bots that ignore robots.txt but do honor meta directives.
+
+export const metadata = {
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: {
+      index: false,
+      follow: false,
+    },
+  },
+};
+
+export default function ExploreLayout({ children }) {
+  return children;
+}

--- a/src/app/explore/page.js
+++ b/src/app/explore/page.js
@@ -13,19 +13,19 @@ import ExploreViewToggle from '@/components/Explore/ExploreViewToggle';
 import ExploreMonthScrubber from '@/components/Explore/ExploreMonthScrubber';
 import ExploreMap from '@/components/Explore/ExploreMap';
 import DensityBar from '@/components/Explore/DensityBar';
-import { categoryLabel } from '@/components/Explore/exploreConstants';
+import { categoryLabel, regionFor } from '@/components/Explore/exploreConstants';
 import { expandToNextInstance } from '@/utils/nextInstance';
 import { getApiBaseUrl } from '@/utils/apiUrlResolver';
 import dayjs from 'dayjs';
 
 // TIEMPO-408 Explore pass 2 (Toby guidance):
 // - Categories filter: multi-select (Set)
-// - Country filter: multi-select (Set) — TIEMPO-416 symmetry with categories
+// - Region filter: multi-select (Set) — continent/region grouping replaces country filter
 // - AI-Found visual: made prominent in card/list and visx bars
 // - Desktop fallback to card list when no country is resolved yet
 
 const COOKIE_CATS = 'tt_explore_categories';
-const COOKIE_COUNTRIES = 'tt_explore_countries';
+const COOKIE_REGIONS = 'tt_explore_regions';
 const COOKIE_VIEW = 'tt_explore_view';
 
 const readSetCookie = (name) => {
@@ -45,13 +45,20 @@ export default function ExplorePage() {
   const [events, setEvents] = useState(null);
   const [error, setError] = useState(null);
   const [selectedCategories, setSelectedCategoriesState] = useState(() => readSetCookie(COOKIE_CATS) || new Set());
-  const [selectedCountries, setSelectedCountriesState] = useState(() => readSetCookie(COOKIE_COUNTRIES) || new Set());
+  const [selectedRegions, setSelectedRegionsState] = useState(() => readSetCookie(COOKIE_REGIONS) || new Set());
   const [selectedMonthKey, setSelectedMonthKey] = useState(null); // 'YYYY-MM' or null = all in window
   const [offsetMonths, setOffsetMonths] = useState(0); // <<>> page offset, multiples of 6
   const [view, setViewState] = useState(() => {
-    if (typeof window === 'undefined') return 'timeline';
-    return Cookies.get(COOKIE_VIEW) === 'map' ? 'map' : 'timeline';
+    if (typeof window === 'undefined') return 'mobile-default';
+    const saved = Cookies.get(COOKIE_VIEW);
+    if (saved === 'map') return 'map';
+    if (saved === 'list') return 'list';
+    if (saved === 'timeline') return 'timeline';
+    return 'mobile-default';
   });
+  const effectiveView = view === 'mobile-default'
+    ? (isMobile ? 'list' : 'timeline')
+    : (view === 'list' && !isMobile ? 'timeline' : view);
   const [xInfo, setXInfo] = useState(null);
 
   const setView = useCallback((next) => {
@@ -64,9 +71,9 @@ export default function ExplorePage() {
     writeSetCookie(COOKIE_CATS, next);
   }, []);
 
-  const setSelectedCountries = useCallback((next) => {
-    setSelectedCountriesState(next);
-    writeSetCookie(COOKIE_COUNTRIES, next);
+  const setSelectedRegions = useCallback((next) => {
+    setSelectedRegionsState(next);
+    writeSetCookie(COOKIE_REGIONS, next);
   }, []);
 
   useEffect(() => {
@@ -82,19 +89,22 @@ export default function ExplorePage() {
       .catch((err) => setError(err.message || 'Failed to load events'));
   }, []);
 
-  const availableCountries = useMemo(() => {
+  const availableRegions = useMemo(() => {
     if (!events) return [];
-    return Array.from(new Set(events.map((e) => e.masteredCountryName).filter(Boolean))).sort();
+    return Array.from(new Set(events.map((e) => regionFor(e.masteredCountryName)).filter(Boolean))).sort();
   }, [events]);
 
-  // Drop any selected country that's no longer in the available set
+  const availableCategories = useMemo(() => {
+    if (!events) return [];
+    return Array.from(new Set(events.map((e) => categoryLabel(e.categoryFirst)).filter(Boolean))).sort();
+  }, [events]);
+
+  // Drop any selected region that's no longer in the available set
   useEffect(() => {
-    if (!events || selectedCountries.size === 0) return;
-    const pruned = new Set(Array.from(selectedCountries).filter((c) => availableCountries.includes(c)));
-    if (pruned.size !== selectedCountries.size) {
-      setSelectedCountries(pruned);
-    }
-  }, [events, availableCountries, selectedCountries, setSelectedCountries]);
+    if (!events || selectedRegions.size === 0) return;
+    const pruned = new Set(Array.from(selectedRegions).filter((r) => availableRegions.includes(r)));
+    if (pruned.size !== selectedRegions.size) setSelectedRegions(pruned);
+  }, [events, availableRegions, selectedRegions, setSelectedRegions]);
 
   // 12-month rolling window anchored to offsetMonths from today. Arrows on
   // the scrubber shift this window forward/backward by 6-month increments.
@@ -116,7 +126,7 @@ export default function ExplorePage() {
       const display = expandToNextInstance(e, fromMs, toMs);
       if (!display) continue;
 
-      if (selectedCountries.size > 0 && !selectedCountries.has(display.masteredCountryName)) continue;
+      if (selectedRegions.size > 0 && !selectedRegions.has(regionFor(display.masteredCountryName))) continue;
       if (selectedCategories.size > 0 && !selectedCategories.has(categoryLabel(display.categoryFirst))) continue;
 
       if (selectedMonthKey) {
@@ -129,7 +139,7 @@ export default function ExplorePage() {
       out.push(display);
     }
     return out;
-  }, [events, selectedCountries, selectedCategories, selectedMonthKey, windowStart, windowEnd]);
+  }, [events, selectedRegions, selectedCategories, selectedMonthKey, windowStart, windowEnd]);
 
   // Visx timeline needs country rows — derive from filtered set
   const sortedActiveCountries = useMemo(
@@ -179,11 +189,15 @@ export default function ExplorePage() {
               <ExploreFilters
                 selectedCategories={selectedCategories}
                 onCategoriesChange={setSelectedCategories}
-                availableCountries={availableCountries}
-                selectedCountries={selectedCountries}
-                onCountriesChange={setSelectedCountries}
+                availableCategories={availableCategories}
+                availableRegions={availableRegions}
+                selectedRegions={selectedRegions}
+                onRegionsChange={setSelectedRegions}
               />
-              {!isMobile && <ExploreViewToggle view={view} onChange={setView} />}
+              {isMobile
+                ? <ExploreViewToggle view={effectiveView} onChange={setView} showList />
+                : <ExploreViewToggle view={effectiveView} onChange={setView} />
+              }
             </Box>
 
             <Box sx={{ mb: 1.5 }}>
@@ -196,15 +210,41 @@ export default function ExplorePage() {
             </Box>
 
             {isMobile ? (
-              <ExploreCardList events={filteredEvents} />
-            ) : availableCountries.length === 0 ? (
+              effectiveView === 'map' ? (
+                <ExploreMap events={filteredEvents} />
+              ) : effectiveView === 'timeline' ? (
+                <Paper elevation={1} sx={{ p: 2, mt: 1 }}>
+                  <ExploreTimeline
+                    events={filteredEvents}
+                    countries={sortedActiveCountries}
+                    dateRange={dateRange}
+                    onXScaleReady={setXInfo}
+                  />
+                  {xInfo && (
+                    <>
+                      <Divider sx={{ my: 1 }} />
+                      <Box sx={{ overflowX: 'auto' }}>
+                        <DensityBar
+                          events={filteredEvents}
+                          xScale={xInfo.xScale}
+                          leftMargin={xInfo.leftMargin}
+                          width={xInfo.width}
+                        />
+                      </Box>
+                    </>
+                  )}
+                </Paper>
+              ) : (
+                <ExploreCardList events={filteredEvents} />
+              )
+            ) : availableRegions.length === 0 ? (
               <>
                 <Alert severity="info" sx={{ mb: 1 }}>
                   Country data is still catching up — showing event list.
                 </Alert>
                 <ExploreCardList events={filteredEvents} />
               </>
-            ) : view === 'map' ? (
+            ) : effectiveView === 'map' ? (
               <ExploreMap events={filteredEvents} />
             ) : filteredEvents.length === 0 ? (
               <Alert severity="info">No events match the current filter. Try relaxing category, country, or month.</Alert>

--- a/src/app/explore/page.js
+++ b/src/app/explore/page.js
@@ -20,12 +20,12 @@ import dayjs from 'dayjs';
 
 // TIEMPO-408 Explore pass 2 (Toby guidance):
 // - Categories filter: multi-select (Set)
-// - Country filter: single-select (string | null)
+// - Country filter: multi-select (Set) — TIEMPO-416 symmetry with categories
 // - AI-Found visual: made prominent in card/list and visx bars
 // - Desktop fallback to card list when no country is resolved yet
 
 const COOKIE_CATS = 'tt_explore_categories';
-const COOKIE_COUNTRY = 'tt_explore_country';
+const COOKIE_COUNTRIES = 'tt_explore_countries';
 const COOKIE_VIEW = 'tt_explore_view';
 
 const readSetCookie = (name) => {
@@ -45,11 +45,7 @@ export default function ExplorePage() {
   const [events, setEvents] = useState(null);
   const [error, setError] = useState(null);
   const [selectedCategories, setSelectedCategoriesState] = useState(() => readSetCookie(COOKIE_CATS) || new Set());
-  const [selectedCountry, setSelectedCountryState] = useState(() => {
-    if (typeof window === 'undefined') return null;
-    const raw = Cookies.get(COOKIE_COUNTRY);
-    return raw || null;
-  });
+  const [selectedCountries, setSelectedCountriesState] = useState(() => readSetCookie(COOKIE_COUNTRIES) || new Set());
   const [selectedMonthKey, setSelectedMonthKey] = useState(null); // 'YYYY-MM' or null = all in window
   const [offsetMonths, setOffsetMonths] = useState(0); // <<>> page offset, multiples of 6
   const [view, setViewState] = useState(() => {
@@ -68,10 +64,9 @@ export default function ExplorePage() {
     writeSetCookie(COOKIE_CATS, next);
   }, []);
 
-  const setSelectedCountry = useCallback((next) => {
-    setSelectedCountryState(next);
-    if (next === null) Cookies.remove(COOKIE_COUNTRY);
-    else Cookies.set(COOKIE_COUNTRY, next, { expires: 365, sameSite: 'Lax' });
+  const setSelectedCountries = useCallback((next) => {
+    setSelectedCountriesState(next);
+    writeSetCookie(COOKIE_COUNTRIES, next);
   }, []);
 
   useEffect(() => {
@@ -92,12 +87,14 @@ export default function ExplorePage() {
     return Array.from(new Set(events.map((e) => e.masteredCountryName).filter(Boolean))).sort();
   }, [events]);
 
-  // If selectedCountry is no longer in the available set, clear it
+  // Drop any selected country that's no longer in the available set
   useEffect(() => {
-    if (selectedCountry && events && !availableCountries.includes(selectedCountry)) {
-      setSelectedCountry(null);
+    if (!events || selectedCountries.size === 0) return;
+    const pruned = new Set(Array.from(selectedCountries).filter((c) => availableCountries.includes(c)));
+    if (pruned.size !== selectedCountries.size) {
+      setSelectedCountries(pruned);
     }
-  }, [events, availableCountries, selectedCountry, setSelectedCountry]);
+  }, [events, availableCountries, selectedCountries, setSelectedCountries]);
 
   // 12-month rolling window anchored to offsetMonths from today. Arrows on
   // the scrubber shift this window forward/backward by 6-month increments.
@@ -119,7 +116,7 @@ export default function ExplorePage() {
       const display = expandToNextInstance(e, fromMs, toMs);
       if (!display) continue;
 
-      if (selectedCountry && display.masteredCountryName !== selectedCountry) continue;
+      if (selectedCountries.size > 0 && !selectedCountries.has(display.masteredCountryName)) continue;
       if (selectedCategories.size > 0 && !selectedCategories.has(categoryLabel(display.categoryFirst))) continue;
 
       if (selectedMonthKey) {
@@ -132,7 +129,7 @@ export default function ExplorePage() {
       out.push(display);
     }
     return out;
-  }, [events, selectedCountry, selectedCategories, selectedMonthKey, windowStart, windowEnd]);
+  }, [events, selectedCountries, selectedCategories, selectedMonthKey, windowStart, windowEnd]);
 
   // Visx timeline needs country rows — derive from filtered set
   const sortedActiveCountries = useMemo(
@@ -183,8 +180,8 @@ export default function ExplorePage() {
                 selectedCategories={selectedCategories}
                 onCategoriesChange={setSelectedCategories}
                 availableCountries={availableCountries}
-                selectedCountry={selectedCountry}
-                onCountryChange={setSelectedCountry}
+                selectedCountries={selectedCountries}
+                onCountriesChange={setSelectedCountries}
               />
               {!isMobile && <ExploreViewToggle view={view} onChange={setView} />}
             </Box>

--- a/src/app/explorer-x/page.js
+++ b/src/app/explorer-x/page.js
@@ -251,7 +251,7 @@ export default function ExplorerXPage() {
                 <TableCell sx={{ fontSize: '0.7rem', fontWeight: 700 }}>Category</TableCell>
                 <TableCell sx={{ fontSize: '0.7rem', fontWeight: 700 }}>TW</TableCell>
                 <TableCell sx={{ fontSize: '0.7rem', fontWeight: 700 }}>Start</TableCell>
-                <TableCell sx={{ fontSize: '0.7rem', fontWeight: 700 }}>End</TableCell>
+                <TableCell sx={{ fontSize: '0.7rem', fontWeight: 700 }}>Dur</TableCell>
                 <TableCell sx={{ fontSize: '0.7rem', fontWeight: 700 }}>Venue city (raw)</TableCell>
                 <TableCell sx={{ fontSize: '0.7rem', fontWeight: 700 }}>masteredCity</TableCell>
                 <TableCell sx={{ fontSize: '0.7rem', fontWeight: 700 }}>Venue ctry (raw)</TableCell>
@@ -285,7 +285,11 @@ export default function ExplorerXPage() {
                       {e.startDate ? dayjs(e.startDate).format('YYYY-MM-DD') : ''}
                     </TableCell>
                     <TableCell sx={{ fontSize: '0.7rem', whiteSpace: 'nowrap' }}>
-                      {e.endDate ? dayjs(e.endDate).format('YYYY-MM-DD') : ''}
+                      {(() => {
+                        if (!e.startDate || !e.endDate) return '';
+                        const days = Math.max(1, Math.ceil(dayjs(e.endDate).diff(dayjs(e.startDate), 'day', true)));
+                        return `${days}d`;
+                      })()}
                     </TableCell>
                     <TableCell sx={{ fontSize: '0.7rem', color: '#64748b' }}>
                       {e.venueCityName || ''}

--- a/src/app/explorer-x/page.js
+++ b/src/app/explorer-x/page.js
@@ -1,0 +1,268 @@
+'use client';
+
+// TIEMPO-419: Explorer-X — TEST-only research tool for inspecting the
+// international event corpus. NOT to be promoted to PROD.
+//
+// Hostname gate is the belt-and-suspenders: even if the commit slips
+// into a PROD bundle, the route renders null for any non-test host.
+// Access: type /explorer-x into test.tangotiempo.com or localhost.
+//
+// Filters surface the raw + mastered fields side-by-side so the
+// operator (Toby) can spot corpus-gap venues (null masteredCountryName)
+// and see where discovery-lane metadata is sparse.
+
+import React, { useEffect, useMemo, useState } from 'react';
+import axios from 'axios';
+import {
+  Box, Container, Typography, CircularProgress, Alert,
+  Paper, Table, TableHead, TableBody, TableRow, TableCell,
+  TextField, Checkbox, FormControlLabel, Chip, Stack,
+  Select, MenuItem, InputLabel, FormControl, Button,
+} from '@mui/material';
+import dayjs from 'dayjs';
+import { getApiBaseUrl } from '@/utils/apiUrlResolver';
+
+const NULL_TOKEN = '__NULL__'; // sentinel for "no country" / "no city"
+
+function useHostnameGate() {
+  const [allowed, setAllowed] = useState(null); // null = deciding, true/false = decided
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const host = window.location.hostname;
+    const isTest = host.startsWith('test.') || host === 'localhost' || host === '127.0.0.1';
+    setAllowed(isTest);
+  }, []);
+  return allowed;
+}
+
+function isUS(e) {
+  const m = e.masteredCountryName;
+  if (m === 'United States' || m === 'USA' || m === 'US') return true;
+  return false;
+}
+
+export default function ExplorerXPage() {
+  const allowed = useHostnameGate();
+  const [events, setEvents] = useState(null);
+  const [error, setError] = useState(null);
+
+  // Filter state
+  const [countryPick, setCountryPick] = useState(''); // '' = all, NULL_TOKEN = null-only, else exact match
+  const [cityQuery, setCityQuery] = useState('');
+  const [onlyTravelWorthy, setOnlyTravelWorthy] = useState(false);
+  const [categoryPick, setCategoryPick] = useState(''); // '' = all
+
+  useEffect(() => {
+    if (allowed !== true) return;
+    const appId = process.env.NEXT_PUBLIC_APPLICATION_ID || '1';
+    axios
+      .get(`${getApiBaseUrl()}/api/events`, { params: { appId, limit: 1000 } })
+      .then((res) => {
+        const list = res.data?.events || (Array.isArray(res.data) ? res.data : []);
+        setEvents(list.filter((e) => !isUS(e)));
+      })
+      .catch((err) => setError(err.message || 'Failed to load events'));
+  }, [allowed]);
+
+  const availableCountries = useMemo(() => {
+    if (!events) return [];
+    const set = new Set();
+    for (const e of events) set.add(e.masteredCountryName || NULL_TOKEN);
+    return Array.from(set).sort();
+  }, [events]);
+
+  const availableCategories = useMemo(() => {
+    if (!events) return [];
+    return Array.from(new Set(events.map((e) => e.categoryFirst).filter(Boolean))).sort();
+  }, [events]);
+
+  const filtered = useMemo(() => {
+    if (!events) return [];
+    const cityNeedle = cityQuery.trim().toLowerCase();
+    return events.filter((e) => {
+      if (countryPick === NULL_TOKEN) {
+        if (e.masteredCountryName) return false;
+      } else if (countryPick) {
+        if (e.masteredCountryName !== countryPick) return false;
+      }
+      if (cityNeedle) {
+        const hit =
+          (e.masteredCityName || '').toLowerCase().includes(cityNeedle) ||
+          (e.venueCityName || '').toLowerCase().includes(cityNeedle) ||
+          (e.venueName || '').toLowerCase().includes(cityNeedle);
+        if (!hit) return false;
+      }
+      if (onlyTravelWorthy && !e.travelWorthy) return false;
+      if (categoryPick && e.categoryFirst !== categoryPick) return false;
+      return true;
+    });
+  }, [events, countryPick, cityQuery, onlyTravelWorthy, categoryPick]);
+
+  const clearFilters = () => {
+    setCountryPick('');
+    setCityQuery('');
+    setOnlyTravelWorthy(false);
+    setCategoryPick('');
+  };
+
+  if (allowed === null) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', mt: 10 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+  if (allowed === false) {
+    return null; // belt-and-suspenders: silent on PROD
+  }
+
+  return (
+    <Container maxWidth="xl" sx={{ py: 3 }}>
+      <Typography variant="h5" sx={{ fontWeight: 700, mb: 0.5 }}>
+        Explorer-X
+      </Typography>
+      <Typography variant="caption" color="textSecondary" sx={{ display: 'block', mb: 2 }}>
+        TEST-only research view · non-US events (appId=1) · {filtered.length} shown
+        {events && ` of ${events.length} total`}
+      </Typography>
+
+      <Paper elevation={0} sx={{ p: 2, mb: 2, border: '1px solid rgba(0,0,0,0.08)' }}>
+        <Stack direction="row" spacing={2} sx={{ flexWrap: 'wrap', gap: 1, alignItems: 'center' }}>
+          <FormControl size="small" sx={{ minWidth: 180 }}>
+            <InputLabel>Country</InputLabel>
+            <Select
+              value={countryPick}
+              label="Country"
+              onChange={(e) => setCountryPick(e.target.value)}
+            >
+              <MenuItem value="">(all)</MenuItem>
+              {availableCountries.map((c) => (
+                <MenuItem key={c} value={c}>
+                  {c === NULL_TOKEN ? '(null — unmastered)' : c}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <TextField
+            size="small"
+            label="City search"
+            value={cityQuery}
+            onChange={(e) => setCityQuery(e.target.value)}
+            sx={{ minWidth: 180 }}
+            helperText="matches masteredCity, venueCity, venueName"
+          />
+
+          <FormControl size="small" sx={{ minWidth: 160 }}>
+            <InputLabel>Category</InputLabel>
+            <Select
+              value={categoryPick}
+              label="Category"
+              onChange={(e) => setCategoryPick(e.target.value)}
+            >
+              <MenuItem value="">(all)</MenuItem>
+              {availableCategories.map((c) => (
+                <MenuItem key={c} value={c}>{c}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={onlyTravelWorthy}
+                onChange={(e) => setOnlyTravelWorthy(e.target.checked)}
+                size="small"
+              />
+            }
+            label="travelWorthy only"
+          />
+
+          <Button size="small" onClick={clearFilters}>Clear</Button>
+        </Stack>
+      </Paper>
+
+      {error && <Alert severity="error">{error}</Alert>}
+      {events === null && !error && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
+          <CircularProgress />
+        </Box>
+      )}
+
+      {events && (
+        <Paper elevation={0} sx={{ border: '1px solid rgba(0,0,0,0.08)', overflow: 'auto' }}>
+          <Table size="small" stickyHeader>
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ fontSize: '0.7rem', fontWeight: 700 }}>Title</TableCell>
+                <TableCell sx={{ fontSize: '0.7rem', fontWeight: 700 }}>Category</TableCell>
+                <TableCell sx={{ fontSize: '0.7rem', fontWeight: 700 }}>TW</TableCell>
+                <TableCell sx={{ fontSize: '0.7rem', fontWeight: 700 }}>Start</TableCell>
+                <TableCell sx={{ fontSize: '0.7rem', fontWeight: 700 }}>End</TableCell>
+                <TableCell sx={{ fontSize: '0.7rem', fontWeight: 700 }}>Venue city (raw)</TableCell>
+                <TableCell sx={{ fontSize: '0.7rem', fontWeight: 700 }}>masteredCity</TableCell>
+                <TableCell sx={{ fontSize: '0.7rem', fontWeight: 700 }}>Venue ctry (raw)</TableCell>
+                <TableCell sx={{ fontSize: '0.7rem', fontWeight: 700 }}>masteredCountry</TableCell>
+                <TableCell sx={{ fontSize: '0.7rem', fontWeight: 700 }}>masteringStatus</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {filtered.map((e) => {
+                const nullCountry = !e.masteredCountryName;
+                return (
+                  <TableRow key={e._id} hover sx={nullCountry ? { bgcolor: 'rgba(234, 88, 12, 0.06)' } : undefined}>
+                    <TableCell sx={{ fontSize: '0.72rem', maxWidth: 260, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {e.title}
+                    </TableCell>
+                    <TableCell sx={{ fontSize: '0.7rem' }}>
+                      {e.categoryFirst && (
+                        <Chip
+                          label={e.categoryFirst}
+                          size="small"
+                          sx={{ height: 16, fontSize: '0.62rem', bgcolor: 'rgba(0,0,0,0.06)' }}
+                        />
+                      )}
+                    </TableCell>
+                    <TableCell sx={{ fontSize: '0.7rem' }}>
+                      {e.travelWorthy ? (
+                        <Chip label="TW" size="small" sx={{ height: 16, fontSize: '0.6rem', bgcolor: 'rgba(34,197,94,0.18)', color: '#15803d', fontWeight: 700 }} />
+                      ) : null}
+                    </TableCell>
+                    <TableCell sx={{ fontSize: '0.7rem', whiteSpace: 'nowrap' }}>
+                      {e.startDate ? dayjs(e.startDate).format('YYYY-MM-DD') : ''}
+                    </TableCell>
+                    <TableCell sx={{ fontSize: '0.7rem', whiteSpace: 'nowrap' }}>
+                      {e.endDate ? dayjs(e.endDate).format('YYYY-MM-DD') : ''}
+                    </TableCell>
+                    <TableCell sx={{ fontSize: '0.7rem', color: '#64748b' }}>
+                      {e.venueCityName || ''}
+                    </TableCell>
+                    <TableCell sx={{ fontSize: '0.7rem', fontWeight: e.masteredCityName ? 500 : 400, color: e.masteredCityName ? 'text.primary' : '#94a3b8', fontStyle: e.masteredCityName ? 'normal' : 'italic' }}>
+                      {e.masteredCityName || '(null)'}
+                    </TableCell>
+                    <TableCell sx={{ fontSize: '0.7rem', color: '#64748b' }}>
+                      {e.venueCountry || ''}
+                    </TableCell>
+                    <TableCell sx={{ fontSize: '0.7rem', fontWeight: e.masteredCountryName ? 500 : 400, color: e.masteredCountryName ? 'text.primary' : '#dc2626', fontStyle: e.masteredCountryName ? 'normal' : 'italic' }}>
+                      {e.masteredCountryName || '(null)'}
+                    </TableCell>
+                    <TableCell sx={{ fontSize: '0.7rem', color: '#64748b' }}>
+                      {e.masteringStatus || ''}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+              {filtered.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={10} sx={{ textAlign: 'center', py: 3, color: 'text.secondary' }}>
+                    No events match current filters.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </Paper>
+      )}
+    </Container>
+  );
+}

--- a/src/app/explorer-x/page.js
+++ b/src/app/explorer-x/page.js
@@ -24,6 +24,13 @@ import { getApiBaseUrl } from '@/utils/apiUrlResolver';
 
 const NULL_TOKEN = '__NULL__'; // sentinel for "no country" / "no city"
 
+// TIEMPO-419 iteration: local-recurring categories are NEVER travelWorthy
+// candidates — exclude them at the pull to reduce noise while Toby hunts
+// for events that SHOULD be flagged TW but aren't.
+const LOCAL_CATEGORY_EXCLUDE = new Set(['Class', 'Practica', 'Milonga']);
+const PAGE_LIMIT = 1000;     // request size (BE currently silent-caps at 500)
+const MAX_PAGES = 20;        // safety valve — 20 pages × 1000 = 20k events
+
 function useHostnameGate() {
   const [allowed, setAllowed] = useState(null); // null = deciding, true/false = decided
   useEffect(() => {
@@ -45,6 +52,7 @@ export default function ExplorerXPage() {
   const allowed = useHostnameGate();
   const [events, setEvents] = useState(null);
   const [error, setError] = useState(null);
+  const [loadProgress, setLoadProgress] = useState({ pagesLoaded: 0, totalPages: 0, totalEvents: 0 });
 
   // Filter state
   const [countryPick, setCountryPick] = useState(''); // '' = all, NULL_TOKEN = null-only, else exact match
@@ -55,13 +63,51 @@ export default function ExplorerXPage() {
   useEffect(() => {
     if (allowed !== true) return;
     const appId = process.env.NEXT_PUBLIC_APPLICATION_ID || '1';
-    axios
-      .get(`${getApiBaseUrl()}/api/events`, { params: { appId, limit: 1000 } })
-      .then((res) => {
-        const list = res.data?.events || (Array.isArray(res.data) ? res.data : []);
-        setEvents(list.filter((e) => !isUS(e)));
-      })
-      .catch((err) => setError(err.message || 'Failed to load events'));
+    const baseUrl = `${getApiBaseUrl()}/api/events`;
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const accumulated = [];
+        let page = 1;
+        let totalPages = 1;
+        let totalEvents = 0;
+
+        while (page <= totalPages && page <= MAX_PAGES) {
+          const res = await axios.get(baseUrl, {
+            params: { appId, limit: PAGE_LIMIT, page },
+          });
+          if (cancelled) return;
+
+          const list = res.data?.events || (Array.isArray(res.data) ? res.data : []);
+          const pagination = res.data?.pagination || {};
+          totalPages = pagination.pages || 1;
+          totalEvents = pagination.total || accumulated.length + list.length;
+
+          accumulated.push(...list);
+          setLoadProgress({ pagesLoaded: page, totalPages, totalEvents });
+
+          if (list.length === 0) break;
+          page += 1;
+        }
+
+        if (cancelled) return;
+
+        // Filter pipeline:
+        // 1) exclude US events
+        // 2) exclude local-recurring categories (Class/Practica/Milonga)
+        //    — these are never TW candidates so remove noise
+        const filtered = accumulated.filter(
+          (e) => !isUS(e) && !LOCAL_CATEGORY_EXCLUDE.has(e.categoryFirst)
+        );
+        setEvents(filtered);
+      } catch (err) {
+        if (!cancelled) setError(err.message || 'Failed to load events');
+      }
+    })();
+
+    return () => { cancelled = true; };
   }, [allowed]);
 
   const availableCountries = useMemo(() => {
@@ -122,8 +168,15 @@ export default function ExplorerXPage() {
         Explorer-X
       </Typography>
       <Typography variant="caption" color="textSecondary" sx={{ display: 'block', mb: 2 }}>
-        TEST-only research view · non-US events (appId=1) · {filtered.length} shown
-        {events && ` of ${events.length} total`}
+        TEST-only research view · non-US events, Class/Practica/Milonga excluded (appId=1) ·{' '}
+        {filtered.length} shown
+        {events && ` of ${events.length} after filter`}
+        {loadProgress.totalPages > 1 && (
+          <>
+            {' '}· loaded {loadProgress.pagesLoaded}/{loadProgress.totalPages} pages
+            {' '}({loadProgress.totalEvents} total events in corpus)
+          </>
+        )}
       </Typography>
 
       <Paper elevation={0} sx={{ p: 2, mb: 2, border: '1px solid rgba(0,0,0,0.08)' }}>

--- a/src/app/hooks/useMode.js
+++ b/src/app/hooks/useMode.js
@@ -15,7 +15,7 @@ import { AuthContext } from '@/contexts/AuthContext';
 // Fix: pathname is authoritative. Cookie/userPref only influence navigation
 // DECISIONS in setMode (where to land on fresh arrival), not current state.
 
-const MODES = ['beginner', 'local', 'explore'];
+const MODES = ['local', 'organizer', 'explore', 'beginner'];
 const DEFAULT_MODE = 'local';
 const COOKIE_NAME = 'tt_mode';
 
@@ -33,6 +33,7 @@ export function useMode() {
     if (!pathname) return null;
     if (pathname.startsWith('/explore')) return 'explore';
     if (pathname.startsWith('/beginner')) return 'beginner';
+    if (pathname.startsWith('/organizer')) return 'organizer';
     if (pathname.startsWith('/calendar')) return 'local'; // includes /calendar/boston
     return null;
   }, [pathname]);
@@ -56,6 +57,10 @@ export function useMode() {
     }
     if (target === 'beginner') {
       router.push('/beginner');
+      return;
+    }
+    if (target === 'organizer') {
+      router.push('/organizer');
       return;
     }
     // Local: if already on Boston variant, stay there; otherwise use /calendar.

--- a/src/app/organizer/page.js
+++ b/src/app/organizer/page.js
@@ -1,0 +1,94 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Box, Container, Typography, CircularProgress, Alert } from '@mui/material';
+import dayjs from 'dayjs';
+import SiteMenuBar from '@/components/UI/SiteMenuBar';
+import OrganizerGroupedList from '@/components/Organizer/OrganizerGroupedList';
+import { getApiBaseUrl } from '@/utils/apiUrlResolver';
+import { useGeoLocation } from '@/contexts/GeoLocationContext';
+
+// TIEMPO-413: Organizer page — mapcenter-scoped, 90-day windowed GET.
+// Shows ALL local events grouped by organizer long name. Wider window
+// than Beginner/Local so less-frequent organizers still surface.
+
+const WINDOW_DAYS = 90;
+
+export default function OrganizerPage() {
+  const [events, setEvents] = useState(null);
+  const [error, setError] = useState(null);
+  const { currentLocation, isInitialized } = useGeoLocation();
+
+  const hasLocation = !!(currentLocation?.lat && currentLocation?.lng);
+
+  useEffect(() => {
+    if (!isInitialized) return;
+
+    const appId = process.env.NEXT_PUBLIC_APPLICATION_ID || '1';
+    const params = {
+      appId,
+      limit: 1000,
+      start: dayjs().startOf('day').toISOString(),
+      end: dayjs().add(WINDOW_DAYS, 'day').endOf('day').toISOString(),
+      includeAiGenerated: true,
+    };
+
+    if (hasLocation) {
+      params.useGeoSearch = true;
+      params.lat = currentLocation.lat;
+      params.lng = currentLocation.lng;
+      const radiusMi = currentLocation.zoomRange || 50;
+      params.radius = `${Math.round(radiusMi * 1.60934)}km`;
+      params.sortByDistance = true;
+    }
+
+    setEvents(null);
+    setError(null);
+    axios
+      .get(`${getApiBaseUrl()}/api/events`, { params })
+      .then((res) => {
+        const list = res.data?.events || (Array.isArray(res.data) ? res.data : []);
+        setEvents(list);
+      })
+      .catch((err) => setError(err.message || 'Failed to load events'));
+  }, [isInitialized, hasLocation, currentLocation?.lat, currentLocation?.lng, currentLocation?.zoomRange]);
+
+  const radiusLabel = hasLocation
+    ? `within ${currentLocation.zoomRange || 50} mi of ${currentLocation.cityName || 'your map center'}`
+    : 'near your selected location';
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <SiteMenuBar
+        activeCategories={[]}
+        handleCategoryChange={() => {}}
+        categories={[]}
+        searchTerm=""
+        onSearchChange={() => {}}
+        showDiscovered={false}
+        onDiscoveredToggle={() => {}}
+      />
+      <Container maxWidth="md" sx={{ mt: 3, mb: 6 }}>
+        <Typography variant="body2" color="textSecondary" paragraph sx={{ mt: 1 }}>
+          Organizers hosting events in the next {WINDOW_DAYS} days — {radiusLabel}. Tap a name to see their schedule.
+        </Typography>
+
+        {!isInitialized || events === null ? (
+          !error && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 6 }}>
+              <CircularProgress />
+            </Box>
+          )
+        ) : null}
+        {error && <Alert severity="error">Failed to load events: {error}</Alert>}
+        {events && events.length === 0 && (
+          <Alert severity="info">
+            No events found in the next {WINDOW_DAYS} days near this location. Try widening your map radius.
+          </Alert>
+        )}
+        {events && events.length > 0 && <OrganizerGroupedList events={events} />}
+      </Container>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- Mobile 3-option view toggle (List | Timeline | Map); list default on mobile, timeline on desktop
- Timeline lane overlap fix: greedy packing expands country rows so concurrent events never stack
- Continent/Region filter (Americas/Europe/Asia-Pacific/Other) replaces 40+ country dropdown
- Dynamic category filter derived from live events (was hardcoded 4 presets)
- MapCenter jump: Explore event click sets location before navigating to /calendar
- CityPill hidden on /explore; BrandMark 36→44px
- Card right chip shows continent/region; country name moved to subtitle

## Test plan
- [ ] Desktop: Timeline default, Map toggle, no card list option on desktop
- [ ] Mobile: List default, toggle to Timeline (touch pan) and Map
- [ ] Overlapping events in same country show on separate lanes (not stacked)
- [ ] Continent filter: Americas/Europe/Asia-Pacific/Other; filters correctly
- [ ] Category filter shows live values from event data
- [ ] Explore card click → calendar opens near venue location
- [ ] /explore header: no CityPill, larger TT logo
- [ ] Card chip shows continent label; subtitle shows "date · city · country"

🤖 Generated with [Claude Code](https://claude.com/claude-code)