### PR TITLE
TIEMPO-426: /explore window-scoped fetch + map+month filter; /explorer-x window scope

### DIFF
--- a/src/app/calendar/boston/page.js
+++ b/src/app/calendar/boston/page.js
@@ -132,6 +132,14 @@ const BostonCalendarPage = () => {
   const getInitialView = () => {
     return typeof window !== 'undefined' && window.innerWidth >= 768 ? 'dayGrid8Week' : 'list21Days';
   };
+  // TIEMPO-425: Anchor initial view to LOCAL today, not UTC today.
+  // FullCalendar runs timeZone="UTC", so after 8pm EDT (UTC midnight rollover)
+  // its default "today" is tomorrow Boston-time and the list-21-day view
+  // starts beyond tonight's events.
+  const getInitialDate = () => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  };
   const [currentViewType, setCurrentViewType] = useState(getInitialView());
 
   // Force Boston location on mount
@@ -1162,6 +1170,7 @@ const BostonCalendarPage = () => {
             ref={calendarRef}
             plugins={[dayGridPlugin, listPlugin, interactionPlugin, rrulePlugin]}
             initialView={currentViewType}
+            initialDate={getInitialDate()}
             events={coloredFilteredEvents}
             eventClick={handleEventClick}
             // Sort isDiscovered events after regular events, then by start time, then title

--- a/src/app/calendar/page.js
+++ b/src/app/calendar/page.js
@@ -122,6 +122,15 @@ const CalendarPage = () => {
     return window.innerWidth >= 768 ? 'dayGrid8Week' : 'list21Days';
   };
 
+  // TIEMPO-425: Anchor initial view to LOCAL today, not UTC today.
+  // FullCalendar runs timeZone="UTC", so after 8pm EDT (UTC midnight rollover)
+  // its default "today" is tomorrow local-time and the list-21-day view
+  // starts beyond tonight's events.
+  const getInitialDate = () => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  };
+
   // TIEMPO-246: Generate placeholder events without Date() conversions
   const generatePlaceholderEvents = (startDate, endDate) => {
     const placeholders = [];
@@ -1366,6 +1375,7 @@ const CalendarPage = () => {
           timeZone="UTC"
           //        initialView="dayGridMonth"
           initialView={getInitialView()}
+          initialDate={getInitialDate()}
           events={eventsWithPlaceholders}
           // Sort isDiscovered events after regular events, then by start time, then title
           eventOrder={(a, b) => {

--- a/src/app/components/Modals/ViewEvents/ViewEventDetailsOrganizer.js
+++ b/src/app/components/Modals/ViewEvents/ViewEventDetailsOrganizer.js
@@ -26,6 +26,7 @@ import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import EventIcon from '@mui/icons-material/Event';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import { useOrganizers } from '@/hooks/useOrganizers';
+import { expandToNextInstance } from '@/utils/nextInstance';
 import axios from 'axios';
 import { getApiBaseUrl } from '@/utils/apiUrlResolver';
 
@@ -75,8 +76,15 @@ const ViewEventDetailsOrganizer = ({ eventDetails }) => {
       });
       
       if (response.data && response.data.events) {
-// TIEMPO-276: Security cleanup - removed logging
-        setUpcomingEvents(response.data.events);
+        // Recurring masters come back with a historical base startDate regardless
+        // of the start filter. Expand each to its next real occurrence so the
+        // "Upcoming Events" list actually shows upcoming dates.
+        const fromMs = now.getTime();
+        const toMs = endDate.getTime();
+        const expanded = response.data.events
+          .map((e) => expandToNextInstance(e, fromMs, toMs))
+          .filter(Boolean);
+        setUpcomingEvents(expanded);
       }
     } catch (err) {
       console.error('Error fetching upcoming events:', err);

--- a/src/app/explore/page.js
+++ b/src/app/explore/page.js
@@ -66,12 +66,14 @@ export default function ExplorePage() {
     Cookies.set(COOKIE_VIEW, next, { expires: 365, sameSite: 'Lax' });
   }, []);
 
-  // When a month is chosen (from scrubber or timeline label) switch to timeline
-  // so the user sees the month-framed window immediately.
+  // TIEMPO-426: When a month is chosen, only auto-switch to timeline if the
+  // user is on a view that doesn't render time-axis filtering meaningfully
+  // (mobile-default or list). Map and timeline views both filter by
+  // selectedMonthKey, so don't yank the user away from map.
   const handleMonthChange = useCallback((mk) => {
     setSelectedMonthKey(mk);
-    if (mk) setView('timeline');
-  }, [setView]);
+    if (mk && view !== 'map' && view !== 'timeline') setView('timeline');
+  }, [setView, view]);
 
   const setSelectedCategories = useCallback((next) => {
     setSelectedCategoriesState(next);
@@ -81,19 +83,6 @@ export default function ExplorePage() {
   const setSelectedRegions = useCallback((next) => {
     setSelectedRegionsState(next);
     writeSetCookie(COOKIE_REGIONS, next);
-  }, []);
-
-  useEffect(() => {
-    const appId = process.env.NEXT_PUBLIC_APPLICATION_ID || '1';
-    axios
-      .get(`${getApiBaseUrl()}/api/events`, {
-        params: { travelWorthy: true, appId, limit: 500 },
-      })
-      .then((res) => {
-        const list = res.data?.events || (Array.isArray(res.data) ? res.data : []);
-        setEvents(list);
-      })
-      .catch((err) => setError(err.message || 'Failed to load events'));
   }, []);
 
   const availableRegions = useMemo(() => {
@@ -120,6 +109,28 @@ export default function ExplorePage() {
     const we = ws.add(12, 'month').endOf('day');
     return { windowStart: ws, windowEnd: we };
   }, [offsetMonths]);
+
+  // TIEMPO-426: Fetch only the visible 12-month window instead of all
+  // travel-worthy events forever. Refetch when the window changes
+  // (user pages with <</>>). Also bump limit to 1000 (was 500) — the
+  // curated TW set crossed 500 and we were silently truncating.
+  useEffect(() => {
+    const appId = process.env.NEXT_PUBLIC_APPLICATION_ID || '1';
+    const start = windowStart.format('YYYY-MM-DD');
+    const end = windowEnd.format('YYYY-MM-DD');
+    let cancelled = false;
+    axios
+      .get(`${getApiBaseUrl()}/api/events`, {
+        params: { travelWorthy: true, appId, start, end, limit: 1000 },
+      })
+      .then((res) => {
+        if (cancelled) return;
+        const list = res.data?.events || (Array.isArray(res.data) ? res.data : []);
+        setEvents(list);
+      })
+      .catch((err) => { if (!cancelled) setError(err.message || 'Failed to load events'); });
+    return () => { cancelled = true; };
+  }, [windowStart, windowEnd]);
 
   const filteredEvents = useMemo(() => {
     if (!events) return [];

--- a/src/app/explorer-x/page.js
+++ b/src/app/explorer-x/page.js
@@ -67,6 +67,13 @@ export default function ExplorerXPage() {
 
     let cancelled = false;
 
+    // TIEMPO-426: Scope to next 18 months. Without a date window the page
+    // pulls the entire corpus on every mount (10k+ events as the BE grows),
+    // most of which are far-past or far-future events the operator isn't
+    // triaging right now. 18 months covers all realistic festival lookahead.
+    const start = dayjs().startOf('day').format('YYYY-MM-DD');
+    const end = dayjs().add(18, 'month').endOf('day').format('YYYY-MM-DD');
+
     (async () => {
       try {
         const accumulated = [];
@@ -76,7 +83,7 @@ export default function ExplorerXPage() {
 
         while (page <= totalPages && page <= MAX_PAGES) {
           const res = await axios.get(baseUrl, {
-            params: { appId, limit: PAGE_LIMIT, page },
+            params: { appId, limit: PAGE_LIMIT, page, start, end },
           });
           if (cancelled) return;
 


### PR DESCRIPTION
## Summary
- **`/explore` data load:** fetch now scoped to the visible 12-month window via `start`/`end` params, refetches on `<<`/`>>`. Limit bumped 500 → 1000 (was hitting `EVENT LIMIT HIT: Returned 500/516`).
- **`/explore` map+month UX:** `handleMonthChange` no longer force-switches to timeline when user is on map or timeline. Map+month filter now works together.
- **`/explorer-x` data load:** scoped to next 18 months. Was eagerly paginating the entire corpus on every mount (10k+ growing).

## Stacked on
PR #273 (TIEMPO-425). Once #273 merges, this PR will show only its own commit.

## travelWorthy classifier note (Fulton / CALBEAF)
Rule at `calendar-be-af/src/utils/eventClassification.js:70-80`: `duration>24h AND categoryFirst NOT IN [Class, Milonga, Practica]`. Likely false-positive surface — recurring masters with non-local `categoryFirst` (Workshop, Festival, Encuentro) where `endDate` spans weeks of master recurrence get flagged TW. Plausibly contributing to the 500+ count creep. Recommend separate CALBEAF ticket: exclude recurring masters from TW computation, or use first-occurrence duration instead of master span.

## Test plan
- [ ] `/explore` loads without `EVENT LIMIT HIT` console error.
- [ ] On mobile or desktop map view, click a month pill → map stays on map, just filters.
- [ ] Click `<<` / `>>` → events refetch for new window.
- [ ] `/explorer-x` (test.tangotiempo.com only) loads faster, shows 18-month corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)