### PR TITLE
TIEMPO-436: SL gets RO-pattern submenu + modal occurrence-nav arrows

### DIFF
--- a/src/app/components/Modals/ViewEvents/SpotlightOnlyModal.js
+++ b/src/app/components/Modals/ViewEvents/SpotlightOnlyModal.js
@@ -16,7 +16,7 @@
 
 'use client';
 
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect, useMemo, useContext } from 'react';
 import PropTypes from 'prop-types';
 import {
   Modal,
@@ -37,7 +37,11 @@ import {
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import axios from 'axios';
+import { format, addMonths } from 'date-fns';
+import { RRule } from 'rrule';
 import { AuthContext } from '@/contexts/AuthContext';
 import { getApiBaseUrl } from '@/utils/apiUrlResolver';
 import ModalHeader from '@/components/UI/ModalHeader';
@@ -81,32 +85,78 @@ const SpotlightOnlyModal = ({ open, onClose, eventDetails, onSpotlightsChanged }
   const eventFullTitle = eventDetails?.title || eventTitle;
   const isRepeating = !!(eventDetails?.extendedProps?.isRecurring || eventDetails?.extendedProps?.recurrenceRule);
 
-  // TIEMPO-433: Event summary for verification — SL skips View Event modal,
-  // so the spotlight modal is now the only confirmation they have.
-  const eventStart = eventDetails?.start;
-  const formattedDate = eventStart
-    ? new Date(eventStart).toLocaleDateString(undefined, {
-        weekday: 'short',
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric',
-      })
-    : '';
   const venueName =
     eventDetails?.extendedProps?.venueName ||
     eventDetails?.extendedProps?.venueShortName ||
     '';
   const venueCity = eventDetails?.extendedProps?.venueCityName || eventDetails?.extendedProps?.masteredCityName || '';
 
-  // TIEMPO-433: For recurring events the click identifies a specific
-  // occurrence — pass that as `instanceKey` so BE writes via instanceOverrides
-  // (one night only). Mirrors how RO Edit-This-Date works.
-  const instanceKey = isRepeating && eventStart
-    ? (typeof eventStart === 'string' ? eventStart : new Date(eventStart).toISOString())
+  // TIEMPO-436: Build the occurrence list for recurring events so SL can
+  // page << / >> through them inside the modal. Mirrors ViewEventDetailModal
+  // / EditOccurrenceModal pattern.
+  const recurrenceRule = eventDetails?.extendedProps?.recurrenceRule;
+  const venueDisplayStartTime = eventDetails?.extendedProps?.displayStartTime;
+  const eventStartDateRaw = eventDetails?.extendedProps?.originalStartDate || eventDetails?.start;
+
+  const occurrenceDates = useMemo(() => {
+    if (!isRepeating || !recurrenceRule) return [];
+    const dtstartSource = venueDisplayStartTime || eventStartDateRaw;
+    if (!dtstartSource) return [];
+    try {
+      let rruleStr;
+      if (typeof venueDisplayStartTime === 'string' && !venueDisplayStartTime.endsWith('Z')) {
+        const dtStartFormatted = venueDisplayStartTime.replace(/[-:]/g, '').replace('T', 'T').substring(0, 15);
+        rruleStr = `DTSTART:${dtStartFormatted}\nRRULE:${recurrenceRule}`;
+      } else {
+        const dtstart = new Date(dtstartSource);
+        rruleStr = `DTSTART:${format(dtstart, "yyyyMMdd'T'HHmmss")}\nRRULE:${recurrenceRule}`;
+      }
+      const rule = RRule.fromString(rruleStr);
+      const dtstart = new Date(dtstartSource);
+      const endRange = addMonths(new Date(), 6);
+      return rule.between(dtstart, endRange, true).slice(0, 52);
+    } catch {
+      return [];
+    }
+  }, [isRepeating, recurrenceRule, venueDisplayStartTime, eventStartDateRaw]);
+
+  // currentDateIndex tracks where the user has paged to. Initialize to the
+  // clicked occurrence; reset whenever the underlying event changes.
+  const initialIndex = useMemo(() => {
+    if (!isRepeating || !occurrenceDates.length || !eventDetails?.start) return 0;
+    const target = new Date(eventDetails.start).toISOString().split('T')[0];
+    const idx = occurrenceDates.findIndex(
+      (d) => new Date(d).toISOString().split('T')[0] === target
+    );
+    return idx >= 0 ? idx : 0;
+  }, [isRepeating, occurrenceDates, eventDetails?.start]);
+
+  const [currentDateIndex, setCurrentDateIndex] = useState(initialIndex);
+  useEffect(() => {
+    setCurrentDateIndex(initialIndex);
+  }, [initialIndex]);
+
+  // The "current" occurrence the SL is editing — either the rrule-derived
+  // navigated date (recurring) or the click's start (single).
+  const currentOccurrenceDate = isRepeating && occurrenceDates.length
+    ? occurrenceDates[currentDateIndex]
+    : eventDetails?.start;
+
+  const formattedDate = currentOccurrenceDate
+    ? new Date(currentOccurrenceDate).toLocaleDateString(undefined, {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      })
+    : '';
+
+  const instanceKey = isRepeating && currentOccurrenceDate
+    ? (typeof currentOccurrenceDate === 'string'
+        ? currentOccurrenceDate
+        : new Date(currentOccurrenceDate).toISOString())
     : null;
 
-  // Existing spotlights for THIS occurrence — for recurring events, prefer
-  // any instanceOverride matching the occurrence date over the master array.
   const masterSpotlights =
     eventDetails?.extendedProps?.spotlights ||
     eventDetails?.extendedProps?.features ||
@@ -134,10 +184,8 @@ const SpotlightOnlyModal = ({ open, onClose, eventDetails, onSpotlightsChanged }
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState(null);
 
-  // TIEMPO-436: Modal is mounted once at the calendar page level and reused
-  // across event clicks. useState initializers only fire on first mount, so
-  // values from the previous event leak into the next. Reset whenever the
-  // event identity OR the selected occurrence changes.
+  // TIEMPO-436: Reset spotlights + form whenever the event OR the selected
+  // occurrence changes (covers both event-switching AND prev/next nav).
   useEffect(() => {
     setSpotlights(initialSpotlights);
     setNewType('');
@@ -146,6 +194,15 @@ const SpotlightOnlyModal = ({ open, onClose, eventDetails, onSpotlightsChanged }
     setSubmitting(false);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [eventId, instanceKey]);
+
+  const handlePrevDate = () => {
+    if (currentDateIndex > 0) setCurrentDateIndex((i) => i - 1);
+  };
+  const handleNextDate = () => {
+    if (currentDateIndex < occurrenceDates.length - 1) setCurrentDateIndex((i) => i + 1);
+  };
+  const hasPrevDate = isRepeating && currentDateIndex > 0;
+  const hasNextDate = isRepeating && currentDateIndex < occurrenceDates.length - 1;
 
   const selectedOption = SPOTLIGHT_OPTIONS.find((o) => o.value === newType);
   const maxLength = selectedOption?.maxLength || 19;
@@ -207,6 +264,41 @@ const SpotlightOnlyModal = ({ open, onClose, eventDetails, onSpotlightsChanged }
         <ModalHeader title="Add Spotlight" onClose={onClose} />
 
         <Box sx={{ flex: 1, overflow: 'auto', p: isMobile ? 2 : 3 }}>
+          {/* TIEMPO-436: Occurrence navigation arrows for recurring events.
+              Mirrors EditOccurrenceModal pattern — click prev/next to page
+              through the series without closing the modal. */}
+          {isRepeating && occurrenceDates.length > 1 && (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                mb: 1.5,
+                px: 0.5,
+              }}
+            >
+              <IconButton
+                size="small"
+                onClick={handlePrevDate}
+                disabled={!hasPrevDate || submitting}
+                aria-label="previous occurrence"
+              >
+                <ChevronLeftIcon />
+              </IconButton>
+              <Typography variant="caption" color="text.secondary">
+                Occurrence {currentDateIndex + 1} of {occurrenceDates.length}
+              </Typography>
+              <IconButton
+                size="small"
+                onClick={handleNextDate}
+                disabled={!hasNextDate || submitting}
+                aria-label="next occurrence"
+              >
+                <ChevronRightIcon />
+              </IconButton>
+            </Box>
+          )}
+
           {/* TIEMPO-433: Event summary at top so SL can verify the right event */}
           <Box
             sx={{

--- a/src/app/hooks/useCalendarPage.js
+++ b/src/app/hooks/useCalendarPage.js
@@ -461,12 +461,10 @@ export const useCalendarPage = () => {
       // Regular event handling
       setSelectedEventDetails(arg.event);
 
-      // TIEMPO-433: Spotlighter role — open SpotlightOnlyModal directly,
-      // no View Event modal, no context menu. Pure spotlight-add intent.
-      if (selectedRole === listOfAllRoles.SPOTLIGHTER) {
-        setSpotlightOnlyModalOpen(true);
-        return;
-      }
+      // TIEMPO-436: Spotlighter mirrors RO process — show context menu so
+      // user can choose View Event vs Spotlight. (TIEMPO-433 originally
+      // skipped the menu; TIEMPO-436 reverts that for parity with RO UX.)
+      // Falls through to the elevated-role context-menu branch below.
 
       // Feature_3019: For NamedUser (Milongerx) and Anonymous (not logged in) roles, directly open ViewEventDetailModal
       // Issue_1035: Also check for empty string which is set by AuthContext for anonymous users
@@ -523,6 +521,15 @@ export const useCalendarPage = () => {
       // Store the action for ViewEventDetailModal to handle on open
       setPendingOccurrenceAction(action);
       setViewDetailModalOpen(true);
+    }
+
+    // TIEMPO-436: Spotlighter actions — open the spotlight-only modal.
+    // 'spotlightOccurrence' (recurring) and 'spotlightEvent' (single) both
+    // funnel to the same modal; the click event already carries the date,
+    // so the modal extracts instanceKey from selectedEventDetails.start
+    // for recurring events.
+    if (action === 'spotlightEvent' || action === 'spotlightOccurrence') {
+      setSpotlightOnlyModalOpen(true);
     }
   };
 

--- a/src/app/hooks/useMenuItems.js
+++ b/src/app/hooks/useMenuItems.js
@@ -137,6 +137,21 @@ const useMenuItems = () => {
             { label: 'Add Photos', action: 'addPhotos' },
           ];
         }
+      } else if (selectedRole === listOfAllRoles.SPOTLIGHTER) {
+        // TIEMPO-436: Spotlighter mirrors RO menu structure but capabilities
+        // are subsetted — spotlight actions only, no edit/delete/add-event.
+        if (isRecurring && formattedDate) {
+          menuOptions = [
+            ...menuOptions,
+            { label: `Spotlight This Date (${formattedDate})`, action: 'spotlightOccurrence' },
+            { label: 'See All Dates', action: 'seeAllDates' },
+          ];
+        } else {
+          menuOptions = [
+            ...menuOptions,
+            { label: 'Spotlight This Event', action: 'spotlightEvent' },
+          ];
+        }
       } else if (selectedRole === listOfAllRoles.NAMED_USER) {
         menuOptions = [...menuOptions, { label: 'Add Comment/Photo', action: 'addCommentPhoto' }];
       }


### PR DESCRIPTION
Per Toby UX clarification: SL should mirror RO process (look + feel) with subsetted rights — same submenu, same modal nav, just spotlight-only actions.

## Changes
- **useMenuItems.js** — SPOTLIGHTER branch in eventClick context.
  - Recurring: View Event / Spotlight This Date (formattedDate) / See All Dates
  - Single: View Event / Spotlight This Event
- **useCalendarPage.js** — handleEventClick falls through to context-menu branch for SL (reverts TIEMPO-433 direct-open). handleMenuAction wires `spotlightEvent` + `spotlightOccurrence` → opens SpotlightOnlyModal.
- **SpotlightOnlyModal.js** — RRule-derived occurrenceDates, currentDateIndex state, prev/next handlers, header nav strip showing "Occurrence X of Y". instanceKey + spotlights re-derive on nav. Existing reset useEffect on instanceKey change handles form/error reset cleanly.

3 files, +142 / -28.

## Test plan
- [ ] SL clicks single event → context menu shows View / Spotlight This Event
- [ ] SL clicks recurring event → menu shows View / Spotlight This Date / See All Dates
- [ ] Click Spotlight This Date → modal opens for that date
- [ ] Modal shows "Occurrence X of Y" + arrows for recurring
- [ ] Click >> → moves to next occurrence; spotlights re-read from instanceOverrides for new date
- [ ] Click << → moves backward
- [ ] Add spotlight on occurrence #3 → only #3 affected, #4 next-page is empty
- [ ] Other roles unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)