### PR TITLE
TIEMPO-446 cleanup: drop forBeginners fallback, ?view=beginner is sufficient

### DIFF
--- a/src/app/beginner/page.js
+++ b/src/app/beginner/page.js
@@ -30,8 +30,7 @@ export default function BeginnerPage() {
 
     const appId = process.env.NEXT_PUBLIC_APPLICATION_ID || '1';
     const params = {
-      view: 'beginner',       // TIEMPO-446: BE returns all forBeginners=true events
-      forBeginners: true,     // fallback for BE versions before TIEMPO-446 lands
+      view: 'beginner', // TIEMPO-446: BE returns all forBeginners=true events
       appId,
       limit: 500,
       start: dayjs().startOf('day').toISOString(),


### PR DESCRIPTION
CALBEAF-156 confirmed the new ?view= param is purely additive (no fallback needed). Removes the redundant forBeginners:true from beginner page — clean signal only.