### PR TITLE
TIEMPO-444: Organizer Settings redesign — Profile / Settings / Status (3 tabs)

### DIFF
--- a/src/app/components/Modals/RegionalOrganizers/OrganizerProfileTab.js
+++ b/src/app/components/Modals/RegionalOrganizers/OrganizerProfileTab.js
@@ -1,0 +1,381 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import PropTypes from 'prop-types';
+import axios from 'axios';
+import {
+  Box, Typography, TextField, Grid, Card, CardContent,
+  InputAdornment, IconButton, Tooltip, Button, CircularProgress,
+  Alert,
+} from '@mui/material';
+import LockIcon from '@mui/icons-material/Lock';
+import LockOpenIcon from '@mui/icons-material/LockOpen';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import CancelIcon from '@mui/icons-material/Cancel';
+import PersonIcon from '@mui/icons-material/Person';
+import ContactMailIcon from '@mui/icons-material/ContactMail';
+import ImageIcon from '@mui/icons-material/Image';
+import { getApiBaseUrl } from '@/utils/apiUrlResolver';
+
+// Probe candidate against /shortname-check, suffix-retry up to 5x.
+const probeUnique = async (candidate, appId) => {
+  const root = (candidate || '').replace(/[^A-Za-z0-9]/g, '').slice(0, 9) || 'New';
+  for (let i = 0; i <= 5; i++) {
+    const tryName = i === 0 ? root : `${root}${i + 1}`.slice(0, 9);
+    try {
+      const { data } = await axios.get(
+        `${getApiBaseUrl()}/api/organizers/shortname-check?appId=${appId}&candidate=${encodeURIComponent(tryName)}`
+      );
+      if (data?.available) return tryName;
+    } catch {
+      return tryName; // network blip — fall through to POST
+    }
+  }
+  return null;
+};
+
+const OrganizerProfileTab = ({ organizer, onFieldChange, unsavedChanges, onShortNameBlocked, savedAt }) => {
+  const appId = process.env.NEXT_PUBLIC_APPLICATION_ID || '1';
+
+  // ── local field state ────────────────────────────────────────────────────
+  const [fullName, setFullName] = useState('');
+  const [shortName, setShortName] = useState('');
+  const [shortNameLocked, setShortNameLocked] = useState(true);
+  const [shortNameStatus, setShortNameStatus] = useState({ checking: false, available: null, message: '' });
+  const [description, setDescription] = useState('');
+  const [url, setUrl] = useState('');
+  const [phone, setPhone] = useState('');
+  const [email, setEmail] = useState('');
+  const [street1, setStreet1] = useState('');
+  const [street2, setStreet2] = useState('');
+  const [city, setCity] = useState('');
+  const [addrState, setAddrState] = useState('');
+  const [zip, setZip] = useState('');
+
+  // Seed from organizer (and re-lock shortName whenever organizer or savedAt changes)
+  useEffect(() => {
+    if (!organizer) return;
+    setFullName(organizer.fullName || '');
+    setShortName(organizer.shortName || '');
+    setDescription(organizer.description || '');
+    setUrl(organizer.publicContactInfo?.url || '');
+    setPhone(organizer.publicContactInfo?.phone || '');
+    setEmail(organizer.publicContactInfo?.Email || '');
+    const addr = organizer.publicContactInfo?.address || {};
+    setStreet1(addr.street1 || '');
+    setStreet2(addr.street2 || '');
+    setCity(addr.city || '');
+    setAddrState(addr.state || '');
+    setZip(addr.postalCode || '');
+    // Re-lock short name after every organizer refresh (post-save)
+    setShortNameLocked(true);
+    setShortNameStatus({ checking: false, available: null, message: '' });
+  }, [organizer, savedAt]);
+
+  // Apply unsaved overrides from centralized modal state
+  const displayFullName = unsavedChanges?.fullName ?? fullName;
+  const displayShortName = unsavedChanges?.shortName ?? shortName;
+  const displayDescription = unsavedChanges?.description ?? description;
+  const displayUrl = unsavedChanges?.['publicContactInfo.url'] ?? url;
+  const displayPhone = unsavedChanges?.['publicContactInfo.phone'] ?? phone;
+  const displayEmail = unsavedChanges?.['publicContactInfo.Email'] ?? email;
+  const displayStreet1 = unsavedChanges?.['publicContactInfo.address.street1'] ?? street1;
+  const displayStreet2 = unsavedChanges?.['publicContactInfo.address.street2'] ?? street2;
+  const displayCity = unsavedChanges?.['publicContactInfo.address.city'] ?? city;
+  const displayAddrState = unsavedChanges?.['publicContactInfo.address.state'] ?? addrState;
+  const displayZip = unsavedChanges?.['publicContactInfo.address.postalCode'] ?? zip;
+
+  // Tell modal whether Save should be blocked due to shortName state
+  useEffect(() => {
+    const blocked = !shortNameLocked && shortNameStatus.available !== true;
+    onShortNameBlocked?.(blocked);
+  }, [shortNameLocked, shortNameStatus.available, onShortNameBlocked]);
+
+  const handleShortNameBlur = useCallback(async () => {
+    const candidate = displayShortName.trim();
+    if (!candidate) {
+      setShortNameStatus({ checking: false, available: null, message: '' });
+      return;
+    }
+    if (candidate.length < 3 || candidate.length > 9) {
+      setShortNameStatus({ checking: false, available: false, message: 'Must be 3–9 characters' });
+      return;
+    }
+    if (/CHANGE|TANGO/i.test(candidate)) {
+      setShortNameStatus({ checking: false, available: false, message: 'Cannot contain "CHANGE" or "TANGO"' });
+      return;
+    }
+    // Skip check if unchanged from saved value
+    if (candidate === organizer?.shortName) {
+      setShortNameStatus({ checking: false, available: true, message: 'Current name' });
+      return;
+    }
+    setShortNameStatus({ checking: true, available: null, message: 'Checking…' });
+    try {
+      const { data } = await axios.get(
+        `${getApiBaseUrl()}/api/organizers/shortname-check?appId=${appId}&candidate=${encodeURIComponent(candidate)}`
+      );
+      setShortNameStatus(
+        data?.available
+          ? { checking: false, available: true, message: 'Available' }
+          : { checking: false, available: false, message: 'Already taken — try a variation' }
+      );
+    } catch {
+      setShortNameStatus({ checking: false, available: null, message: '' });
+    }
+  }, [displayShortName, organizer?.shortName, appId]);
+
+  const handleSuggest = useCallback(async () => {
+    const root = displayFullName.replace(/[^A-Za-z0-9]/g, '') || 'New';
+    setShortNameStatus({ checking: true, available: null, message: 'Finding a unique name…' });
+    const suggested = await probeUnique(root, appId);
+    if (suggested) {
+      setShortName(suggested);
+      onFieldChange?.('shortName', suggested);
+      setShortNameStatus({ checking: false, available: true, message: 'Available' });
+    } else {
+      setShortNameStatus({ checking: false, available: false, message: 'Could not find a unique suggestion — edit manually' });
+    }
+  }, [displayFullName, appId, onFieldChange]);
+
+  const field = (key, setter) => (v) => {
+    setter(v);
+    onFieldChange?.(key, v);
+  };
+
+  const addrField = (subKey, setter) => (v) => {
+    setter(v);
+    onFieldChange?.(`publicContactInfo.address.${subKey}`, v);
+  };
+
+  const contactField = (subKey, setter) => (v) => {
+    setter(v);
+    onFieldChange?.(`publicContactInfo.${subKey}`, v);
+  };
+
+  return (
+    <Box sx={{ mt: 1 }}>
+
+      {/* ── Identity ───────────────────────────────────────────────────────── */}
+      <Card variant="outlined" sx={{ mb: 2 }}>
+        <CardContent>
+          <Box display="flex" alignItems="center" sx={{ mb: 2 }}>
+            <PersonIcon sx={{ mr: 1 }} />
+            <Typography variant="subtitle1" fontWeight="bold">Identity</Typography>
+          </Box>
+
+          <Grid container spacing={2}>
+
+            {/* Full Name */}
+            <Grid item xs={12} sm={7}>
+              <TextField
+                label="Full Name"
+                fullWidth
+                value={displayFullName}
+                onChange={(e) => field('fullName', setFullName)(e.target.value)}
+                error={displayFullName.trim().length > 0 && displayFullName.trim().length < 7}
+                helperText={
+                  displayFullName.trim().length > 0 && displayFullName.trim().length < 7
+                    ? 'Min 7 characters required'
+                    : 'Your name or group name as shown to the public'
+                }
+                inputProps={{ maxLength: 80 }}
+              />
+            </Grid>
+
+            {/* Short Name — locked/unlocked */}
+            <Grid item xs={12} sm={5}>
+              <TextField
+                label="Short Name"
+                fullWidth
+                value={displayShortName}
+                disabled={shortNameLocked}
+                onChange={(e) => {
+                  const v = e.target.value.replace(/[^A-Za-z0-9]/g, '').slice(0, 9);
+                  setShortName(v);
+                  onFieldChange?.('shortName', v);
+                  setShortNameStatus({ checking: false, available: null, message: '' });
+                }}
+                onBlur={handleShortNameBlur}
+                error={!shortNameLocked && shortNameStatus.available === false}
+                helperText={
+                  shortNameLocked
+                    ? 'Click 🔒 to edit'
+                    : shortNameStatus.checking
+                      ? 'Checking…'
+                      : shortNameStatus.message || '3–9 alphanumeric characters'
+                }
+                inputProps={{ maxLength: 9 }}
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      {!shortNameLocked && (
+                        shortNameStatus.checking ? (
+                          <CircularProgress size={16} sx={{ mr: 0.5 }} />
+                        ) : shortNameStatus.available === true ? (
+                          <CheckCircleIcon color="success" fontSize="small" sx={{ mr: 0.5 }} />
+                        ) : shortNameStatus.available === false ? (
+                          <CancelIcon color="error" fontSize="small" sx={{ mr: 0.5 }} />
+                        ) : null
+                      )}
+                      <Tooltip title={shortNameLocked ? 'Unlock to edit Short Name' : 'Lock (discard edit)'}>
+                        <IconButton
+                          size="small"
+                          onClick={() => {
+                            if (shortNameLocked) {
+                              setShortNameLocked(false);
+                            } else {
+                              // Re-lock: revert to saved value
+                              setShortName(organizer?.shortName || '');
+                              onFieldChange?.('shortName', organizer?.shortName || '');
+                              setShortNameLocked(true);
+                              setShortNameStatus({ checking: false, available: null, message: '' });
+                            }
+                          }}
+                        >
+                          {shortNameLocked ? <LockIcon fontSize="small" /> : <LockOpenIcon fontSize="small" />}
+                        </IconButton>
+                      </Tooltip>
+                    </InputAdornment>
+                  ),
+                }}
+              />
+              {!shortNameLocked && (
+                <Button
+                  size="small"
+                  sx={{ mt: 0.5 }}
+                  onClick={handleSuggest}
+                  disabled={shortNameStatus.checking}
+                >
+                  Suggest a unique name
+                </Button>
+              )}
+            </Grid>
+
+            {/* Description */}
+            <Grid item xs={12}>
+              <TextField
+                label="Description"
+                fullWidth
+                multiline
+                minRows={3}
+                value={displayDescription}
+                onChange={(e) => field('description', setDescription)(e.target.value)}
+                inputProps={{ maxLength: 500 }}
+                helperText={`${displayDescription.trim().length}/500 — describe what you organize`}
+              />
+            </Grid>
+
+            {/* URL */}
+            <Grid item xs={12}>
+              <TextField
+                label="Website / Social Media"
+                fullWidth
+                value={displayUrl}
+                onChange={(e) => contactField('url', setUrl)(e.target.value)}
+                helperText="Optional — website, Facebook, Instagram, etc."
+              />
+            </Grid>
+
+          </Grid>
+        </CardContent>
+      </Card>
+
+      {/* ── Contact ────────────────────────────────────────────────────────── */}
+      <Card variant="outlined" sx={{ mb: 2 }}>
+        <CardContent>
+          <Box display="flex" alignItems="center" sx={{ mb: 2 }}>
+            <ContactMailIcon sx={{ mr: 1 }} />
+            <Typography variant="subtitle1" fontWeight="bold">Contact</Typography>
+          </Box>
+
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                label="Contact Email"
+                fullWidth
+                value={displayEmail}
+                onChange={(e) => contactField('Email', setEmail)(e.target.value)}
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                label="Phone"
+                fullWidth
+                value={displayPhone}
+                onChange={(e) => contactField('phone', setPhone)(e.target.value)}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <TextField
+                label="Street Address"
+                fullWidth
+                value={displayStreet1}
+                onChange={(e) => addrField('street1', setStreet1)(e.target.value)}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <TextField
+                label="Street Address 2"
+                fullWidth
+                value={displayStreet2}
+                onChange={(e) => addrField('street2', setStreet2)(e.target.value)}
+                helperText="Apt, suite, etc. (optional)"
+              />
+            </Grid>
+            <Grid item xs={12} sm={5}>
+              <TextField
+                label="City"
+                fullWidth
+                value={displayCity}
+                onChange={(e) => addrField('city', setCity)(e.target.value)}
+              />
+            </Grid>
+            <Grid item xs={6} sm={4}>
+              <TextField
+                label="State"
+                fullWidth
+                value={displayAddrState}
+                onChange={(e) => addrField('state', setAddrState)(e.target.value)}
+              />
+            </Grid>
+            <Grid item xs={6} sm={3}>
+              <TextField
+                label="Zip"
+                fullWidth
+                value={displayZip}
+                onChange={(e) => addrField('postalCode', setZip)(e.target.value)}
+              />
+            </Grid>
+          </Grid>
+        </CardContent>
+      </Card>
+
+      {/* ── Images placeholder ─────────────────────────────────────────────── */}
+      <Card variant="outlined" sx={{ mb: 1, opacity: 0.7 }}>
+        <CardContent>
+          <Box display="flex" alignItems="center" sx={{ mb: 1 }}>
+            <ImageIcon sx={{ mr: 1 }} color="disabled" />
+            <Typography variant="subtitle1" fontWeight="bold" color="text.secondary">
+              Profile Images
+            </Typography>
+          </Box>
+          <Alert severity="info" variant="outlined">
+            Banner, profile photo, and logo upload — coming soon.
+          </Alert>
+        </CardContent>
+      </Card>
+
+    </Box>
+  );
+};
+
+OrganizerProfileTab.propTypes = {
+  organizer: PropTypes.object,
+  onFieldChange: PropTypes.func,
+  unsavedChanges: PropTypes.object,
+  onShortNameBlocked: PropTypes.func,
+  savedAt: PropTypes.number,
+};
+
+export default OrganizerProfileTab;

