### PR TITLE
TIEMPO-446: forBeginners replaces beginnerFriendly toggle + ?view= query param

### DIFF
--- a/src/app/beginner/page.js
+++ b/src/app/beginner/page.js
@@ -30,7 +30,8 @@ export default function BeginnerPage() {
 
     const appId = process.env.NEXT_PUBLIC_APPLICATION_ID || '1';
     const params = {
-      forBeginners: true,
+      view: 'beginner',       // TIEMPO-446: BE returns all forBeginners=true events
+      forBeginners: true,     // fallback for BE versions before TIEMPO-446 lands
       appId,
       limit: 500,
       start: dayjs().startOf('day').toISOString(),

--- a/src/app/components/Modals/CreateEvents/CreateEventDetailsBasic.js
+++ b/src/app/components/Modals/CreateEvents/CreateEventDetailsBasic.js
@@ -633,27 +633,8 @@ const CreateEventDetailsBasic = ({ eventData, setEventData, editMode = false, or
           </FormControl>
         </Grid>
 
-        {/* TIEMPO-401: Beginner-friendly flag (gates Beginner UX mode) */}
-        <Grid item xs={12} md={6}>
-          <FormControl fullWidth>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={Boolean(eventData.beginnerFriendly)}
-                  onChange={(e) => setEventData(prevData => ({ ...prevData, beginnerFriendly: e.target.checked }))}
-                />
-              }
-              label="Beginner-friendly event"
-            />
-            <Typography variant="caption" color="textSecondary" sx={{ ml: 4, mt: -0.5 }}>
-              Check if someone with zero tango experience can show up and feel welcome.
-            </Typography>
-          </FormControl>
-        </Grid>
-
-        {/* TIEMPO-408 + TIEMPO-440: forBeginners toggle with strict
-            client-side gate (Class/Workshop). Aligned with BE
-            BEGINNER_ELIGIBLE_CATEGORIES per CALBEAF-154. */}
+        {/* TIEMPO-446: forBeginners — organizer-authoritative flag.
+            beginnerFriendly is classifier-only and no longer shown here. */}
         <Grid item xs={12} md={6}>
           <Collapse in={FOR_BEGINNERS_ELIGIBLE.has(eventData.categoryFirst)} timeout={150}>
             <FormControl fullWidth>
@@ -665,17 +646,17 @@ const CreateEventDetailsBasic = ({ eventData, setEventData, editMode = false, or
                       onChange={(e) => setEventData(prevData => ({ ...prevData, forBeginners: e.target.checked }))}
                     />
                   }
-                  label="This event is designed for beginners"
+                  label="Beginner-only event"
                 />
                 <Tooltip
                   arrow
-                  title="Available for Classes, Workshops, and beginner-targeted Festivals. Switches off automatically if you change to a different category."
+                  title="Marks this event as beginner-only. It will appear in the Beginner tab and be excluded from the main calendar."
                 >
                   <HelpOutlineIcon fontSize="small" sx={{ color: 'text.secondary', cursor: 'help' }} />
                 </Tooltip>
               </Box>
               <Typography variant="caption" color="textSecondary" sx={{ ml: 4, mt: -0.5 }}>
-                Shown on the Beginner tab. Removed from the main (Local) calendar.
+                Appears in the Beginner tab only — not shown in the main calendar.
               </Typography>
             </FormControl>
           </Collapse>

--- a/src/app/hooks/useCalendarPage.js
+++ b/src/app/hooks/useCalendarPage.js
@@ -85,11 +85,12 @@ export const useCalendarPage = () => {
   // Use the updated useEvents hook with location preferences
   // Enable GeoLocationContext to get temporaryLocation for SET operations
   const { events, loading: eventsLoading, error: eventsError, noLocationSelected, refreshEvents } = useEvents({
-    startDate: datesSet?.start, 
+    startDate: datesSet?.start,
     endDate: datesSet?.end,
-    limit: 500, // Increase the limit to ensure we get all events
-    useGeoLocationContext: true, // Enable GeoLocationContext to get temporaryLocation
-    useLocationPreferences: true // Enable saved user preferences
+    limit: 500,
+    useGeoLocationContext: true,
+    useLocationPreferences: true,
+    view: 'main', // TIEMPO-446: exclude organizer-explicit forBeginner events from main calendar
   });
   
   // Initialize event operations

--- a/src/app/hooks/useEvents.js
+++ b/src/app/hooks/useEvents.js
@@ -125,7 +125,8 @@ export function useEvents({
   page = 1,
   limit = 100,
   useGeoLocationContext = true, // Flag to control whether to use GeoLocationContext
-  useLocationPreferences = false // Flag to use saved user preferences
+  useLocationPreferences = false, // Flag to use saved user preferences
+  view, // TIEMPO-446: 'main' | 'beginner' | undefined — passed to ?view= BE param
 } = {}) {
   const [eventsData, setEventsData] = useState({
     events: [],
@@ -255,6 +256,9 @@ export function useEvents({
         appId: process.env.NEXT_PUBLIC_APPLICATION_ID || '1',
         page,
         limit,
+        // TIEMPO-446: view=main excludes organizer-explicit forBeginner events;
+        // view=beginner returns only forBeginner events. Undefined = no filter.
+        ...(view && { view }),
       };
 
       // Format date parameters
@@ -384,7 +388,8 @@ export function useEvents({
     userRoles,
     selectedRole,
     includeAiGenerated,
-    currentLocation
+    currentLocation,
+    view, // TIEMPO-446
     // Removed config options and setState functions to prevent infinite loops
   ]);
 


### PR DESCRIPTION
## Summary
- **Form** (`CreateEventDetailsBasic`): removes `beginnerFriendly` checkbox (classifier-only, no organizer input). `forBeginners` toggle relabeled "Beginner-only event" with tooltip explaining it appears in Beginner tab and is excluded from main calendar. Category gate (Class/Workshop only) preserved.
- **`useEvents` hook**: new `view` param (`'main'` | `'beginner'` | undefined) → passed as `?view=` query string to BE
- **`useCalendarPage`**: passes `view: 'main'` — once Fulton's BE ships, main calendar automatically excludes organizer-explicit beginner-only events
- **`beginner/page.js`**: sends both `view: 'beginner'` AND `forBeginners: true` — belt+suspenders until BE is ready

## Behavior during BE transition
- Before Fulton ships `?view=` support: calendar behavior unchanged (BE ignores unknown param), beginner page still works via `forBeginners: true` fallback
- After Fulton ships: main calendar excludes organizer `forBeginners` events; beginner page returns all `forBeginners=true` events

## BE work needed (Fulton — separate CALBEAF ticket)
1. `forBeginners` classifier skip for `isDiscovered !== true` events
2. `?view=main` and `?view=beginner` filter logic on `/api/events`

## Test plan
- [ ] Create Class or Workshop event → "Beginner-only event" checkbox shows; `beginnerFriendly` checkbox gone
- [ ] Non-Class category → Beginner-only checkbox hidden (Collapse gate)
- [ ] `forBeginners: true` saves correctly in event payload
- [ ] Main calendar request includes `?view=main` in network tab
- [ ] Beginner page request includes `?view=beginner&forBeginners=true`
- [ ] No visible regression in calendar event display

🤖 Generated with [Claude Code](https://claude.com/claude-code)