### PR TITLE
TIEMPO-431: Spotlighter role enabled — role-switcher + spotlight-only modal

### DIFF
--- a/src/app/components/Modals/ViewEvents/SpotlightOnlyModal.js
+++ b/src/app/components/Modals/ViewEvents/SpotlightOnlyModal.js
@@ -1,0 +1,256 @@
+/**
+ * SpotlightOnlyModal.js
+ * TIEMPO-431: Stripped-down modal for the Spotlighter (SL) role to add/remove
+ * spotlights on any event without going through the full event-edit form.
+ *
+ * Each add/remove fires a direct PATCH /api/events/{eventId}/spotlights call.
+ * For v1 we only operate on master spotlights (recurring events affect ALL
+ * occurrences). Per-occurrence overrides via instanceKey are deferred to v2
+ * per TIEMPO-393 spec.
+ */
+
+'use client';
+
+import React, { useState, useContext } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Modal,
+  Box,
+  Typography,
+  TextField,
+  Button,
+  IconButton,
+  Chip,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Alert,
+  CircularProgress,
+  useTheme,
+  useMediaQuery,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import axios from 'axios';
+import { AuthContext } from '@/contexts/AuthContext';
+import { getApiBaseUrl } from '@/utils/apiUrlResolver';
+import ModalHeader from '@/components/UI/ModalHeader';
+
+const BASE_OPTIONS = [
+  { value: 'dj', label: 'DJ', maxLength: 19 },
+  { value: 'instructor', label: 'Instructor', maxLength: 19 },
+  { value: 'performer', label: 'Performer', maxLength: 19 },
+];
+
+const SINGLE_EVENT_OPTIONS = [
+  { value: 'orchestra', label: 'Orchestra', maxLength: 19 },
+  { value: 'note', label: 'Special Note', maxLength: 19 },
+];
+
+const getModalStyle = (isMobile) => ({
+  position: isMobile ? 'fixed' : 'absolute',
+  top: isMobile ? 0 : '50%',
+  left: isMobile ? 0 : '50%',
+  transform: isMobile ? 'none' : 'translate(-50%, -50%)',
+  width: isMobile ? '100vw' : '90%',
+  maxWidth: isMobile ? '100%' : '500px',
+  height: isMobile ? '100vh' : 'auto',
+  maxHeight: isMobile ? '100vh' : '85vh',
+  bgcolor: 'background.paper',
+  boxShadow: 24,
+  display: 'flex',
+  flexDirection: 'column',
+  overflow: 'hidden',
+  zIndex: 1400,
+});
+
+const SpotlightOnlyModal = ({ open, onClose, eventDetails, onSpotlightsChanged }) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const { getIdToken } = useContext(AuthContext);
+
+  const eventId = eventDetails?.extendedProps?._id;
+  const eventTitle = eventDetails?.extendedProps?.shortTitle || eventDetails?.title || 'Event';
+  const isRepeating = !!(eventDetails?.extendedProps?.isRecurring || eventDetails?.extendedProps?.recurrenceRule);
+
+  // Existing spotlights surfaced for visibility/removal. Read both fields
+  // (legacy `features` + canonical `spotlights`) to mirror BE behavior.
+  const initialSpotlights =
+    eventDetails?.extendedProps?.spotlights ||
+    eventDetails?.extendedProps?.features ||
+    [];
+
+  const [spotlights, setSpotlights] = useState(initialSpotlights);
+  const [newType, setNewType] = useState('');
+  const [newName, setNewName] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const SPOTLIGHT_OPTIONS = isRepeating ? BASE_OPTIONS : [...BASE_OPTIONS, ...SINGLE_EVENT_OPTIONS];
+  const selectedOption = SPOTLIGHT_OPTIONS.find((o) => o.value === newType);
+  const maxLength = selectedOption?.maxLength || 19;
+
+  const callSpotlightApi = async (action, spotlight) => {
+    const token = await getIdToken();
+    const url = `${getApiBaseUrl()}/api/events/${eventId}/spotlights`;
+    return axios.patch(
+      url,
+      { action, spotlight },
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+  };
+
+  const handleAdd = async () => {
+    setError(null);
+    if (!newType) {
+      setError('Pick a spotlight type.');
+      return;
+    }
+    const trimmed = newName.trim();
+    if (!trimmed) {
+      setError('Enter a name.');
+      return;
+    }
+    if (spotlights.some((s) => s.type === newType && s.name === trimmed)) {
+      setError('That spotlight is already added.');
+      return;
+    }
+    const name = trimmed.length > maxLength ? trimmed.substring(0, maxLength) : trimmed;
+    setSubmitting(true);
+    try {
+      await callSpotlightApi('add', { type: newType, name });
+      setSpotlights((prev) => [...prev, { type: newType, name }]);
+      setNewType('');
+      setNewName('');
+      if (onSpotlightsChanged) onSpotlightsChanged();
+    } catch (err) {
+      setError(err.response?.data?.error || err.message || 'Failed to add spotlight.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleRemove = async (s) => {
+    setError(null);
+    setSubmitting(true);
+    try {
+      await callSpotlightApi('remove', { type: s.type, name: s.name });
+      setSpotlights((prev) => prev.filter((x) => !(x.type === s.type && x.name === s.name)));
+      if (onSpotlightsChanged) onSpotlightsChanged();
+    } catch (err) {
+      setError(err.response?.data?.error || err.message || 'Failed to remove spotlight.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <Box sx={getModalStyle(isMobile)}>
+        <ModalHeader title={`Spotlights · ${eventTitle}`} onClose={onClose} />
+
+        <Box sx={{ flex: 1, overflow: 'auto', p: isMobile ? 2 : 3 }}>
+          {isRepeating && (
+            <Alert severity="info" sx={{ mb: 2 }}>
+              This is a recurring event. Spotlights you add here apply to all occurrences.
+            </Alert>
+          )}
+
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>
+            Current spotlights
+          </Typography>
+          {spotlights.length === 0 ? (
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              No spotlights yet.
+            </Typography>
+          ) : (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, mb: 2 }}>
+              {spotlights.map((s, i) => (
+                <Box
+                  key={`${s.type}-${s.name}-${i}`}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    p: 1,
+                    border: '1px solid',
+                    borderColor: 'divider',
+                    borderRadius: 1,
+                  }}
+                >
+                  <Chip label={s.type} size="small" />
+                  <Typography variant="body2" sx={{ flex: 1 }}>
+                    {s.name}
+                  </Typography>
+                  <IconButton
+                    size="small"
+                    onClick={() => handleRemove(s)}
+                    disabled={submitting}
+                    aria-label="remove"
+                  >
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </Box>
+              ))}
+            </Box>
+          )}
+
+          <Typography variant="subtitle2" sx={{ mt: 2, mb: 1 }}>
+            Add a spotlight
+          </Typography>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <FormControl size="small" fullWidth>
+              <InputLabel>Type</InputLabel>
+              <Select
+                value={newType}
+                label="Type"
+                onChange={(e) => setNewType(e.target.value)}
+                disabled={submitting}
+              >
+                {SPOTLIGHT_OPTIONS.map((o) => (
+                  <MenuItem key={o.value} value={o.value}>
+                    {o.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <TextField
+              size="small"
+              fullWidth
+              label="Name"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              inputProps={{ maxLength }}
+              helperText={`Max ${maxLength} chars`}
+              disabled={submitting}
+            />
+            <Button
+              variant="contained"
+              startIcon={submitting ? <CircularProgress size={16} /> : <AddIcon />}
+              onClick={handleAdd}
+              disabled={submitting || !newType || !newName.trim()}
+            >
+              Add Spotlight
+            </Button>
+          </Box>
+
+          {error && (
+            <Alert severity="error" sx={{ mt: 2 }}>
+              {error}
+            </Alert>
+          )}
+        </Box>
+      </Box>
+    </Modal>
+  );
+};
+
+SpotlightOnlyModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  eventDetails: PropTypes.object,
+  onSpotlightsChanged: PropTypes.func,
+};
+
+export default SpotlightOnlyModal;

--- a/src/app/components/Modals/ViewEvents/ViewEventDetailModal.js
+++ b/src/app/components/Modals/ViewEvents/ViewEventDetailModal.js
@@ -5,6 +5,7 @@ import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ShareIcon from '@mui/icons-material/Share';
+import StarIcon from '@mui/icons-material/Star';
 import CloseIcon from '@mui/icons-material/Close';
 import RepeatIcon from '@mui/icons-material/Repeat';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
@@ -22,6 +23,8 @@ import ViewEventDetailsVenue from './ViewEventDetailsVenue';
 import CancelOccurrenceDialog from './CancelOccurrenceDialog';
 import EditOccurrenceModal from './EditOccurrenceModal';
 import OccurrenceDatePicker from './OccurrenceDatePicker';
+// TIEMPO-431: Spotlight-only modal for Spotlighter (SL) role
+import SpotlightOnlyModal from './SpotlightOnlyModal';
 import { cancelOccurrence, createOverride, addExcludedDate } from '@/services/eventOverrides';
 import { uploadEventImage } from '@/utils/uploadEventImages';
 import PropTypes from 'prop-types';
@@ -65,6 +68,8 @@ const ViewEventDetailModal = ({ open, onClose, eventDetails, onEventUpdated, ini
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
   const [editOccurrenceOpen, setEditOccurrenceOpen] = useState(false);
   const [datePickerOpen, setDatePickerOpen] = useState(false);
+  // TIEMPO-431: Spotlight-only modal state for Spotlighter role
+  const [spotlightOnlyOpen, setSpotlightOnlyOpen] = useState(false);
   const [selectedOccurrenceDate, setSelectedOccurrenceDate] = useState(null);
   const [isOverrideLoading, setIsOverrideLoading] = useState(false);
   // Track if we've handled the initial action to prevent re-triggering
@@ -337,6 +342,10 @@ const ViewEventDetailModal = ({ open, onClose, eventDetails, onEventUpdated, ini
   
   const canEditEvent = isRegionalOrganizer || isRegionalAdmin;
 
+  // TIEMPO-431: Spotlighter role — surfaces an "Add Spotlight" action.
+  // BE re-validates the role on the spotlight PATCH, so this is just a UI gate.
+  const isSpotlighter = !!user && selectedRole === 'Spotlighter';
+
   // TIEMPO-362: Detect recurring event and capture occurrence date
   const isRecurringEvent = eventDetails?.extendedProps?.isRecurring ||
                           eventDetails?.extendedProps?.recurrenceRule;
@@ -569,6 +578,18 @@ const ViewEventDetailModal = ({ open, onClose, eventDetails, onEventUpdated, ini
       >
         Share
       </Button>
+
+      {/* TIEMPO-431: Add Spotlight button when user is in Spotlighter role */}
+      {isSpotlighter && (
+        <Button
+          onClick={() => setSpotlightOnlyOpen(true)}
+          size="small"
+          startIcon={<StarIcon fontSize="small" />}
+          sx={{ fontSize: '0.875rem' }}
+        >
+          Add Spotlight
+        </Button>
+      )}
 
       {/* TIEMPO-362: Actions removed from modal - now in calendar submenu */}
       {/* Edit/Delete buttons for users with permissions (non-recurring only) */}
@@ -992,6 +1013,16 @@ const ViewEventDetailModal = ({ open, onClose, eventDetails, onEventUpdated, ini
         startDate={eventDetails?.extendedProps?.originalStartDate || eventDetails?.start}
         instanceOverrides={eventDetails?.extendedProps?.instanceOverrides || []}
         excludedDates={eventDetails?.extendedProps?.excludedDates || []}
+      />
+
+      {/* TIEMPO-431: Spotlight-only modal for Spotlighter role */}
+      <SpotlightOnlyModal
+        open={spotlightOnlyOpen}
+        onClose={() => setSpotlightOnlyOpen(false)}
+        eventDetails={eventDetails}
+        onSpotlightsChanged={() => {
+          if (onEventUpdated) onEventUpdated();
+        }}
       />
     </>
   );

--- a/src/app/components/UI/SiteMenuBarUserDrawer.js
+++ b/src/app/components/UI/SiteMenuBarUserDrawer.js
@@ -34,7 +34,8 @@ import { useActivityLogger } from '@/hooks/useActivityLogger';
 // TIEMPO-319: Removed fetchAllGeolocationData import - no longer needed for logout
 
 // Define the standard role display order for consistency (static constant)
-const ROLE_DISPLAY_ORDER = ['NamedUser', 'RegionalOrganizer', 'RegionalAdmin', 'SystemAdmin', 'SystemOwner'];
+// TIEMPO-431: Spotlighter sits between NamedUser and RegionalOrganizer
+const ROLE_DISPLAY_ORDER = ['NamedUser', 'Spotlighter', 'RegionalOrganizer', 'RegionalAdmin', 'SystemAdmin', 'SystemOwner'];
 
 const SiteMenuBarUserDrawer = ({ userDrawerOpen, handleUserDrawerClose, showRoleMessage, readOnly = false }) => {
   const router = useRouter();
@@ -52,8 +53,9 @@ const SiteMenuBarUserDrawer = ({ userDrawerOpen, handleUserDrawerClose, showRole
   // Define role display mapping (backend role -> display name)
   const roleDisplayMap = {
     'NamedUser': 'Milonger@',
+    'Spotlighter': 'Spotlighter',
     'RegionalOrganizer': 'Organizer/Artist',
-    'RegionalAdmin': 'RegionalAdmin', 
+    'RegionalAdmin': 'RegionalAdmin',
     'SystemAdmin': 'SystemAdmin',
     'SystemOwner': 'SystemOwner'
   };
@@ -219,31 +221,16 @@ const SiteMenuBarUserDrawer = ({ userDrawerOpen, handleUserDrawerClose, showRole
                 </Typography>
                 <FormControl component="fieldset">
                   <RadioGroup value={selectedRole || 'NamedUser'} onChange={handleRoleChange}>
+                    {/* TIEMPO-431: Spotlighter is now real — render as a normal role
+                        when present in the user's roles array. The previous
+                        hardcoded "(coming soon)" disabled placeholder is removed. */}
                     {orderedUserRoles.map((role) => (
-                      <React.Fragment key={role}>
-                        <FormControlLabel
-                          value={role}
-                          control={<Radio />}
-                          label={roleDisplayMap[role] || role}
-                        />
-                        {/* Spotlighter coming soon - appears after NamedUser (Milonger@) */}
-                        {role === 'NamedUser' && (
-                          <FormControlLabel
-                            value="Spotlighter"
-                            control={<Radio disabled />}
-                            label={
-                              <Typography
-                                component="span"
-                                sx={{ color: 'text.disabled', fontStyle: 'italic' }}
-                              >
-                                Spotlighter <Typography component="span" variant="caption" sx={{ color: 'text.disabled' }}>(coming soon)</Typography>
-                              </Typography>
-                            }
-                            disabled
-                            sx={{ opacity: 0.6 }}
-                          />
-                        )}
-                      </React.Fragment>
+                      <FormControlLabel
+                        key={role}
+                        value={role}
+                        control={<Radio />}
+                        label={roleDisplayMap[role] || role}
+                      />
                     ))}
                   </RadioGroup>
                 </FormControl>

--- a/src/app/utils/masterData.js
+++ b/src/app/utils/masterData.js
@@ -2,6 +2,7 @@
 
 export const listOfAllRoles = {
   NAMED_USER: 'NamedUser',
+  SPOTLIGHTER: 'Spotlighter',
   REGIONAL_ORGANIZER: 'RegionalOrganizer',
   REGIONAL_ADMIN: 'RegionalAdmin',
   SYSTEM_OWNER: 'SystemOwner',


### PR DESCRIPTION
## Summary
Subset of TIEMPO-393. Gets the SL role functional in TT so the few users Toby has already granted (via direct DB edit) can actually use it. Defers CalOps grant UI, audit view, and per-occurrence recurring-event spotlights to their own tickets.

## Changes
- `masterData.js` — `SPOTLIGHTER` added to `listOfAllRoles`
- `SiteMenuBarUserDrawer.js` — `Spotlighter` in `ROLE_DISPLAY_ORDER` (between NamedUser and RegionalOrganizer) and `roleDisplayMap`. Hardcoded disabled "(coming soon)" placeholder removed.
- `ViewEventDetailModal.js` — surfaces an **Add Spotlight** button in the header when `selectedRole === 'Spotlighter'`. Opens new modal.
- `SpotlightOnlyModal.js` (new) — list current spotlights + add/remove controls. Each action `PATCH /api/events/{eventId}/spotlights` with bearer token. Recurring events: info banner that v1 applies to all occurrences; per-occurrence (instanceKey) is v2.

## BE
Untouched. `Events_Spotlights.js` (CALBEAF-91) already authorizes spotlight PATCH for users with SL + `spotlighterInfo.isEnabled !== false`. This is purely the FE wiring that was missing.

## Test plan
- [ ] User with `Spotlighter` in `roleIds` sees the role in the user-drawer dropdown (no longer disabled placeholder)
- [ ] Selecting Spotlighter role shows "Add Spotlight" button in any event's view modal
- [ ] Clicking Add Spotlight opens stripped modal with type select + name input
- [ ] Add a DJ spotlight → 200 from BE, calendar refreshes, spotlight visible on event
- [ ] Remove the spotlight → 200 from BE, gone from event
- [ ] Recurring event: info banner shown; spotlight applies to master
- [ ] User without SL role: no Add Spotlight button (BE re-validates anyway)

## Out of scope (separate tickets)
- CalOps grant/revoke UI (Dash, queued behind his TEST validation lane)
- CALOPS-51 (full audit view, v2)
- Per-occurrence spotlight overrides for recurring events (v2)
- Notifications to event owner (Fulton, TODO in BE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)