--- a/src/app/components/Modals/RegionalOrganizers/OrganizerSettingsTab.js
+++ b/src/app/components/Modals/RegionalOrganizers/OrganizerSettingsTab.js
@@ -1,0 +1,197 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Box, Typography, FormControlLabel, Checkbox, Switch,
+  Tooltip, IconButton, Grid, Card, CardContent, Alert,
+  useMediaQuery, useTheme,
+} from '@mui/material';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import GroupIcon from '@mui/icons-material/Group';
+
+// ── Tooltip info strings ────────────────────────────────────────────────────
+const TYPE_INFO = {
+  isEventOrganizer: 'Required. Allows you to create and manage tango events (milongas, classes, festivals).',
+  isTeacher:        'You offer tango group or private lessons. Will appear in the Teachers directory when available.',
+  isMaestro:        'Recognized master teacher. Travels to teach and perform at festivals.',
+  isDJ:             'You play music at milongas and tango events.',
+  isOrchestra:      'You perform live Argentine tango music.',
+  isTaxiDancer:     'You are available for hire as a guided dance partner at events.',
+  isVendor:         'You sell tango-related products or services (shoes, clothing, music, etc.).',
+};
+
+const VISIBILITY_INFO = {
+  isEnabled:   'Activates your organizer account. When on, you can create and edit events. Turn off to pause without deleting your profile.',
+  isVisible:   'Your profile appears in organizer dropdowns so others can add you as the organizer of their events.',
+  wantRender:  'Your organizer profile page is included in search engine results (Google, etc.).',
+};
+
+const InfoTip = ({ text }) => (
+  <Tooltip title={text} arrow placement="right">
+    <IconButton size="small" tabIndex={-1} sx={{ ml: 0.5, color: 'text.secondary' }}>
+      <InfoOutlinedIcon fontSize="small" />
+    </IconButton>
+  </Tooltip>
+);
+InfoTip.propTypes = { text: PropTypes.string.isRequired };
+
+const OrganizerSettingsTab = ({ organizer, onFieldChange, unsavedChanges }) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const defaultTypes = {
+    isEventOrganizer: true,
+    isTeacher: false,
+    isMaestro: false,
+    isDJ: false,
+    isOrchestra: false,
+    isTaxiDancer: false,
+    isVendor: false,
+  };
+
+  const [localTypes, setLocalTypes] = useState(defaultTypes);
+  const [localIsEnabled, setLocalIsEnabled] = useState(true);
+  const [localIsVisible, setLocalIsVisible] = useState(true);
+  const [localWantRender, setLocalWantRender] = useState(false);
+
+  useEffect(() => {
+    if (!organizer) return;
+    const t = organizer.organizerTypes || {};
+    setLocalTypes({
+      isEventOrganizer: t.isEventOrganizer ?? true,
+      isTeacher:        t.isTeacher        ?? false,
+      isMaestro:        t.isMaestro        ?? false,
+      isDJ:             t.isDJ             ?? false,
+      isOrchestra:      t.isOrchestra      ?? false,
+      isTaxiDancer:     t.isTaxiDancer     ?? false,
+      isVendor:         t.isVendor         ?? false,
+    });
+    setLocalIsEnabled(organizer.isEnabled !== false);
+    setLocalIsVisible(organizer.isVisible !== false);
+    setLocalWantRender(organizer.wantRender || false);
+  }, [organizer]);
+
+  // Apply centralized overrides
+  const types      = unsavedChanges?.organizerTypes ?? localTypes;
+  const isEnabled  = unsavedChanges?.isEnabled  ?? localIsEnabled;
+  const isVisible  = unsavedChanges?.isVisible  ?? localIsVisible;
+  const wantRender = unsavedChanges?.wantRender ?? localWantRender;
+
+  const handleTypeChange = (name, checked) => {
+    if (name === 'isEventOrganizer' && !checked) return; // always-on
+    const next = { ...types, [name]: checked };
+    setLocalTypes(next);
+    onFieldChange?.('organizerTypes', next);
+  };
+
+  const handleVisibility = (key, setter) => (e) => {
+    setter(e.target.checked);
+    onFieldChange?.(key, e.target.checked);
+  };
+
+  const typeRows = [
+    ['isEventOrganizer', 'Event Organizer'],
+    ['isTeacher',        'Teacher'],
+    ['isMaestro',        'Maestro'],
+    ['isDJ',             'DJ'],
+    ['isOrchestra',      'Orchestra'],
+    ['isTaxiDancer',     'Taxi Dancer'],
+    ['isVendor',         'Vendor'],
+  ];
+
+  return (
+    <Box sx={{ mt: 1 }}>
+
+      {/* ── What you do ──────────────────────────────────────────────────── */}
+      <Card variant="outlined" sx={{ mb: 2 }}>
+        <CardContent>
+          <Typography variant="subtitle1" fontWeight="bold" sx={{ mb: 1 }}>
+            What you do
+          </Typography>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 2 }}>
+            Artists+ types will have dedicated searchable profiles. Select yours now to be notified when they launch.
+          </Typography>
+
+          <Grid container spacing={0} columns={isMobile ? 1 : 2}>
+            {typeRows.map(([key, label]) => (
+              <Grid item xs={1} key={key}>
+                <Box display="flex" alignItems="center">
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={types[key] ?? false}
+                        onChange={(e) => handleTypeChange(key, e.target.checked)}
+                        disabled={key === 'isEventOrganizer'}
+                        color="primary"
+                        size="small"
+                      />
+                    }
+                    label={label}
+                    sx={{ mr: 0 }}
+                  />
+                  <InfoTip text={TYPE_INFO[key]} />
+                </Box>
+              </Grid>
+            ))}
+          </Grid>
+        </CardContent>
+      </Card>
+
+      {/* ── Visibility & Access ──────────────────────────────────────────── */}
+      <Card variant="outlined" sx={{ mb: 2 }}>
+        <CardContent>
+          <Typography variant="subtitle1" fontWeight="bold" sx={{ mb: 2 }}>
+            Visibility &amp; Access
+          </Typography>
+
+          {[
+            { key: 'isEnabled',  label: 'Profile Active',         value: isEnabled,  setter: setLocalIsEnabled },
+            { key: 'isVisible',  label: 'Profile Visible',        value: isVisible,  setter: setLocalIsVisible },
+            { key: 'wantRender', label: 'Search Engine Visible',  value: wantRender, setter: setLocalWantRender },
+          ].map(({ key, label, value, setter }) => (
+            <Box key={key} display="flex" alignItems="center" sx={{ mb: 1 }}>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={value}
+                    onChange={handleVisibility(key, setter)}
+                    color="primary"
+                    size="small"
+                  />
+                }
+                label={label}
+                sx={{ mr: 0, minWidth: 200 }}
+              />
+              <InfoTip text={VISIBILITY_INFO[key]} />
+            </Box>
+          ))}
+        </CardContent>
+      </Card>
+
+      {/* ── Delegation placeholder ───────────────────────────────────────── */}
+      <Card variant="outlined" sx={{ mb: 1, opacity: 0.7 }}>
+        <CardContent>
+          <Box display="flex" alignItems="center" sx={{ mb: 1 }}>
+            <GroupIcon sx={{ mr: 1 }} color="disabled" />
+            <Typography variant="subtitle1" fontWeight="bold" color="text.secondary">
+              Delegated Organizers
+            </Typography>
+          </Box>
+          <Alert severity="info" variant="outlined">
+            Allow others to create events on your behalf — coming soon.
+          </Alert>
+        </CardContent>
+      </Card>
+
+    </Box>
+  );
+};
+
+OrganizerSettingsTab.propTypes = {
+  organizer: PropTypes.object,
+  onFieldChange: PropTypes.func,
+  unsavedChanges: PropTypes.object,
+};
+
+export default OrganizerSettingsTab;

