### PR TITLE
TIEMPO-430: filter user roles by current appId (drop cross-app role leaks)

### DIFF
--- a/src/app/contexts/AuthContext.js
+++ b/src/app/contexts/AuthContext.js
@@ -28,6 +28,17 @@ import { getApiBaseUrl } from '@/utils/apiUrlResolver';
 // Create Auth Context
 export const AuthContext = createContext();
 
+// TIEMPO-430: A populated role document is "this app's role" if its appId
+// matches NEXT_PUBLIC_APPLICATION_ID. Roles without an appId (legacy /
+// global) are treated as belonging here so we don't accidentally strip
+// the AnonymousUser fallback or any pre-appId role docs.
+const roleMatchesCurrentApp = (role) => {
+  if (!role || typeof role !== 'object') return false;
+  if (role.appId == null) return true;
+  const currentAppId = process.env.NEXT_PUBLIC_APPLICATION_ID || '1';
+  return String(role.appId) === String(currentAppId);
+};
+
 // AuthProvider Component
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null); // Unified user state
@@ -165,18 +176,26 @@ export const AuthProvider = ({ children }) => {
             isApproved: backendInfo.regionalOrganizerInfo.isApproved
           });
         }
-      } else if (backendInfo.roleIds && backendInfo.roleIds.some(role => 
-        typeof role === 'object' && role.roleName === 'RegionalOrganizer'
+      } else if (backendInfo.roleIds && backendInfo.roleIds.some(role =>
+        typeof role === 'object' && role.roleName === 'RegionalOrganizer' && roleMatchesCurrentApp(role)
       )) {
         // TIEMPO-275: Keep console.warn for important warnings
         console.warn('User has RegionalOrganizer role but no organizerId in regionalOrganizerInfo!');
       }
 
+      // TIEMPO-430: Defensive filter — BE UserLogins.js populates roleIds
+      // by _id only without appId, so cross-app roles can leak in. Drop
+      // anything that isn't this app's role here. BE-side fix tracked
+      // separately as a CALBEAF follow-up.
+      const appRoleObjects = (backendInfo.roleIds || []).filter(
+        (role) => typeof role === 'object' && roleMatchesCurrentApp(role)
+      );
+
       // Merge Firebase and backend user data
       const mergedUser = {
         ...firebaseUser, // Spread Firebase user properties directly
         backendInfo,
-        roles: backendInfo.roleIds.map((role) => role.roleName) || [],
+        roles: appRoleObjects.map((role) => role.roleName),
         token: idToken, // Store the token for API calls
       };
 // TIEMPO-276: Security cleanup - removed logging


### PR DESCRIPTION
## Summary
Role selector was showing roles from other apps (HJ, NTTT, etc.). Root cause is BE-side: `calendar-be-af/src/functions/UserLogins.js:154-156` populates `user.roleIds` against the roles collection by `_id` only, no `appId` filter. Cross-app role refs leak through.

This PR adds a defensive FE filter in AuthContext: keep only role documents whose `appId` matches `NEXT_PUBLIC_APPLICATION_ID`. Roles with no `appId` (legacy/global) pass through to preserve the AnonymousUser fallback. Same filter applied to the RegionalOrganizer detection check.

## BE follow-up (Fulton / CALBEAF)
The BE populate query should also filter by `appId`. FTPNTD: data layer should not return cross-app roles regardless of FE behavior. I will message Fulton.

## Severity
Misleading UI only — BE permission checks still verify per-call. But user sees roles they cannot actually use.

## Test plan
- [ ] User with roles in TT-only sees only TT roles in dropdown (unchanged)
- [ ] User with roles in TT + HJ now only sees TT roles in TT
- [ ] AnonymousUser fallback path still works (role has no appId)
- [ ] Default role selection (NamedUser preferred, else first available) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)