### PR TITLE
fix(share): rename Share → Copy / Share, remove URL bar in event detail modal

### DIFF
--- a/src/app/components/Modals/ViewEvents/ViewEventDetailModal.js
+++ b/src/app/components/Modals/ViewEvents/ViewEventDetailModal.js
@@ -563,14 +563,13 @@ const ViewEventDetailModal = ({ open, onClose, eventDetails, onEventUpdated, ini
   // TIEMPO-362: Show OccurrenceActionMenu for recurring events
   const headerActions = (
     <>
-      {/* TIEMPO-256: Share button - visible to all users */}
       <Button
         onClick={handleShareClick}
         size="small"
         startIcon={<ShareIcon fontSize="small" />}
         sx={{ fontSize: '0.875rem' }}
       >
-        Share
+        Copy / Share
       </Button>
 
       {/* TIEMPO-362: Actions removed from modal - now in calendar submenu */}
@@ -625,32 +624,6 @@ const ViewEventDetailModal = ({ open, onClose, eventDetails, onEventUpdated, ini
             actions={headerActions}
           />
 
-          {/* TIEMPO-256: Shareable link display - dynamic domain */}
-          {eventDetails?.extendedProps?._id && (
-            <Box
-              sx={{
-                px: isMobile ? 2 : 3,
-                py: 0.5,
-                bgcolor: 'grey.100',
-                borderBottom: '1px solid',
-                borderColor: 'divider',
-              }}
-            >
-              <Typography
-                variant="caption"
-                color="text.secondary"
-                sx={{
-                  fontFamily: 'monospace',
-                  fontSize: '0.7rem',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 0.5,
-                }}
-              >
-                Share: {typeof window !== 'undefined' ? window.location.host : 'tangotiempo.com'}/event/{eventDetails.extendedProps._id}
-              </Typography>
-            </Box>
-          )}
 
           {/* Modal Content */}
           <Box sx={{


### PR DESCRIPTION
Button label: 'Share' → 'Copy / Share'. Removes the monospace URL bar that showed below the header — it was redundant and confusing since the button already copies the link.