### PR TITLE
TIEMPO-440: merge MapCenterOnboardingModal into MapCenterModal (Option B)

### DIFF
--- a/src/app/calendar/page.js
+++ b/src/app/calendar/page.js
@@ -30,7 +30,7 @@ import { AuthContext } from '@/contexts/AuthContext';
 import { RoleContext } from '@/contexts/RoleContext';
 import { listOfAllRoles } from '@/utils/masterData';
 import WelcomeModal from '@/components/Modals/Welcome/WelcomeModal'; // TIEMPO-329: Welcome modal
-import MapCenterOnboardingModal from '@/components/Modals/misc/MapCenterOnboardingModal'; // TIEMPO-381: Onboarding modal
+// TIEMPO-440: MapCenterOnboardingModal removed; onboarding now reuses MapCenterModal via openMapCenterModal()
 import { wasWelcomeShown } from '@/utils/visitorTracking'; // TIEMPO-329: Visitor tracking
 
 const CalendarPage = () => {
@@ -59,8 +59,6 @@ const CalendarPage = () => {
     openLocationSettings,
     openMapCenterModal,
     needsOnboarding,
-    setNeedsOnboarding,
-    saveToCloudDefault,
     isInitialized: geoInitialized,
     currentLocation
   } = useGeoLocation();
@@ -1197,6 +1195,16 @@ const CalendarPage = () => {
     }
   }, []);
 
+  // TIEMPO-440: Logged-in users without a saved mapCenter — open the same
+  // MapCenterModal everyone else uses (replaces the legacy
+  // MapCenterOnboardingModal). saveToCloudDefault now clears
+  // needsOnboarding on success so the modal won't re-open in a loop.
+  useEffect(() => {
+    if (needsOnboarding && user) {
+      openMapCenterModal();
+    }
+  }, [needsOnboarding, user, openMapCenterModal]);
+
   // Auto-open location settings for LOGGED-IN users only if no location selected
   // TIEMPO-381: Wait for geoInitialized before making decision - prevents race condition
   // TIEMPO-388: Anonymous users are handled by WelcomeModal (tries browser geolocation first)
@@ -1665,14 +1673,9 @@ const CalendarPage = () => {
         onClose={() => setShowWelcomeModal(false)}
       />
 
-      {/* TIEMPO-381: MapCenter Onboarding Modal - Shows for logged-in users without mapCenter */}
-      <MapCenterOnboardingModal
-        open={needsOnboarding && !!user}
-        onSaveLocation={async (locationData, firebaseToken) => {
-          await saveToCloudDefault(locationData, firebaseToken);
-          setNeedsOnboarding(false);
-        }}
-      />
+      {/* TIEMPO-440: MapCenterOnboardingModal merged into MapCenterModal —
+          onboarding now triggers the same modal everyone else uses, opened
+          via openMapCenterModal(). saveToCloudDefault clears needsOnboarding. */}
 
       {/* TIEMPO-408: floating map icon removed — CityPill in chrome replaces it. */}
     </div>

--- a/src/app/components/Modals/misc/MapCenterOnboardingModal.js
+++ b/src/app/components/Modals/misc/MapCenterOnboardingModal.js
@@ -29,6 +29,14 @@ import {
 import 'leaflet/dist/leaflet.css';
 
 /**
+ * @deprecated TIEMPO-440 — Replaced by MapCenterModal opened via
+ * `openMapCenterModal()` for the onboarding case. This file is retained for
+ * one merge cycle as a rollback fallback; if nothing renders it after soak
+ * on TEST, it will be deleted.
+ *
+ * If you see the console.warn below firing, something is still importing
+ * this component — please migrate to MapCenterModal and report back to Sarah.
+ *
  * MapCenterOnboardingModal - Blocking modal for new users without mapCenter
  *
  * TIEMPO-381: Forces user to set their location before accessing the calendar.
@@ -38,6 +46,12 @@ const MapCenterOnboardingModal = ({
   open,
   onSaveLocation,
 }) => {
+  // TIEMPO-440: Surface accidental rendering to error tracking. If you're
+  // seeing this fire, something still imports the deprecated modal — should
+  // route through openMapCenterModal() / MapCenterModal instead.
+  if (open && typeof window !== 'undefined') {
+    console.warn('[DEPRECATED] MapCenterOnboardingModal rendered — TIEMPO-440 replaced this with MapCenterModal. Please migrate.');
+  }
   const { user } = useContext(AuthContext);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));

--- a/src/app/contexts/GeoLocationContext.js
+++ b/src/app/contexts/GeoLocationContext.js
@@ -547,6 +547,10 @@ export const GeoLocationProvider = ({ children }) => {
     // Update location AND fetch city name
     await updateLocationWithCityName(locData);
 
+    // TIEMPO-440: Clear onboarding flag so the (now reused) MapCenterModal
+    // closes the onboarding loop the same way MapCenterOnboardingModal did.
+    setNeedsOnboarding(false);
+
     return result;
   }, [updateLocationWithCityName]);
 


### PR DESCRIPTION
Onboarding now reuses the same MapCenterModal everyone else uses (Option B from your UX review). Saves us 600+ lines of duplicate-modal logic to maintain.

## Changes
- `calendar/page.js`: replace `<MapCenterOnboardingModal>` JSX with `useEffect` triggering `openMapCenterModal()` when `needsOnboarding && user`
- `GeoLocationContext.js`: `saveToCloudDefault` now calls `setNeedsOnboarding(false)` on success — closes the onboarding loop without needing the dedicated modal
- `MapCenterOnboardingModal.js`: `@deprecated` JSDoc + render-time `console.warn`. **File kept** for one merge cycle as a rollback fallback; deletion follow-up after TEST soak

## Test plan
- [ ] First-visit logged-in user without saved mapCenter → MapCenterModal opens (not the old blocking one)
- [ ] Save Cloud Default → modal closes, calendar populates, doesn't re-open
- [ ] Anonymous first-visit flow (WelcomeModal) unchanged
- [ ] No `[DEPRECATED] MapCenterOnboardingModal rendered` warning in console after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)