### PR TITLE
TIEMPO-440: Workshop becomes FLEX, DayWorkshop deprecated (FE-side match for CALBEAF-154)

### DIFF
--- a/src/app/components/Modals/CreateEvents/CreateEventDetailsBasic.js
+++ b/src/app/components/Modals/CreateEvents/CreateEventDetailsBasic.js
@@ -14,12 +14,16 @@ import VenueModal from '@/components/Modals/Venues/VenueModal'; // TIEMPO-290: I
 import SeriesDetectionHint from '@/components/Modals/CreateEvents/SeriesDetectionHint'; // TIEMPO-409: SAS-FTPNTD hint
 import PropTypes from 'prop-types';
 
-// TIEMPO-408 / Thread 1 sign-off (2026-04-18): strict gate eligible categories.
-const FOR_BEGINNERS_ELIGIBLE = new Set(['Class', 'Workshop', 'DayWorkshop', 'Festival']);
+// TIEMPO-408 strict gate, aligned with BE TIEMPO-440 / CALBEAF-154.
+// BE BEGINNER_ELIGIBLE_CATEGORIES = ['Class', 'Workshop']. Festival dropped
+// (BE never had it); DayWorkshop dropped (deprecated — Workshop covers both
+// short and long durations now).
+const FOR_BEGINNERS_ELIGIBLE = new Set(['Class', 'Workshop']);
 
 const CreateEventDetailsBasic = ({ eventData, setEventData, editMode = false, organizer = null, onTimeModified = null }) => {
   const allCategories = useCategories(); // Fetch categories
-  // TIEMPO-291: Filter out DayWorkshop (replaced by Encuentro), Trip, and Unknown
+  // TIEMPO-440: Filter out DayWorkshop (deprecated — Workshop covers both
+  // short and long durations), Trip, and Unknown.
   const categories = useMemo(() =>
     allCategories.filter(cat =>
       cat.categoryName !== 'DayWorkshop' &&
@@ -647,9 +651,9 @@ const CreateEventDetailsBasic = ({ eventData, setEventData, editMode = false, or
           </FormControl>
         </Grid>
 
-        {/* TIEMPO-408 (provisional pre-TIEMPO-405): forBeginners toggle with
-            strict client-side gate (Class/Workshop/DayWorkshop/Festival).
-            Server rejection path follows when Fulton's bulk-enrich endpoint ships. */}
+        {/* TIEMPO-408 + TIEMPO-440: forBeginners toggle with strict
+            client-side gate (Class/Workshop). Aligned with BE
+            BEGINNER_ELIGIBLE_CATEGORIES per CALBEAF-154. */}
         <Grid item xs={12} md={6}>
           <Collapse in={FOR_BEGINNERS_ELIGIBLE.has(eventData.categoryFirst)} timeout={150}>
             <FormControl fullWidth>

--- a/src/app/components/Organizer/OrganizerGroupedList.js
+++ b/src/app/components/Organizer/OrganizerGroupedList.js
@@ -22,12 +22,12 @@ const WINDOW_DAYS = 90;
 // Broader category palette than Explore's 5-color filtered set — Local
 // events cover Milonga/Practica/Class that don't appear in Explore. Kept
 // local to this file so Explore's legend stays lean.
+// TIEMPO-440: DayWorkshop entry dropped — Workshop covers both short and long durations.
 const CATEGORY_COLORS = {
   Milonga: '#ef4444',     // red
   Practica: '#14b8a6',    // teal
   Class: '#3b82f6',       // blue
   Workshop: '#ec4899',    // pink
-  DayWorkshop: '#d946ef', // magenta
   Festival: '#e94560',    // pink-red
   Marathon: '#f97316',    // orange
   Encuentro: '#22c55e',   // green

--- a/src/app/components/UI/PostFilter.js
+++ b/src/app/components/UI/PostFilter.js
@@ -15,7 +15,8 @@ import { categoryColors } from '@/utils/categoryColors';
 
 const PostFilter = ({ activeCategories = [], categories = [], handleCategoryChange }) => {
   // Define the ordered categories
-  // TIEMPO-291: Removed DayWorkshop (replaced by Encuentro), removed Trip and Unknown
+  // TIEMPO-440: DayWorkshop deprecated — Workshop covers both short and long
+  // durations now. Trip and Unknown remain unbucketed and excluded from filter UI.
   const orderedCategories = [
     'Milonga',
     'Practica',
@@ -29,7 +30,7 @@ const PostFilter = ({ activeCategories = [], categories = [], handleCategoryChan
   // Make a safe copy of categories if it's an array, otherwise use an empty array
   const categoriesSafe = Array.isArray(categories) ? [...categories] : [];
 
-  // TIEMPO-291: Filter out DayWorkshop, Trip, and Unknown
+  // TIEMPO-440: Filter out DayWorkshop (deprecated), Trip, and Unknown
   // Sort the categories based on their order in orderedCategories
   const sortedCategories = categoriesSafe.filter(cat =>
     cat &&

--- a/src/app/explorer/page.js
+++ b/src/app/explorer/page.js
@@ -42,11 +42,11 @@ const Popup = dynamic(() => import('react-leaflet').then((mod) => mod.Popup), { 
 const MapEventHandler = dynamic(() => import('@/components/EventDiscovery/MapEventHandler'), { ssr: false });
 
 // Event categories
+// TIEMPO-440: DayWorkshop dropped — Workshop covers both short and long durations.
 const EVENT_CATEGORIES = [
   'Milonga',
   'Festival',
   'Workshop',
-  'DayWorkshop',
   'Classes',
   'Practices',
   'Concerts',

--- a/src/app/options/page.js
+++ b/src/app/options/page.js
@@ -3,7 +3,8 @@
 import React from 'react';
 import { Box, Typography, Grid, Switch, FormControlLabel, Paper } from '@mui/material';
 
-const eventTypes = ['Festivals', 'Workshops', 'DayWorkshops', 'Milongas', 'Practices', 'Classes', 'Concerts'];
+// TIEMPO-440: DayWorkshops dropped — Workshops covers both short and long durations.
+const eventTypes = ['Festivals', 'Workshops', 'Milongas', 'Practices', 'Classes', 'Concerts'];
 
 const eventLevels = [
   { level: 'Favorites', label: 'Favorites' },

--- a/src/app/utils/eventCategoryValidation.js
+++ b/src/app/utils/eventCategoryValidation.js
@@ -1,19 +1,28 @@
 /**
- * Event Category Duration Validation (TIEMPO-291)
+ * Event Category Duration Validation (TIEMPO-291, TIEMPO-440)
  *
- * Rules:
- * 1. SHORT events (Milonga, Practica, Class) must be >= 15 minutes and < 24 hours
- * 2. LONG events (Festival, Encuentro, Marathon, Workshop) must be >= 24 hours
- * 3. SHORT and LONG categories cannot be mixed (mutual exclusion)
- * 4. SHORT and LONG events cannot exceed 7 days (168 hours)
+ * Canonical rule (mirrors BE CALBEAF-154 — `calendar-be-af/src/utils/eventCategoryValidation.js`):
+ *
+ * 1. SHORT events (Milonga, Practica, Class) — 15 min ≤ duration < 24h
+ * 2. LONG  events (Festival, Encuentro, Marathon) — 24h ≤ duration ≤ 168h
+ * 3. FLEX  events (Workshop, Other) — 15 min ≤ duration ≤ 168h (no LONG-min gate)
+ * 4. Hard cap on any event: 168h (7 days)
+ * 5. Mix rule: SHORT + LONG cannot combine. FLEX combines with either.
  *
  * RegionalAdmin bypasses all validation.
+ *
+ * DayWorkshop deprecated (TIEMPO-440): time is the distinction, not the label.
+ * A small workshop = Workshop with short duration; a multi-day workshop =
+ * Workshop with long duration. No more separate label.
  */
 
 // Category classifications
 export const SHORT_CATEGORIES = ['Milonga', 'Practica', 'Class'];
-export const LONG_CATEGORIES = ['Festival', 'Encuentro', 'Marathon', 'Workshop'];
+export const LONG_CATEGORIES = ['Festival', 'Encuentro', 'Marathon'];
+export const FLEX_CATEGORIES = ['Workshop', 'Other'];
 export const NEUTRAL_CATEGORIES = ['Trip', 'Unknown'];
+
+const HARD_CAP_HOURS = 168; // 7 days
 
 /**
  * Validate event duration and category combinations
@@ -34,7 +43,7 @@ export const validateEventCategoryRules = (eventData, selectedRole) => {
   const categorySecond = eventData.categorySecond || '';
   const categoryThird = eventData.categoryThird || '';
 
-  // Calculate duration in hours
+  // Calculate duration
   if (!eventData.startDate || !eventData.endDate) {
     return { isValid: true, errors: [] }; // Skip validation if dates not set
   }
@@ -42,41 +51,50 @@ export const validateEventCategoryRules = (eventData, selectedRole) => {
   const durationHours = eventData.endDate.diff(eventData.startDate, 'hour', true);
   const durationMinutes = eventData.endDate.diff(eventData.startDate, 'minute', true);
 
-  // Rule 1: SHORT events must be >= 15 minutes and < 24 hours
+  // Pluralize for friendlier error copy
+  const pluralize = (cat) => (cat === 'Class' ? 'Classes' : `${cat}s`);
+
+  // Rule 1: SHORT — 15 min ≤ duration < 24h
   if (SHORT_CATEGORIES.includes(categoryFirst)) {
     if (durationMinutes < 15) {
-      const categoryName = categoryFirst === 'Class' ? 'Classes' : `${categoryFirst}s`;
-      errors.push(`${categoryName} must be at least 15 minutes. Current duration: ${Math.round(durationMinutes)} minutes.`);
+      errors.push(`${pluralize(categoryFirst)} must be at least 15 minutes. Current duration: ${Math.round(durationMinutes)} minutes.`);
     }
     if (durationHours >= 24) {
-      const categoryName = categoryFirst === 'Class' ? 'Classes' : `${categoryFirst}s`;
-      errors.push(`${categoryName} must be less than 24 hours. Current duration: ${Math.round(durationHours)} hours.`);
+      errors.push(`${pluralize(categoryFirst)} must be less than 24 hours. Current duration: ${Math.round(durationHours)} hours.`);
     }
   }
 
-  // Rule 2: LONG events must be >= 24 hours
+  // Rule 2: LONG — 24h ≤ duration ≤ 168h
   if (LONG_CATEGORIES.includes(categoryFirst)) {
     if (durationHours < 24) {
-      const categoryName = categoryFirst === 'Workshop' ? 'Workshops' : `${categoryFirst}s`;
-      errors.push(`${categoryName} must be 24 hours or longer. Current duration: ${Math.round(durationHours)} hours.`);
+      errors.push(`${pluralize(categoryFirst)} must be 24 hours or longer. Current duration: ${Math.round(durationHours)} hours.`);
     }
   }
 
-  // Rule 4: SHORT and LONG events cannot exceed 7 days (168 hours)
-  const isShortOrLong = SHORT_CATEGORIES.includes(categoryFirst) || LONG_CATEGORIES.includes(categoryFirst);
-  if (isShortOrLong && durationHours > 168) {
+  // Rule 3: FLEX — 15 min ≤ duration ≤ 168h (no LONG-min)
+  if (FLEX_CATEGORIES.includes(categoryFirst)) {
+    if (durationMinutes < 15) {
+      errors.push(`${pluralize(categoryFirst)} must be at least 15 minutes. Current duration: ${Math.round(durationMinutes)} minutes.`);
+    }
+  }
+
+  // Rule 4: Hard cap on duration applies to anything that's bucketed
+  const isBucketed =
+    SHORT_CATEGORIES.includes(categoryFirst) ||
+    LONG_CATEGORIES.includes(categoryFirst) ||
+    FLEX_CATEGORIES.includes(categoryFirst);
+  if (isBucketed && durationHours > HARD_CAP_HOURS) {
     const durationDays = Math.round(durationHours / 24);
     errors.push(`Events cannot exceed 7 days. Current duration: ${durationDays} days (${Math.round(durationHours)} hours).`);
   }
 
-  // Rule 3: Mutual exclusion - SHORT and LONG cannot be mixed
-  const allCategories = [categoryFirst, categorySecond, categoryThird].filter(cat => cat);
+  // Rule 5: Mutual exclusion — SHORT + LONG cannot combine. FLEX is permissive.
+  const allCategories = [categoryFirst, categorySecond, categoryThird].filter(Boolean);
   const hasShort = allCategories.some(cat => SHORT_CATEGORIES.includes(cat));
   const hasLong = allCategories.some(cat => LONG_CATEGORIES.includes(cat));
-
   if (hasShort && hasLong) {
     errors.push(
-      'Short events (Milonga, Practica, Class) and Long events (Festival, Encuentro, Marathon, Workshop) cannot be combined. Please choose categories from the same group.'
+      'Short events (Milonga, Practica, Class) and Long events (Festival, Encuentro, Marathon) cannot be combined. Please choose categories from the same group.'
     );
   }
 
@@ -89,10 +107,11 @@ export const validateEventCategoryRules = (eventData, selectedRole) => {
 /**
  * Get user-friendly category group name
  * @param {string} category - Category name
- * @returns {string} 'SHORT', 'LONG', or 'NEUTRAL'
+ * @returns {'SHORT'|'LONG'|'FLEX'|'NEUTRAL'} Group name
  */
 export const getCategoryGroup = (category) => {
   if (SHORT_CATEGORIES.includes(category)) return 'SHORT';
   if (LONG_CATEGORIES.includes(category)) return 'LONG';
+  if (FLEX_CATEGORIES.includes(category)) return 'FLEX';
   return 'NEUTRAL';
 };


### PR DESCRIPTION
Match BE CALBEAF-154. Workshop now FLEX (15min-168h). DayWorkshop dropped from FE labels (BE has 0 events using it per Fulton's audit). FOR_BEGINNERS_ELIGIBLE aligned with BE = [Class, Workshop].

🤖 Generated with [Claude Code](https://claude.com/claude-code)