### PR TITLE
chore: bump version 1.23.0 → 1.24.0 for PROD bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",


### PR DESCRIPTION
Version bump only — required before TEST→PROD promotion per branching strategy.