### PR TITLE
TIEMPO-433: add Cancel button to SpotlightOnlyModal footer

### DIFF
--- a/src/app/components/Modals/ViewEvents/SpotlightOnlyModal.js
+++ b/src/app/components/Modals/ViewEvents/SpotlightOnlyModal.js
@@ -303,6 +303,22 @@ const SpotlightOnlyModal = ({ open, onClose, eventDetails, onSpotlightsChanged }
             </Alert>
           )}
         </Box>
+
+        {/* TIEMPO-433: Sticky footer with explicit Cancel — adds/removes commit
+            individually, so Cancel just closes the modal without a confirm step. */}
+        <Box
+          sx={{
+            borderTop: '1px solid',
+            borderColor: 'divider',
+            p: isMobile ? 1.5 : 2,
+            display: 'flex',
+            justifyContent: 'flex-end',
+          }}
+        >
+          <Button onClick={onClose} variant="outlined" disabled={submitting}>
+            Cancel
+          </Button>
+        </Box>
       </Box>
     </Modal>
   );


### PR DESCRIPTION
Sticky footer with right-aligned outlined Cancel button. Adds/removes commit individually to BE so Cancel just closes — no confirm step needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)