### PR TITLE
TIEMPO-433: Spotlighter clicks event → spotlight modal directly (no View Event)

### DIFF
--- a/src/app/calendar/boston/page.js
+++ b/src/app/calendar/boston/page.js
@@ -22,6 +22,7 @@ import { useCalendarPage } from '@/hooks/useCalendarPage';
 // CalendarSubMenu removed for simplified Boston view
 // CreateEventDetailModal removed - Boston is read-only
 import ViewEventDetailModal from '@/components/Modals/ViewEvents/ViewEventDetailModal.js';
+import SpotlightOnlyModal from '@/components/Modals/ViewEvents/SpotlightOnlyModal';
 import ViewAIEventDetails from '@/components/Modals/ViewEvents/ViewAIEventDetails';
 import CategoryCircles from '@/components/UI/CategoryCircles';
 import NoEventsAlert from '@/components/UI/NoEventsAlert';
@@ -171,6 +172,9 @@ const BostonCalendarPage = () => {
     selectedAIEventDetails: selectedAIEvent,  // AI event details
     isAIDetailModalOpen: isViewAIEventModalOpen,  // AI modal state
     setAIDetailModalOpen: handleAIModalClose,  // AI modal close
+    // TIEMPO-433: Spotlight-only modal for Spotlighter role
+    isSpotlightOnlyModalOpen,
+    setSpotlightOnlyModalOpen,
     // Create event modal not used - Boston is read-only
   } = useCalendarPage();
 
@@ -1345,6 +1349,13 @@ const BostonCalendarPage = () => {
           eventDetails={selectedAIEvent}
         />
       )}
+
+      {/* TIEMPO-433: Spotlight-only modal — opened directly from event click in Spotlighter role */}
+      <SpotlightOnlyModal
+        open={isSpotlightOnlyModalOpen}
+        onClose={() => setSpotlightOnlyModalOpen(false)}
+        eventDetails={selectedEventDetails}
+      />
 
       {/* Create modal removed - read-only view */}
     </div>

--- a/src/app/calendar/page.js
+++ b/src/app/calendar/page.js
@@ -21,6 +21,7 @@ import { useCalendarPage } from '@/hooks/useCalendarPage';
 import CalendarSubMenu from '@/components/UI/CalendarSubMenu';
 import CreateEventDetailModal from '@/components/Modals/CreateEvents/CreateEventDetailModal';
 import ViewEventDetailModal from '@/components/Modals/ViewEvents/ViewEventDetailModal.js';
+import SpotlightOnlyModal from '@/components/Modals/ViewEvents/SpotlightOnlyModal';
 import ViewAIEventDetails from '@/components/Modals/ViewEvents/ViewAIEventDetails';
 import CategoryCircles from '@/components/UI/CategoryCircles';
 import NoEventsAlert from '@/components/UI/NoEventsAlert';