--- a/src/app/components/Modals/RegionalOrganizers/OrganizerStatusTab.js
+++ b/src/app/components/Modals/RegionalOrganizers/OrganizerStatusTab.js
@@ -1,0 +1,111 @@
+'use client';
+
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Box, Typography, Chip, Card, CardContent,
+  Accordion, AccordionSummary, AccordionDetails, Divider,
+} from '@mui/material';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import CancelIcon from '@mui/icons-material/Cancel';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import BugReportIcon from '@mui/icons-material/BugReport';
+
+const StatusRow = ({ label, value }) => (
+  <Box display="flex" alignItems="center" justifyContent="space-between" sx={{ py: 0.75 }}>
+    <Typography variant="body2" color="text.secondary">{label}</Typography>
+    <Chip
+      size="small"
+      icon={value ? <CheckCircleIcon /> : <CancelIcon />}
+      label={value ? 'Yes' : 'No'}
+      color={value ? 'success' : 'default'}
+      variant="outlined"
+    />
+  </Box>
+);
+StatusRow.propTypes = { label: PropTypes.string.isRequired, value: PropTypes.bool };
+
+const DebugRow = ({ label, value }) => (
+  <Box sx={{ py: 0.5 }}>
+    <Typography variant="caption" color="text.secondary">{label}</Typography>
+    <Typography
+      variant="body2"
+      sx={{ fontFamily: 'monospace', wordBreak: 'break-all', fontSize: '0.75rem' }}
+    >
+      {value || '—'}
+    </Typography>
+  </Box>
+);
+DebugRow.propTypes = { label: PropTypes.string.isRequired, value: PropTypes.string };
+
+const OrganizerStatusTab = ({ organizer, user }) => {
+  const [debugOpen, setDebugOpen] = useState(false);
+
+  const roInfo = user?.backendInfo?.regionalOrganizerInfo || {};
+  const approvalDate = roInfo.ApprovalDate
+    ? new Date(roInfo.ApprovalDate).toLocaleDateString()
+    : null;
+  const updatedAt = organizer?.updatedAt
+    ? new Date(organizer.updatedAt).toLocaleDateString()
+    : null;
+
+  return (
+    <Box sx={{ mt: 1 }}>
+
+      <Card variant="outlined" sx={{ mb: 2 }}>
+        <CardContent>
+          <Typography variant="subtitle1" fontWeight="bold" sx={{ mb: 1 }}>
+            Account Status
+          </Typography>
+          <Divider sx={{ mb: 1 }} />
+          <StatusRow label="Application Approved"  value={roInfo.isApproved} />
+          <StatusRow label="Profile Active"         value={organizer?.isEnabled} />
+          <StatusRow label="Profile Visible"        value={organizer?.isVisible} />
+          <StatusRow label="Search Engine Visible"  value={organizer?.wantRender} />
+          {approvalDate && (
+            <Box sx={{ mt: 1 }}>
+              <Typography variant="caption" color="text.secondary">
+                Approved: {approvalDate}
+              </Typography>
+            </Box>
+          )}
+          {updatedAt && (
+            <Box>
+              <Typography variant="caption" color="text.secondary">
+                Last updated: {updatedAt}
+              </Typography>
+            </Box>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Debug IDs — collapsed by default */}
+      <Accordion
+        expanded={debugOpen}
+        onChange={() => setDebugOpen((v) => !v)}
+        variant="outlined"
+        sx={{ '&:before': { display: 'none' } }}
+      >
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Box display="flex" alignItems="center" gap={1}>
+            <BugReportIcon fontSize="small" color="action" />
+            <Typography variant="body2" color="text.secondary">Debug Info</Typography>
+          </Box>
+        </AccordionSummary>
+        <AccordionDetails>
+          <DebugRow label="Organizer ID"   value={organizer?._id} />
+          <DebugRow label="User ID"        value={user?.backendInfo?._id} />
+          <DebugRow label="Firebase UID"   value={user?.uid} />
+        </AccordionDetails>
+      </Accordion>
+
+    </Box>
+  );
+};
+
+OrganizerStatusTab.propTypes = {
+  organizer: PropTypes.object,
+  user: PropTypes.object,
+};
+
+export default OrganizerStatusTab;

--- a/src/app/components/Modals/RegionalOrganizers/RegionalOrganizersModal.js
+++ b/src/app/components/Modals/RegionalOrganizers/RegionalOrganizersModal.js
@@ -1,270 +1,210 @@
 'use client';
 
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect, useContext, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { Modal, Box, Typography, Tabs, Tab, useMediaQuery, useTheme, AppBar, Toolbar, IconButton, Button } from '@mui/material';
+import {
+  Modal, Box, AppBar, Toolbar, Typography, Tabs, Tab,
+  IconButton, Button, Tooltip, CircularProgress,
+  useMediaQuery, useTheme,
+} from '@mui/material';
 import { Close as CloseIcon } from '@mui/icons-material';
-import RegionalOrganizersProfile from './RegionalOrganizersProfile';
-import RegionalOrganizerTypes from './RegionalOrganizersTypes';
-import RegionalOrganizersStatus from './RegionalOrganizersStatus';
-import RegionalOrganizersSettings from './RegionalOrganizersSettings';
 import { AuthContext } from '@/contexts/AuthContext';
 import { useOrganizers } from '@/hooks/useOrganizers';
 import modalStyle from '@/components/Styles/modalStyles';
+import OrganizerProfileTab  from './OrganizerProfileTab';
+import OrganizerSettingsTab from './OrganizerSettingsTab';
+import OrganizerStatusTab   from './OrganizerStatusTab';
 
 const RegionalOrganizersModal = ({ open, onClose }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-  const auth = useContext(AuthContext);
-  const { user } = auth || {};
+  const { user } = useContext(AuthContext) || {};
   const { organizer, loading, error, fetchOrganizerById, updateOrganizer } = useOrganizers();
-  const [currentTab, setCurrentTab] = useState('status');
-  
-  // TIEMPO-254: Centralized state for all tabs - persists across tab changes
-  const [unsavedChanges, setUnsavedChanges] = useState({});
-  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
-  const [saveMessage, setSaveMessage] = useState('');
+
+  const [currentTab, setCurrentTab]           = useState('profile');
+  const [unsavedChanges, setUnsavedChanges]   = useState({});
+  const [hasUnsaved, setHasUnsaved]           = useState(false);
+  const [shortNameBlocked, setShortNameBlocked] = useState(false);
+  const [isSaving, setIsSaving]               = useState(false);
+  const [saveMessage, setSaveMessage]         = useState('');
+  // Bumped on successful save to trigger Profile re-lock
+  const [savedAt, setSavedAt]                 = useState(0);
 
   useEffect(() => {
-    if (open) {
-      setCurrentTab('status');
-      // TIEMPO-254: Reset unsaved changes when modal opens
-      setUnsavedChanges({});
-      setHasUnsavedChanges(false);
-      setSaveMessage('');
-
-      const organizerId = user?.backendInfo?.regionalOrganizerInfo?.organizerId;
-
-      if (organizerId) {
-        try {
-          fetchOrganizerById(organizerId);
-        } catch (error) {
-          console.error('Error calling fetchOrganizerById:', error);
-        }
-      } else {
-        console.warn('No Organizer ID available. Skipping fetch.');
-      }
-    }
+    if (!open) return;
+    setCurrentTab('profile');
+    setUnsavedChanges({});
+    setHasUnsaved(false);
+    setSaveMessage('');
+    const organizerId = user?.backendInfo?.regionalOrganizerInfo?.organizerId;
+    if (organizerId) fetchOrganizerById(organizerId);
   }, [open, user, fetchOrganizerById]);
 
-  const handleTabChange = (event, newValue) => {
-    // TIEMPO-254: Preserve unsaved changes when switching tabs
-    setCurrentTab(newValue);
-  };
+  const handleTabChange = (_, newTab) => setCurrentTab(newTab);
 
-  // TIEMPO-254: Centralized field change handler
-  const handleFieldChange = (tabName, fieldName, value) => {
+  const handleFieldChange = useCallback((tabKey, fieldName, value) => {
     setUnsavedChanges(prev => ({
       ...prev,
-      [tabName]: {
-        ...prev[tabName],
-        [fieldName]: value
-      }
+      [tabKey]: { ...prev[tabKey], [fieldName]: value },
     }));
-    setHasUnsavedChanges(true);
-    setSaveMessage(''); // Clear any previous save message
-  };
+    setHasUnsaved(true);
+    setSaveMessage('');
+  }, []);
 
-  // TIEMPO-254: Centralized save handler - saves all tabs at once
   const handleSaveAll = async () => {
-    if (!hasUnsavedChanges || !organizer?._id) return;
-
+    if (!hasUnsaved || !organizer?._id) return;
     setIsSaving(true);
     setSaveMessage('');
-
-    // Merge all unsaved changes into a single update object
     const allChanges = {};
-    Object.values(unsavedChanges).forEach(tabChanges => {
-      Object.assign(allChanges, tabChanges);
-    });
-
+    Object.values(unsavedChanges).forEach(c => Object.assign(allChanges, c));
     try {
-      // Update the organizer with all changes
       await updateOrganizer(organizer._id, allChanges);
-
-      // Clear unsaved changes and show success
       setUnsavedChanges({});
-      setHasUnsavedChanges(false);
-      setSaveMessage('All changes saved! Restarting to apply changes...');
-      
-      // TIEMPO-272: Auto-restart after all saves to ensure system is fully updated
-      setTimeout(() => {
-        window.location.reload();
-      }, 2000);
-    } catch (error) {
-      console.error('Error saving changes:', error);
-
-      // TIEMPO-284: Handle 409 Conflict for duplicate shortName
-      if (error.response?.status === 409) {
-        const shortName = allChanges.shortName || organizer?.shortName;
-        setSaveMessage(
-          `The Short Name "${shortName}" is already taken by another organizer. ` +
-          `Please choose a unique name.`
-        );
+      setHasUnsaved(false);
+      setSavedAt(Date.now());
+      setSaveMessage('Saved');
+      setTimeout(() => setSaveMessage(''), 3000);
+    } catch (err) {
+      if (err.response?.status === 409) {
+        setSaveMessage(`Short name "${allChanges.shortName || organizer.shortName}" is already taken.`);
       } else {
-        setSaveMessage('Error saving changes. Please try again.');
+        setSaveMessage('Error saving — please try again.');
       }
     } finally {
       setIsSaving(false);
     }
   };
 
-  // TIEMPO-254: Handle modal close - warn about unsaved changes
   const handleClose = () => {
-    if (hasUnsavedChanges) {
-      if (window.confirm('You have unsaved changes. Are you sure you want to close?')) {
-        setUnsavedChanges({});
-        setHasUnsavedChanges(false);
-        onClose();
-      }
-    } else {
-      onClose();
+    if (hasUnsaved) {
+      if (!window.confirm('You have unsaved changes. Close anyway?')) return;
     }
+    setUnsavedChanges({});
+    setHasUnsaved(false);
+    onClose();
   };
+
+  const saveBlocked = shortNameBlocked;
+  const saveDisabled = !hasUnsaved || isSaving || saveBlocked;
+
+  const saveTooltip = isSaving
+    ? 'Saving…'
+    : saveBlocked
+      ? 'Confirm short name availability before saving'
+      : !hasUnsaved
+        ? 'No changes'
+        : '';
+
+  const organizerId = user?.backendInfo?.regionalOrganizerInfo?.organizerId;
 
   return (
     <Modal open={open} onClose={handleClose}>
       <Box sx={modalStyle(isMobile)}>
-        {/* Header with Close Button */}
-        <AppBar position="static" color="default">
+
+        {/* ── Header ─────────────────────────────────────────────────────── */}
+        <AppBar position="static" color="default" elevation={1}>
           <Toolbar variant="dense">
-            <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
-              Event Organizer Settings
-              {hasUnsavedChanges && (
-                <Typography component="span" variant="caption" sx={{ ml: 2, color: 'warning.main' }}>
-                  (Unsaved Changes)
+            <Typography variant="h6" sx={{ flexGrow: 1 }}>
+              Organizer Settings
+              {hasUnsaved && (
+                <Typography component="span" variant="caption" sx={{ ml: 1, color: 'warning.main' }}>
+                  · unsaved
                 </Typography>
               )}
             </Typography>
-            {/* TIEMPO-254: Save All button in header */}
-            {hasUnsavedChanges && (
-              <Button
-                variant="contained"
-                color="primary"
-                size="small"
-                onClick={handleSaveAll}
-                disabled={isSaving}
-                sx={{ mr: 2 }}
-              >
-                {isSaving ? 'Saving...' : 'Save All'}
-              </Button>
-            )}
+
             {saveMessage && (
-              <Typography variant="caption" sx={{ mr: 2, color: saveMessage.includes('Error') ? 'error.main' : 'success.main' }}>
+              <Typography
+                variant="caption"
+                sx={{ mr: 1.5, color: saveMessage === 'Saved' ? 'success.main' : 'error.main' }}
+              >
                 {saveMessage}
               </Typography>
             )}
-            <IconButton edge="end" color="inherit" onClick={handleClose} aria-label="close">
+
+            <Tooltip title={saveTooltip} disableHoverListener={!saveTooltip}>
+              <span>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  size="small"
+                  onClick={handleSaveAll}
+                  disabled={saveDisabled}
+                  sx={{ mr: 1 }}
+                  startIcon={isSaving ? <CircularProgress size={14} color="inherit" /> : null}
+                >
+                  {isSaving ? 'Saving…' : 'Save'}
+                </Button>
+              </span>
+            </Tooltip>
+
+            <IconButton edge="end" color="inherit" onClick={handleClose} size="small">
               <CloseIcon />
             </IconButton>
           </Toolbar>
         </AppBar>
 
-        {user?.backendInfo.regionalOrganizerInfo?.organizerId && (
-          <Typography variant="body2" color="textSecondary" gutterBottom sx={{ p: 1 }}>
-            Organizer ID: {user.backendInfo.regionalOrganizerInfo.organizerId}
-          </Typography>
-        )}
+        {organizerId ? (
+          <Box sx={{ display: 'flex', flexDirection: 'column', height: 'calc(100% - 48px)' }}>
 
-        {user?.backendInfo.regionalOrganizerInfo?.organizerId ? (
-          <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+            {/* ── Tabs ───────────────────────────────────────────────────── */}
             <Tabs
               value={currentTab}
               onChange={handleTabChange}
-              aria-label="Regional Organizer Settings Tabs"
               variant="scrollable"
               scrollButtons="auto"
               allowScrollButtonsMobile
-              sx={{ 
-                borderBottom: 1, 
-                borderColor: 'divider',
-                '& .MuiTabs-scrollableX': {
-                  overflowX: 'auto',
-                  scrollbarWidth: 'none',
-                  '&::-webkit-scrollbar': {
-                    display: 'none',
-                  },
-                },
-                '& .MuiTabs-scroller': {
-                  overflowX: 'auto',
-                  scrollbarWidth: 'none',
-                  '&::-webkit-scrollbar': {
-                    display: 'none',
-                  },
-                }
-              }}
+              sx={{ borderBottom: 1, borderColor: 'divider', flexShrink: 0 }}
             >
-              <Tab label="Status" value="status" />
+              <Tab label="Profile"  value="profile"  />
               <Tab label="Settings" value="settings" />
-              <Tab label="Profile" value="profile" />
-              <Tab label="Artists+" value="types" />
+              <Tab label="Status"   value="status"   />
             </Tabs>
 
+            {/* ── Tab content ────────────────────────────────────────────── */}
             {loading ? (
-              <Typography>Loading...</Typography>
+              <Box sx={{ p: 3, display: 'flex', justifyContent: 'center' }}>
+                <CircularProgress size={32} />
+              </Box>
             ) : error ? (
-              <Typography color="error">Error loading organizer data</Typography>
+              <Typography color="error" sx={{ p: 2 }}>Error loading organizer data.</Typography>
             ) : (
-              <Box
-                sx={{
-                  flexGrow: 1,
-                  overflowY: 'auto',
-                  p: 2,
-                }}
-              >
-                {currentTab === 'status' && (
-                  <RegionalOrganizersStatus
-                    organizerId={organizer?._id}
-                    organizer={organizer}
-                    updateOrganizer={updateOrganizer}
-                    onFieldChange={(field, value) => handleFieldChange('status', field, value)}
-                    unsavedChanges={unsavedChanges.status || {}}
-                    onSave={handleSaveAll}
-                    isSaving={isSaving}
-                  />
-                )}
-                {currentTab === 'settings' && (
-                  <RegionalOrganizersSettings
-                    organizerId={organizer?._id}
-                    organizer={organizer}
-                    updateOrganizer={updateOrganizer}
-                    onFieldChange={(field, value) => handleFieldChange('settings', field, value)}
-                    unsavedChanges={unsavedChanges.settings || {}}
-                    onSave={handleSaveAll}
-                    isSaving={isSaving}
-                  />
-                )}
+              <Box sx={{ flexGrow: 1, overflowY: 'auto', p: 2 }}>
+
                 {currentTab === 'profile' && (
-                  <RegionalOrganizersProfile
-                    organizerId={organizer?._id}
+                  <OrganizerProfileTab
                     organizer={organizer}
-                    updateOrganizer={updateOrganizer}
-                    onFieldChange={(field, value) => handleFieldChange('profile', field, value)}
                     unsavedChanges={unsavedChanges.profile || {}}
-                    onSave={handleSaveAll}
-                    isSaving={isSaving}
+                    onFieldChange={(field, value) => handleFieldChange('profile', field, value)}
+                    onShortNameBlocked={setShortNameBlocked}
+                    savedAt={savedAt}
                   />
                 )}
-                {currentTab === 'types' && (
-                  <RegionalOrganizerTypes
-                    organizerId={organizer?._id}
+
+                {currentTab === 'settings' && (
+                  <OrganizerSettingsTab
                     organizer={organizer}
-                    updateOrganizer={updateOrganizer}
-                    onFieldChange={(field, value) => handleFieldChange('types', field, value)}
-                    unsavedChanges={unsavedChanges.types || {}}
-                    onSave={handleSaveAll}
-                    isSaving={isSaving}
+                    unsavedChanges={unsavedChanges.settings || {}}
+                    onFieldChange={(field, value) => handleFieldChange('settings', field, value)}
                   />
                 )}
+
+                {currentTab === 'status' && (
+                  <OrganizerStatusTab
+                    organizer={organizer}
+                    user={user}
+                  />
+                )}
+
               </Box>
             )}
           </Box>
         ) : (
-          <Typography color="textSecondary" gutterBottom sx={{ p: 2 }}>
-            No organizer information available.
+          <Typography color="text.secondary" sx={{ p: 2 }}>
+            No organizer profile found. Apply to become an Event Organizer first.
           </Typography>
         )}
+
       </Box>
     </Modal>
   );


### PR DESCRIPTION
## Summary
- **Profile tab** (default): Full Name, Short Name with lock/unlock/probe/suggest, Description, Contact info, Address, Images placeholder
- **Settings tab**: Organizer types (checkboxes + ⓘ tooltips, Event Organizer always-on) + Visibility switches (isEnabled / isVisible / wantRender each with ⓘ hover info) + Delegation placeholder
- **Status tab** (last): Read-only approval/active/visible status + collapsible Debug accordion (OrganizerID, UserID, Firebase UID)
- **Save always in AppBar** — disabled when clean or when Short Name is unlocked but not confirmed; tooltip explains why
- Cross-tab dirty tracking preserved; no more auto page-reload on save
- Old Status/Settings/Types/Name/Address/Delegated sub-components replaced (files left in place, no longer imported)

## Short Name unlock flow
1. Field starts locked (🔒) — read-only
2. Click lock → unlocks (🔓), field becomes editable
3. Type → alphanumeric mask, max 9 chars
4. Blur → fires `/shortname-check` → ✓ green / ✗ red inline
5. "Suggest a unique name" button → probe-retry from Full Name root
6. Save blocked (with tooltip) until Available confirmed
7. Re-locks automatically after successful save or manual re-lock click

## Test plan
- [ ] Open Organizer Settings → lands on Profile tab
- [ ] Short Name shows locked; click lock → unlocks, editable
- [ ] Type new short name, blur → availability check fires
- [ ] "Suggest" button fills in a unique available name
- [ ] Save disabled when short name unlocked but not checked
- [ ] Settings tab: types checkboxes save, visibility switches save
- [ ] Status tab: shows correct flags + debug IDs expand on click
- [ ] Save in header enables on any change, disables after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)