### PR TITLE
TIEMPO-425: list-view UTC anchor + organizer upcoming-events fix

### DIFF
--- a/src/app/calendar/boston/page.js
+++ b/src/app/calendar/boston/page.js
@@ -132,6 +132,14 @@ const BostonCalendarPage = () => {
   const getInitialView = () => {
     return typeof window !== 'undefined' && window.innerWidth >= 768 ? 'dayGrid8Week' : 'list21Days';
   };
+  // TIEMPO-425: Anchor initial view to LOCAL today, not UTC today.
+  // FullCalendar runs timeZone="UTC", so after 8pm EDT (UTC midnight rollover)
+  // its default "today" is tomorrow Boston-time and the list-21-day view
+  // starts beyond tonight's events.
+  const getInitialDate = () => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  };
   const [currentViewType, setCurrentViewType] = useState(getInitialView());
 
   // Force Boston location on mount
@@ -1162,6 +1170,7 @@ const BostonCalendarPage = () => {
             ref={calendarRef}
             plugins={[dayGridPlugin, listPlugin, interactionPlugin, rrulePlugin]}
             initialView={currentViewType}
+            initialDate={getInitialDate()}
             events={coloredFilteredEvents}
             eventClick={handleEventClick}
             // Sort isDiscovered events after regular events, then by start time, then title

--- a/src/app/calendar/page.js
+++ b/src/app/calendar/page.js
@@ -122,6 +122,15 @@ const CalendarPage = () => {
     return window.innerWidth >= 768 ? 'dayGrid8Week' : 'list21Days';
   };
 
+  // TIEMPO-425: Anchor initial view to LOCAL today, not UTC today.
+  // FullCalendar runs timeZone="UTC", so after 8pm EDT (UTC midnight rollover)
+  // its default "today" is tomorrow local-time and the list-21-day view
+  // starts beyond tonight's events.
+  const getInitialDate = () => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  };
+
   // TIEMPO-246: Generate placeholder events without Date() conversions
   const generatePlaceholderEvents = (startDate, endDate) => {
     const placeholders = [];
@@ -1366,6 +1375,7 @@ const CalendarPage = () => {
           timeZone="UTC"
           //        initialView="dayGridMonth"
           initialView={getInitialView()}
+          initialDate={getInitialDate()}
           events={eventsWithPlaceholders}
           // Sort isDiscovered events after regular events, then by start time, then title
           eventOrder={(a, b) => {

--- a/src/app/components/Modals/ViewEvents/ViewEventDetailsOrganizer.js
+++ b/src/app/components/Modals/ViewEvents/ViewEventDetailsOrganizer.js
@@ -26,6 +26,7 @@ import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import EventIcon from '@mui/icons-material/Event';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import { useOrganizers } from '@/hooks/useOrganizers';
+import { expandToNextInstance } from '@/utils/nextInstance';
 import axios from 'axios';
 import { getApiBaseUrl } from '@/utils/apiUrlResolver';
 
@@ -75,8 +76,15 @@ const ViewEventDetailsOrganizer = ({ eventDetails }) => {
       });
       
       if (response.data && response.data.events) {
-// TIEMPO-276: Security cleanup - removed logging
-        setUpcomingEvents(response.data.events);
+        // Recurring masters come back with a historical base startDate regardless
+        // of the start filter. Expand each to its next real occurrence so the
+        // "Upcoming Events" list actually shows upcoming dates.
+        const fromMs = now.getTime();
+        const toMs = endDate.getTime();
+        const expanded = response.data.events
+          .map((e) => expandToNextInstance(e, fromMs, toMs))
+          .filter(Boolean);
+        setUpcomingEvents(expanded);
       }
     } catch (err) {
       console.error('Error fetching upcoming events:', err);


### PR DESCRIPTION
## Summary
- **Calendar list view (TIEMPO-425):** anchor `<FullCalendar />` to local-today via `initialDate` on both `/calendar` and `/calendar/boston`. Without this, after 8pm EDT the UTC midnight rollover puts FullCalendar's "today" on tomorrow Boston-time, list-21-day view starts past the prev-UTC-day bucket where tonight's events live (due to `nextDayThreshold`), and they vanish from view.
- **Organizer upcoming list (folded):** `ViewEventDetailsOrganizer` now expands recurring masters to next occurrence via `expandToNextInstance(now, +12mo)`. Previously showed historical base startDate (often years old). Mirrors pattern already in `/explore`.

## Test plan
- [ ] After 8pm EDT, load `/calendar` on mobile → confirm tonight's events appear at top of list.
- [ ] After 8pm EDT, load `/calendar/boston` on mobile → same.
- [ ] Open organizer modal for a recurring weekly milonga organizer → confirm "Upcoming Events" shows next real dates, not the master's historical base date.
- [ ] Desktop 8-week grid view still shows current month (cosmetic; not affected by bug).
- [ ] Backend (Fulton's Events_Get) untouched — verify no API changes needed.

## Known limitations
- Partial fix: clicking the "Today" button still calls `api.today()` which reverts to UTC-today. Out of scope for this ticket; track separately if needed.
- Pre-existing `MapIcon` lint error in `calendar/page.js` unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)