@@ -82,6 +83,9 @@ const CalendarPage = () => {
     setCreateModalOpen,
     isViewDetailModalOpen,
     setViewDetailModalOpen,
+    // TIEMPO-433: Spotlight-only modal for Spotlighter role
+    isSpotlightOnlyModalOpen,
+    setSpotlightOnlyModalOpen,
     selectedEventDetails,
     handleDatesSet,
     handlePrev,
@@ -1639,6 +1643,14 @@ const CalendarPage = () => {
         eventDetails={selectedEventDetails}
         onEventUpdated={handleEventUpdated}
         initialAction={pendingOccurrenceAction}
+      />
+
+      {/* TIEMPO-433: Spotlight-only modal — opened directly from event click in Spotlighter role */}
+      <SpotlightOnlyModal
+        open={isSpotlightOnlyModalOpen}
+        onClose={() => setSpotlightOnlyModalOpen(false)}
+        eventDetails={selectedEventDetails}
+        onSpotlightsChanged={refreshEvents}
       />
 
       <ViewAIEventDetails

--- a/src/app/components/Modals/ViewEvents/SpotlightOnlyModal.js
+++ b/src/app/components/Modals/ViewEvents/SpotlightOnlyModal.js
@@ -72,7 +72,25 @@ const SpotlightOnlyModal = ({ open, onClose, eventDetails, onSpotlightsChanged }
 
   const eventId = eventDetails?.extendedProps?._id;
   const eventTitle = eventDetails?.extendedProps?.shortTitle || eventDetails?.title || 'Event';
+  const eventFullTitle = eventDetails?.title || eventTitle;
   const isRepeating = !!(eventDetails?.extendedProps?.isRecurring || eventDetails?.extendedProps?.recurrenceRule);
+
+  // TIEMPO-433: Event summary for verification — SL skips View Event modal,
+  // so the spotlight modal is now the only confirmation they have.
+  const eventStart = eventDetails?.start;
+  const formattedDate = eventStart
+    ? new Date(eventStart).toLocaleDateString(undefined, {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      })
+    : '';
+  const venueName =
+    eventDetails?.extendedProps?.venueName ||
+    eventDetails?.extendedProps?.venueShortName ||
+    '';
+  const venueCity = eventDetails?.extendedProps?.venueCityName || eventDetails?.extendedProps?.masteredCityName || '';
 
   // Existing spotlights surfaced for visibility/removal. Read both fields
   // (legacy `features` + canonical `spotlights`) to mirror BE behavior.
@@ -148,9 +166,30 @@ const SpotlightOnlyModal = ({ open, onClose, eventDetails, onSpotlightsChanged }
   return (
     <Modal open={open} onClose={onClose}>
       <Box sx={getModalStyle(isMobile)}>
-        <ModalHeader title={`Spotlights · ${eventTitle}`} onClose={onClose} />
+        <ModalHeader title="Add Spotlight" onClose={onClose} />
 
         <Box sx={{ flex: 1, overflow: 'auto', p: isMobile ? 2 : 3 }}>
+          {/* TIEMPO-433: Event summary at top so SL can verify the right event */}
+          <Box
+            sx={{
+              mb: 2,
+              p: 1.5,
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: 1,
+              bgcolor: 'grey.50',
+            }}
+          >
+            <Typography variant="subtitle1" sx={{ fontWeight: 600, lineHeight: 1.3 }}>
+              {eventFullTitle}
+            </Typography>
+            {(formattedDate || venueName || venueCity) && (
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+                {[formattedDate, venueName, venueCity].filter(Boolean).join(' · ')}
+              </Typography>
+            )}
+          </Box>
+
           {isRepeating && (
             <Alert severity="info" sx={{ mb: 2 }}>
               This is a recurring event. Spotlights you add here apply to all occurrences.

--- a/src/app/components/Modals/ViewEvents/ViewEventDetailModal.js
+++ b/src/app/components/Modals/ViewEvents/ViewEventDetailModal.js
@@ -5,7 +5,6 @@ import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ShareIcon from '@mui/icons-material/Share';
-import StarIcon from '@mui/icons-material/Star';
 import CloseIcon from '@mui/icons-material/Close';
 import RepeatIcon from '@mui/icons-material/Repeat';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
@@ -23,8 +22,6 @@ import ViewEventDetailsVenue from './ViewEventDetailsVenue';
 import CancelOccurrenceDialog from './CancelOccurrenceDialog';
 import EditOccurrenceModal from './EditOccurrenceModal';
 import OccurrenceDatePicker from './OccurrenceDatePicker';
-// TIEMPO-431: Spotlight-only modal for Spotlighter (SL) role
-import SpotlightOnlyModal from './SpotlightOnlyModal';
 import { cancelOccurrence, createOverride, addExcludedDate } from '@/services/eventOverrides';
 import { uploadEventImage } from '@/utils/uploadEventImages';
 import PropTypes from 'prop-types';
@@ -68,8 +65,6 @@ const ViewEventDetailModal = ({ open, onClose, eventDetails, onEventUpdated, ini
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
   const [editOccurrenceOpen, setEditOccurrenceOpen] = useState(false);
   const [datePickerOpen, setDatePickerOpen] = useState(false);
-  // TIEMPO-431: Spotlight-only modal state for Spotlighter role
-  const [spotlightOnlyOpen, setSpotlightOnlyOpen] = useState(false);
   const [selectedOccurrenceDate, setSelectedOccurrenceDate] = useState(null);
   const [isOverrideLoading, setIsOverrideLoading] = useState(false);
   // Track if we've handled the initial action to prevent re-triggering
@@ -342,10 +337,6 @@ const ViewEventDetailModal = ({ open, onClose, eventDetails, onEventUpdated, ini
   
   const canEditEvent = isRegionalOrganizer || isRegionalAdmin;
 
-  // TIEMPO-431: Spotlighter role — surfaces an "Add Spotlight" action.
-  // BE re-validates the role on the spotlight PATCH, so this is just a UI gate.
-  const isSpotlighter = !!user && selectedRole === 'Spotlighter';
-
   // TIEMPO-362: Detect recurring event and capture occurrence date
   const isRecurringEvent = eventDetails?.extendedProps?.isRecurring ||
                           eventDetails?.extendedProps?.recurrenceRule;
@@ -578,18 +569,6 @@ const ViewEventDetailModal = ({ open, onClose, eventDetails, onEventUpdated, ini
       >
         Share
       </Button>
-
-      {/* TIEMPO-431: Add Spotlight button when user is in Spotlighter role */}
-      {isSpotlighter && (
-        <Button
-          onClick={() => setSpotlightOnlyOpen(true)}
-          size="small"
-          startIcon={<StarIcon fontSize="small" />}
-          sx={{ fontSize: '0.875rem' }}
-        >
-          Add Spotlight
-        </Button>
-      )}
 
       {/* TIEMPO-362: Actions removed from modal - now in calendar submenu */}
       {/* Edit/Delete buttons for users with permissions (non-recurring only) */}
@@ -1015,15 +994,6 @@ const ViewEventDetailModal = ({ open, onClose, eventDetails, onEventUpdated, ini
         excludedDates={eventDetails?.extendedProps?.excludedDates || []}
       />
 
-      {/* TIEMPO-431: Spotlight-only modal for Spotlighter role */}
-      <SpotlightOnlyModal
-        open={spotlightOnlyOpen}
-        onClose={() => setSpotlightOnlyOpen(false)}
-        eventDetails={eventDetails}
-        onSpotlightsChanged={() => {
-          if (onEventUpdated) onEventUpdated();
-        }}
-      />
     </>
   );
 };

--- a/src/app/hooks/useCalendarPage.js
+++ b/src/app/hooks/useCalendarPage.js
@@ -36,6 +36,9 @@ export const useCalendarPage = () => {
   const [pendingOccurrenceAction, setPendingOccurrenceAction] = useState(null);
   const [isAIDetailModalOpen, setAIDetailModalOpen] = useState(false);
   const [selectedAIEventDetails, setSelectedAIEventDetails] = useState(null);
+  // TIEMPO-433: Spotlighter role opens SpotlightOnlyModal directly on event click
+  // (skipping ViewEventDetailModal entirely — pure spotlight-add intent)
+  const [isSpotlightOnlyModalOpen, setSpotlightOnlyModalOpen] = useState(false);
   const categories = useCategories();
   const { getMenuItems } = useMenuItems();
   // No longer needed - using saved user preferences instead
@@ -458,6 +461,13 @@ export const useCalendarPage = () => {
       // Regular event handling
       setSelectedEventDetails(arg.event);
 
+      // TIEMPO-433: Spotlighter role — open SpotlightOnlyModal directly,
+      // no View Event modal, no context menu. Pure spotlight-add intent.
+      if (selectedRole === listOfAllRoles.SPOTLIGHTER) {
+        setSpotlightOnlyModalOpen(true);
+        return;
+      }
+
       // Feature_3019: For NamedUser (Milongerx) and Anonymous (not logged in) roles, directly open ViewEventDetailModal
       // Issue_1035: Also check for empty string which is set by AuthContext for anonymous users
       if (selectedRole === listOfAllRoles.NAMED_USER || selectedRole === '' || selectedRole === listOfAllRoles.ANONYMOUS) {
@@ -551,6 +561,9 @@ export const useCalendarPage = () => {
       }
       setViewDetailModalOpen(isOpen);
     },
+    // TIEMPO-433: Spotlight-only modal for Spotlighter role
+    isSpotlightOnlyModalOpen,
+    setSpotlightOnlyModalOpen,
     // TIEMPO-362: Pending occurrence action for ViewEventDetailModal
     pendingOccurrenceAction,
     handleEventUpdated,


### PR DESCRIPTION
Per Toby's UX feedback: SL has no need for View Event. Click event → SpotlightOnlyModal opens directly with event-summary block at the top for verification.

## Changes
- `useCalendarPage.handleEventClick` branches on `selectedRole === 'Spotlighter'` → opens SpotlightOnlyModal directly, skipping context menu + View modal
- New `isSpotlightOnlyModalOpen` state + setter exported from useCalendarPage
- calendar/page.js + calendar/boston/page.js render SpotlightOnlyModal at top level
- SpotlightOnlyModal title → 'Add Spotlight'; new event-summary block (title + date · venue · city)
- ViewEventDetailModal: removed Add Spotlight button + SpotlightOnlyModal rendering (SL never reaches this modal anymore; button was misleading for other roles)

## Test plan
- [ ] Logged in as Spotlighter user → click any event → SpotlightOnlyModal opens (no View modal first)
- [ ] Modal header shows event title, date, venue, city
- [ ] Add/remove spotlights still works (BE PATCH unchanged)
- [ ] Other roles unchanged — View Event modal still opens normally
- [ ] Recurring event banner still appears in SL flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)