### PR TITLE
fix(auth): accept HTTP 201 on userlogin create (signup was failing)

### DIFF
--- a/src/app/contexts/AuthContext.js
+++ b/src/app/contexts/AuthContext.js
@@ -515,7 +515,12 @@ export const AuthProvider = ({ children }) => {
           },
         });
 
-        if (roleResponse.status !== 204) {
+        // TIEMPO-437: BE returns 201 (Created) on POST success — correct REST
+        // semantics for resource creation. Previous code expected 204 which
+        // never matched, so every new signup threw "Failed to assign role"
+        // even though the userlogin record was actually created server-side.
+        // Accept any 2xx as success.
+        if (roleResponse.status < 200 || roleResponse.status >= 300) {
           throw new Error('Failed to assign role in backend');
         }
       } else {


### PR DESCRIPTION
BE returns 201 on POST /api/userlogins; FE was checking !== 204. Every new-user signup threw 'Failed to assign role in backend' even though the userlogin was actually created. Fix: accept any 2xx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)