### PR TITLE
TIEMPO-445: fix spotlight rendering — empty [] is truthy, use length check

### DIFF
--- a/src/app/calendar/boston/page.js
+++ b/src/app/calendar/boston/page.js
@@ -254,7 +254,10 @@ const BostonCalendarPage = () => {
 
   // TIEMPO-388: Helper to get features for non-repeating events (direct event.features array)
   const getEventFeatureData = (event) => {
-    const features = event.extendedProps?.features || event.extendedProps?.spotlights;
+    // TIEMPO-445: length check — [] is truthy, would swallow populated spotlights
+    const rawF = event.extendedProps?.features;
+    const rawS = event.extendedProps?.spotlights;
+    const features = (rawF?.length ? rawF : rawS);
     if (!features || !Array.isArray(features) || features.length === 0) return null;
 
     const canceledFeature = features.find(f => f.type === 'canceled');

--- a/src/app/calendar/page.js
+++ b/src/app/calendar/page.js
@@ -360,9 +360,10 @@ const CalendarPage = () => {
 
   // TIEMPO-388: Helper to get features for non-repeating events (direct event.features array)
   const getEventFeatureData = (event) => {
-    // Check for direct features on the event (for non-repeating events)
-    // Support both 'features' and 'spotlights' field names for backward compatibility
-    const features = event.extendedProps?.features || event.extendedProps?.spotlights;
+    // TIEMPO-445: use length check — [] is truthy, so plain || would swallow a populated spotlights array
+    const rawF = event.extendedProps?.features;
+    const rawS = event.extendedProps?.spotlights;
+    const features = (rawF?.length ? rawF : rawS);
     if (!features || !Array.isArray(features) || features.length === 0) return null;
 
     // Check for canceled in features

--- a/src/app/components/Modals/ViewEvents/ViewEventDetailsBasic.js
+++ b/src/app/components/Modals/ViewEvents/ViewEventDetailsBasic.js
@@ -19,8 +19,10 @@ const ViewEventDetailsBasic = ({ eventDetails, overrideData }) => {
   // 2. Series spotlights: DJ, Instructor, Performer, Canceled only
   // 3. Override spotlights: All types (Orchestra, Note, Description, etc.)
   const overrideFeatures = overrideData?._overridePatch?.features || [];
-  const seriesFeatures = eventDetails?.extendedProps?.features ||
-                         eventDetails?.extendedProps?.spotlights || [];
+  // TIEMPO-445: length check — [] is truthy, so plain || hides a populated spotlights array
+  const rawF = eventDetails?.extendedProps?.features;
+  const rawS = eventDetails?.extendedProps?.spotlights;
+  const seriesFeatures = (rawF?.length ? rawF : rawS) || [];
 
   // Merge: start with override features, add series features that don't have an override
   const overrideTypes = new Set(overrideFeatures.map(f => f.type));

--- a/src/app/utils/transformEvents.js
+++ b/src/app/utils/transformEvents.js
@@ -118,9 +118,9 @@ export function transformEvents(events) {
         venueEndDisplay: event.venueEndDisplay || null,
         venueTZ: event.venueTZ || null,
         venueAbbr: event.venueAbbr || null,
-        // TIEMPO-388: Spotlights for non-repeating events
-        features: event.features || event.spotlights || [],
-        spotlights: event.spotlights || event.features || [],
+        // TIEMPO-445: use length check so an empty [] doesn't shadow a populated array
+        features:   (event.features?.length   ? event.features   : event.spotlights) || [],
+        spotlights: (event.spotlights?.length ? event.spotlights : event.features)   || [],
       },
     };
 


### PR DESCRIPTION
## Root cause
`[] || [{...}]` evaluates to `[]` in JavaScript — empty array is truthy. When the backend returns `features: []` and `spotlights: [{ type: 'performer', name: 'DOM' }]`, the `features || spotlights` pattern in the FE picked up the empty array and rendered nothing.

## Fixes (4 files)
- **transformEvents.js** — seeding `features`/`spotlights` into `extendedProps`
- **calendar/page.js** — `getEventFeatureData` (monthly + 8-week + list views)
- **calendar/boston/page.js** — same (calendar sync rule)
- **ViewEventDetailsBasic.js** — `seriesFeatures` merge in event detail view

All now use `(arr?.length ? arr : fallback) || []` instead of `arr || fallback || []`.

## Pending
Waiting on Fulton (TIEMPO-445) to confirm whether `/api/events` list projection includes `features`/`spotlights`. If those fields are projected out, calendar tiles will still show nothing until BE adds them — this FE fix covers the detail view deep-link path and makes the calendar tile path correct once BE sends the data.

## Test plan
- [ ] Open event 69f0d79dab0463a74c4dae20 detail view → performer:DOM and orchestra:BTWO appear as colored chips
- [ ] Calendar tile for that event shows `Perf: DOM` badge and `LIVE! Orch: BTWO` row
- [ ] Boston calendar same event (if visible) — same behavior
- [ ] No regression on events with no spotlights

🤖 Generated with [Claude Code](https://claude.com/claude-code)