### PR TITLE
TIEMPO-427: hide SEMINAR/UNKNOWN/Trip noise categories from /explore

### DIFF
--- a/src/app/calendar/boston/page.js
+++ b/src/app/calendar/boston/page.js
@@ -132,6 +132,14 @@ const BostonCalendarPage = () => {
   const getInitialView = () => {
     return typeof window !== 'undefined' && window.innerWidth >= 768 ? 'dayGrid8Week' : 'list21Days';
   };
+  // TIEMPO-425: Anchor initial view to LOCAL today, not UTC today.
+  // FullCalendar runs timeZone="UTC", so after 8pm EDT (UTC midnight rollover)
+  // its default "today" is tomorrow Boston-time and the list-21-day view
+  // starts beyond tonight's events.
+  const getInitialDate = () => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  };
   const [currentViewType, setCurrentViewType] = useState(getInitialView());
 
   // Force Boston location on mount
@@ -1162,6 +1170,7 @@ const BostonCalendarPage = () => {
             ref={calendarRef}
             plugins={[dayGridPlugin, listPlugin, interactionPlugin, rrulePlugin]}
             initialView={currentViewType}
+            initialDate={getInitialDate()}
             events={coloredFilteredEvents}
             eventClick={handleEventClick}
             // Sort isDiscovered events after regular events, then by start time, then title

--- a/src/app/calendar/page.js
+++ b/src/app/calendar/page.js
@@ -122,6 +122,15 @@ const CalendarPage = () => {
     return window.innerWidth >= 768 ? 'dayGrid8Week' : 'list21Days';
   };
 
+  // TIEMPO-425: Anchor initial view to LOCAL today, not UTC today.
+  // FullCalendar runs timeZone="UTC", so after 8pm EDT (UTC midnight rollover)
+  // its default "today" is tomorrow local-time and the list-21-day view
+  // starts beyond tonight's events.
+  const getInitialDate = () => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  };
+
   // TIEMPO-246: Generate placeholder events without Date() conversions
   const generatePlaceholderEvents = (startDate, endDate) => {
     const placeholders = [];
@@ -1366,6 +1375,7 @@ const CalendarPage = () => {
           timeZone="UTC"
           //        initialView="dayGridMonth"
           initialView={getInitialView()}
+          initialDate={getInitialDate()}
           events={eventsWithPlaceholders}
           // Sort isDiscovered events after regular events, then by start time, then title
           eventOrder={(a, b) => {

--- a/src/app/components/Explore/exploreConstants.js
+++ b/src/app/components/Explore/exploreConstants.js
@@ -18,6 +18,12 @@ export const CATEGORY_COLORS = {
 export const categoryLabel = (c) => (c && c !== 'unknown' ? c : 'Other');
 export const colorFor = (c) => CATEGORY_COLORS[categoryLabel(c)] || CATEGORY_COLORS.Other;
 
+// TIEMPO-427: Whitelist of categoryFirst values we display in /explore.
+// Events whose categoryLabel resolves outside this set (e.g. SEMINAR,
+// UNKNOWN, Trip) are noise — no load rules exist yet for those types.
+// Filtering at the data source also clears the filter dropdown.
+export const VALID_EXPLORE_CATEGORIES = new Set(Object.keys(CATEGORY_COLORS));
+
 export const REGIONS = {
   Americas: [
     'United States', 'Canada', 'Argentina', 'Brazil', 'Mexico',

--- a/src/app/components/Modals/ViewEvents/ViewEventDetailsOrganizer.js
+++ b/src/app/components/Modals/ViewEvents/ViewEventDetailsOrganizer.js
@@ -26,6 +26,7 @@ import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import EventIcon from '@mui/icons-material/Event';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import { useOrganizers } from '@/hooks/useOrganizers';
+import { expandToNextInstance } from '@/utils/nextInstance';
 import axios from 'axios';
 import { getApiBaseUrl } from '@/utils/apiUrlResolver';
 
@@ -75,8 +76,15 @@ const ViewEventDetailsOrganizer = ({ eventDetails }) => {
       });
       
       if (response.data && response.data.events) {
-// TIEMPO-276: Security cleanup - removed logging
-        setUpcomingEvents(response.data.events);
+        // Recurring masters come back with a historical base startDate regardless
+        // of the start filter. Expand each to its next real occurrence so the
+        // "Upcoming Events" list actually shows upcoming dates.
+        const fromMs = now.getTime();
+        const toMs = endDate.getTime();
+        const expanded = response.data.events
+          .map((e) => expandToNextInstance(e, fromMs, toMs))
+          .filter(Boolean);
+        setUpcomingEvents(expanded);
       }
     } catch (err) {
       console.error('Error fetching upcoming events:', err);

--- a/src/app/explore/page.js
+++ b/src/app/explore/page.js
@@ -13,7 +13,7 @@ import ExploreViewToggle from '@/components/Explore/ExploreViewToggle';
 import ExploreMonthScrubber from '@/components/Explore/ExploreMonthScrubber';
 import ExploreMap from '@/components/Explore/ExploreMap';
 import DensityBar from '@/components/Explore/DensityBar';
-import { categoryLabel, regionFor } from '@/components/Explore/exploreConstants';
+import { categoryLabel, regionFor, VALID_EXPLORE_CATEGORIES } from '@/components/Explore/exploreConstants';
 import { expandToNextInstance } from '@/utils/nextInstance';
 import { getApiBaseUrl } from '@/utils/apiUrlResolver';
 import dayjs from 'dayjs';
@@ -126,7 +126,11 @@ export default function ExplorePage() {
       .then((res) => {
         if (cancelled) return;
         const list = res.data?.events || (Array.isArray(res.data) ? res.data : []);
-        setEvents(list);
+        // TIEMPO-427: Drop events whose categoryFirst falls outside the
+        // explore whitelist (SEMINAR / UNKNOWN / Trip etc.) — no load
+        // rules for those types yet, so they're noise here.
+        const cleaned = list.filter((e) => VALID_EXPLORE_CATEGORIES.has(categoryLabel(e.categoryFirst)));
+        setEvents(cleaned);
       })
       .catch((err) => { if (!cancelled) setError(err.message || 'Failed to load events'); });
     return () => { cancelled = true; };

--- a/src/app/explore/page.js
+++ b/src/app/explore/page.js
@@ -66,12 +66,14 @@ export default function ExplorePage() {
     Cookies.set(COOKIE_VIEW, next, { expires: 365, sameSite: 'Lax' });
   }, []);
 
-  // When a month is chosen (from scrubber or timeline label) switch to timeline
-  // so the user sees the month-framed window immediately.
+  // TIEMPO-426: When a month is chosen, only auto-switch to timeline if the
+  // user is on a view that doesn't render time-axis filtering meaningfully
+  // (mobile-default or list). Map and timeline views both filter by
+  // selectedMonthKey, so don't yank the user away from map.
   const handleMonthChange = useCallback((mk) => {
     setSelectedMonthKey(mk);
-    if (mk) setView('timeline');
-  }, [setView]);
+    if (mk && view !== 'map' && view !== 'timeline') setView('timeline');
+  }, [setView, view]);
 
   const setSelectedCategories = useCallback((next) => {
     setSelectedCategoriesState(next);
@@ -81,19 +83,6 @@ export default function ExplorePage() {
   const setSelectedRegions = useCallback((next) => {
     setSelectedRegionsState(next);
     writeSetCookie(COOKIE_REGIONS, next);
-  }, []);
-
-  useEffect(() => {
-    const appId = process.env.NEXT_PUBLIC_APPLICATION_ID || '1';
-    axios
-      .get(`${getApiBaseUrl()}/api/events`, {
-        params: { travelWorthy: true, appId, limit: 500 },
-      })
-      .then((res) => {
-        const list = res.data?.events || (Array.isArray(res.data) ? res.data : []);
-        setEvents(list);
-      })
-      .catch((err) => setError(err.message || 'Failed to load events'));
   }, []);
 
   const availableRegions = useMemo(() => {
@@ -120,6 +109,28 @@ export default function ExplorePage() {
     const we = ws.add(12, 'month').endOf('day');
     return { windowStart: ws, windowEnd: we };
   }, [offsetMonths]);
+
+  // TIEMPO-426: Fetch only the visible 12-month window instead of all
+  // travel-worthy events forever. Refetch when the window changes
+  // (user pages with <</>>). Also bump limit to 1000 (was 500) — the
+  // curated TW set crossed 500 and we were silently truncating.
+  useEffect(() => {
+    const appId = process.env.NEXT_PUBLIC_APPLICATION_ID || '1';
+    const start = windowStart.format('YYYY-MM-DD');
+    const end = windowEnd.format('YYYY-MM-DD');
+    let cancelled = false;
+    axios
+      .get(`${getApiBaseUrl()}/api/events`, {
+        params: { travelWorthy: true, appId, start, end, limit: 1000 },
+      })
+      .then((res) => {
+        if (cancelled) return;
+        const list = res.data?.events || (Array.isArray(res.data) ? res.data : []);
+        setEvents(list);
+      })
+      .catch((err) => { if (!cancelled) setError(err.message || 'Failed to load events'); });
+    return () => { cancelled = true; };
+  }, [windowStart, windowEnd]);
 
   const filteredEvents = useMemo(() => {
     if (!events) return [];

--- a/src/app/explorer-x/page.js
+++ b/src/app/explorer-x/page.js
@@ -67,6 +67,13 @@ export default function ExplorerXPage() {
 
     let cancelled = false;
 
+    // TIEMPO-426: Scope to next 18 months. Without a date window the page
+    // pulls the entire corpus on every mount (10k+ events as the BE grows),
+    // most of which are far-past or far-future events the operator isn't
+    // triaging right now. 18 months covers all realistic festival lookahead.
+    const start = dayjs().startOf('day').format('YYYY-MM-DD');
+    const end = dayjs().add(18, 'month').endOf('day').format('YYYY-MM-DD');
+
     (async () => {
       try {
         const accumulated = [];
@@ -76,7 +83,7 @@ export default function ExplorerXPage() {
 
         while (page <= totalPages && page <= MAX_PAGES) {
           const res = await axios.get(baseUrl, {
-            params: { appId, limit: PAGE_LIMIT, page },
+            params: { appId, limit: PAGE_LIMIT, page, start, end },
           });
           if (cancelled) return;
 


### PR DESCRIPTION
## Summary
Whitelist `categoryFirst` against `CATEGORY_COLORS` keys (Festival, Marathon, Encuentro, Workshop, Other). Events whose `categoryLabel` resolves outside that set get dropped post-fetch on `/explore`. Filter dropdown auto-clears since it's derived from the events array.

## Stacked on
PRs #273 (TIEMPO-425) and #274 (TIEMPO-426). Once those merge, this PR collapses to its single commit relative to TEST.

## Out of scope (follow-ups noted in commit / JIRA)
- Re-icon the Categories filter (currently uses tag icon, misleading)
- Future separate Tags filter for non-category attributes (LGBT, Free, etc.)
- Wire search box into list/timeline/map filtering on `/explore` and `/calendar` (incl. Boston / beginner route)

## Test plan
- [ ] Open /explore → Category dropdown shows only Festival/Marathon/Encuentro/Workshop/Other (no SEMINAR, UNKNOWN, Trip)
- [ ] Map and timeline don't render SEMINAR/UNKNOWN/Trip events
- [ ] Region filter and counts update consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)