### PR TITLE
fix(forBeginners): Boston route must not inherit view=main filter (TIEMPO-446)

### DIFF
--- a/src/app/calendar/page.js
+++ b/src/app/calendar/page.js
@@ -108,7 +108,7 @@ const CalendarPage = () => {
     eventsLoading,
     // TIEMPO-362: Pending occurrence action from submenu
     pendingOccurrenceAction,
-  } = useCalendarPage();
+  } = useCalendarPage({ view: 'main' });
 
   // TIEMPO-408 T2: Local tab excludes forBeginners=true events — they live
   // exclusively on /beginner. Boston and other callers keep all events.

--- a/src/app/hooks/useCalendarPage.js
+++ b/src/app/hooks/useCalendarPage.js
@@ -21,7 +21,7 @@ import { AuthContext } from '@/contexts/AuthContext';
 import { listOfAllRoles } from '@/utils/masterData';
 import { regionalOrganizerEvent } from '@/utils/RegionalOrganizerEvent';
 
-export const useCalendarPage = () => {
+export const useCalendarPage = ({ view } = {}) => {
   // TIEMPO-256: URL params for deep linking
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -90,7 +90,7 @@ export const useCalendarPage = () => {
     limit: 500,
     useGeoLocationContext: true,
     useLocationPreferences: true,
-    view: 'main', // TIEMPO-446: exclude organizer-explicit forBeginner events from main calendar
+    view, // TIEMPO-446: caller passes 'main' for main calendar; undefined = no filter
   });
   
   // Initialize event operations


### PR DESCRIPTION
useCalendarPage now accepts { view }. Main calendar passes view='main'; Boston passes nothing (no filter, sees all events including forBeginner). One-line caller change each.