### PR TITLE
feat(about): static SEO About page — free global tango calendar, two audiences

### DIFF
--- a/src/app/about/page.js
+++ b/src/app/about/page.js
@@ -1,311 +1,219 @@
-// @/about/page.js
+// Static server-rendered About page — optimised for Google indexing.
+// No 'use client' so Next.js pre-renders full HTML and metadata is picked up.
 
-'use client';
-import React from 'react';
 import Link from 'next/link';
-import { 
-  Button, 
-  Box, 
-  Container, 
-  Typography, 
-  Paper,
-  IconButton,
-  useTheme,
-  useMediaQuery,
-  List,
-  ListItem,
-  ListItemText
-} from '@mui/material';
-import FacebookIcon from '@mui/icons-material/Facebook';
-import EmailIcon from '@mui/icons-material/Email';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+import PropTypes from 'prop-types';
+import { Box, Container, Typography, Button, Divider, Paper, Grid } from '@mui/material';
+import ExploreIcon from '@mui/icons-material/Explore';
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import PeopleIcon from '@mui/icons-material/People';
+import EditCalendarIcon from '@mui/icons-material/EditCalendar';
+import PublicIcon from '@mui/icons-material/Public';
 
-export default function About() {
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+export const metadata = {
+  title: 'About TangoTiempo — Free Global Argentine Tango Calendar',
+  description:
+    'TangoTiempo is a free global calendar for Argentine tango events. Find local milongas, practicas, workshops, and travel-worthy festivals near you or around the world. Organizers can list events for free.',
+  openGraph: {
+    title: 'TangoTiempo — Free Global Argentine Tango Calendar',
+    description:
+      'Find tango events near you or travel-worthy festivals worldwide. Free for dancers. Free for organizers.',
+    url: 'https://tangotiempo.com/about',
+    siteName: 'TangoTiempo',
+    type: 'website',
+  },
+};
 
+const Section = ({ icon, heading, children }) => (
+  <Box sx={{ mb: 5 }}>
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.5 }}>
+      {icon}
+      <Typography variant="h5" component="h2" fontWeight="bold">
+        {heading}
+      </Typography>
+    </Box>
+    {children}
+  </Box>
+);
+
+Section.propTypes = {
+  icon: PropTypes.node.isRequired,
+  heading: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default function AboutPage() {
   return (
-    <Container maxWidth="lg" sx={{ py: 2, px: isMobile ? 1 : 3 }}>
-      {/* Mobile-friendly header with back button */}
-      <Box sx={{ mb: 3, display: 'flex', alignItems: 'center', gap: 1 }}>
-        <Link href="/calendar" passHref>
-          <IconButton size="small">
-            <ArrowBackIcon />
-          </IconButton>
-        </Link>
-        <Box sx={{ flexGrow: 1, textAlign: isMobile ? 'left' : 'center' }}>
-          <Typography variant={isMobile ? 'h4' : 'h3'} component="h1" gutterBottom>
-            Welcome to Tango Tiempo
-          </Typography>
-          <Typography variant={isMobile ? 'body1' : 'h6'} color="text.secondary">
-            America&apos;s Argentine Tango Calendar
-          </Typography>
-        </Box>
-      </Box>
+    <Container maxWidth="md" sx={{ py: { xs: 4, md: 6 } }}>
 
-      {/* Main content */}
-      <Paper sx={{ p: isMobile ? 2 : 4, mb: 4 }}>
-        <Typography variant="body1" paragraph>
-          Tango Tiempo is the free national hub for Argentine tango events. Whether you&apos;re dancing in New Mexico, 
-          attending festivals in San Francisco, teaching in Boston, or organizing events in Chicago — this is your place. 
-          Our platform is <strong>Live</strong>, <strong>Free</strong>, and managed by tango organizers across the 
-          United States. It features <strong>AI discovery</strong> to help dancers find the best tango experiences 
-          anywhere in the U.S.
+      {/* ── Hero ─────────────────────────────────────────────────────────── */}
+      <Box sx={{ textAlign: 'center', mb: 6 }}>
+        <Typography variant="h3" component="h1" fontWeight="bold" gutterBottom>
+          TangoTiempo
         </Typography>
-
-        <Typography variant="body1" paragraph>
-          We&apos;re actively engaging tango organizers throughout the United States, expanding city by city. 
-          If you host any type of tango events (festivals, milongas, practicas, etc.), are a traveling teacher 
-          &quot;Maestro&quot; or tango performer, have a local tango band, or teach Argentine tango — you belong 
-          on this site. Just login and apply. It&apos;s always free to search and find events (with some upcoming 
-          paid services like targeted event promotions and other advanced features). We want to make tango easier 
-          to find, attend, and support. Just click the apply button. Here&apos;s a little secret: it&apos;s 
-          automatically approved, but we do use AI to verify events follow our tango guidelines.
+        <Typography variant="h6" color="text.secondary" sx={{ maxWidth: 560, mx: 'auto', mb: 3 }}>
+          The free global calendar for Argentine tango — helping dancers find events
+          and organizers share them with the world.
         </Typography>
-
-        <Typography variant="h6" gutterBottom sx={{ mt: 3 }}>
-          Want to get in touch? Connect with us through:
-        </Typography>
-        
-        <Box display="flex" flexDirection={isMobile ? "column" : "row"} justifyContent="center" gap={2} mb={3}>
+        <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center', flexWrap: 'wrap' }}>
           <Button
+            component={Link}
+            href="/calendar"
             variant="contained"
-            startIcon={<FacebookIcon />}
-            sx={{ backgroundColor: '#1877F2', '&:hover': { backgroundColor: '#145dbf' } }}
-            href="https://www.facebook.com/tangotiempo"
-            target="_blank"
-            rel="noopener noreferrer"
-            fullWidth={isMobile}
-          >
-            Facebook Messenger
-          </Button>
-          <Button
-            variant="contained"
-            startIcon={<EmailIcon />}
-            sx={{ backgroundColor: '#EA4335', '&:hover': { backgroundColor: '#d33b2c' } }}
-            href="mailto:admin@tangotiempo.com"
-            fullWidth={isMobile}
-          >
-            Email Admin
-          </Button>
-        </Box>
-
-        <Box display="flex" flexDirection="column" alignItems="center" gap={2}>
-          <Link href="/calendar" passHref>
-            <Button 
-              variant="contained" 
-              color="primary"
-              startIcon={<CalendarTodayIcon />}
-              size="large"
-            >
-              View the Live Calendar
-            </Button>
-          </Link>
-        </Box>
-      </Paper>
-
-      {/* What Makes Us Different */}
-      <Paper sx={{ p: isMobile ? 2 : 4, mb: 4 }}>
-        <Typography variant="h5" gutterBottom>
-          What Makes Tango Tiempo Different?
-        </Typography>
-        <List>
-          <ListItem>
-            <ListItemText 
-              primary="Free & Always Will Be"
-              secondary="Our core calendar is free to use, with no strings attached."
-            />
-          </ListItem>
-          <ListItem>
-            <ListItemText 
-              primary="Nationwide Scope"
-              secondary="Discover milongas, practicas, classes, and festivals coast to coast."
-            />
-          </ListItem>
-          <ListItem>
-            <ListItemText 
-              primary="AI Discovery"
-              secondary="Smart filters and regional views help you find what you love."
-            />
-          </ListItem>
-          <ListItem>
-            <ListItemText 
-              primary="Mobile-First"
-              secondary="Use it from your phone, your laptop, or wherever you check your dance plans."
-            />
-          </ListItem>
-        </List>
-      </Paper>
-
-      {/* Mission */}
-      <Paper sx={{ p: isMobile ? 2 : 4, mb: 4 }}>
-        <Typography variant="h5" gutterBottom>
-          Our Mission
-        </Typography>
-        <Typography variant="body1" paragraph>
-          Our mission is to unite and strengthen the U.S. tango community by providing a comprehensive, 
-          accessible, and free platform for discovering and sharing tango events. We believe that by 
-          connecting dancers, organizers, and venues across the country, we can help Argentine tango 
-          thrive in every corner of America.
-        </Typography>
-        <Typography variant="body1" paragraph>
-          Tango Tiempo is built to unite the U.S. tango community. From small practicas to national 
-          encuentros, we&apos;re here to support connection through dance.
-        </Typography>
-      </Paper>
-
-      {/* About Our Logo */}
-      <Paper sx={{ p: isMobile ? 2 : 4, mb: 4 }}>
-        <Typography variant="h5" gutterBottom>
-          About Our Logo
-        </Typography>
-        <Typography variant="body1" paragraph>
-          The Tango Tiempo logo represents the timeless connection between dance partners and the 
-          rhythmic pulse of tango music. The flowing design captures the elegance and passion of 
-          Argentine tango, while the modern aesthetic reflects our commitment to bringing this 
-          traditional dance into the digital age. Our logo embodies the spirit of community, 
-          movement, and the shared moments that make tango special.
-        </Typography>
-        <Typography variant="body1">
-          We do not sell your data. We are not ad-driven. We just believe tango deserves better tools.
-        </Typography>
-      </Paper>
-
-      {/* AI-Guild and HDTS section */}
-      <Paper 
-        sx={{ 
-          p: 3, 
-          mb: 3, 
-          backgroundColor: 'primary.main',
-          color: 'white',
-          borderRadius: 2,
-          boxShadow: 3
-        }}
-      >
-        <Typography variant="h5" gutterBottom sx={{ textAlign: 'center' }}>
-          Built with AI Technology
-        </Typography>
-        
-        <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 3 }}>
-          {/* AI-Guild Section */}
-          <Box sx={{ flex: 1, display: 'flex', alignItems: 'flex-start', gap: 2 }}>
-            <Box
-              component="img"
-              src="/AI GUILD Base.jpeg"
-              alt="AI Guild"
-              sx={{
-                width: { xs: 60, sm: 80 },
-                height: { xs: 60, sm: 80 },
-                borderRadius: 1,
-                objectFit: 'cover'
-              }}
-            />
-            <Box sx={{ flex: 1 }}>
-              <Typography variant="h6" component="h3" gutterBottom>
-                100% AI-Built Application
-              </Typography>
-              <Typography variant="body2" sx={{ opacity: 0.95 }}>
-                This entire application is built by AI, with no human-written code. The AI-Guild 
-                handles all development tasks: coding, merging, GitHub operations, JIRA tracking, 
-                dashboarding, error handling, linting, testing, CI/CD, authentication, and promotion. 
-                Humans interact through commands and approvals while the Guild performs all technical implementation.
-              </Typography>
-            </Box>
-          </Box>
-
-          {/* HDTS Section */}
-          <Box sx={{ flex: 1, display: 'flex', alignItems: 'flex-start', gap: 2 }}>
-            <Box
-              component="img"
-              src="/HDTS.jpg"
-              alt="HDTS LLC"
-              sx={{
-                width: { xs: 60, sm: 80 },
-                height: { xs: 60, sm: 80 },
-                borderRadius: 1,
-                objectFit: 'contain',
-                backgroundColor: 'white',
-                p: 0.5
-              }}
-            />
-            <Box sx={{ flex: 1 }}>
-              <Typography variant="h6" component="h3" gutterBottom>
-                <Box 
-                  component="a" 
-                  href="https://www.hdtsllc.com/" 
-                  target="_blank" 
-                  rel="noopener noreferrer"
-                  sx={{ 
-                    color: 'inherit',
-                    textDecoration: 'underline',
-                    '&:hover': { textDecoration: 'none' }
-                  }}
-                >
-                  HDTSllc.com
-                </Box>
-              </Typography>
-              <Typography variant="body2" sx={{ opacity: 0.95 }}>
-                Half Way Down the Stairs, LLC provides AI consulting and development services. 
-                Specializing in generative AI, React-based AI applications, and document processing systems, 
-                HDTS acts as your temporary AI team member for strategic implementation and custom solutions.
-              </Typography>
-            </Box>
-          </Box>
-        </Box>
-        
-        {/* Links */}
-        <Box sx={{ mt: 2, display: 'flex', gap: 2, flexWrap: 'wrap', justifyContent: 'center' }}>
-          <Box 
-            component="a"
-            href="https://www.linkedin.com/in/toby-balsley-ea-ai-genai/"
-            target="_blank"
-            rel="noopener noreferrer"
-            sx={{
-              color: 'white',
-              textDecoration: 'none',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 0.5,
-              fontSize: '0.875rem',
-              '&:hover': { textDecoration: 'underline' }
-            }}
-          >
-            🔗 Toby Balsley on LinkedIn
-          </Box>
-          <Box 
-            component="a"
-            href="https://www.hdtsllc.com/"
-            target="_blank"
-            rel="noopener noreferrer"
-            sx={{
-              color: 'white',
-              textDecoration: 'none',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 0.5,
-              fontSize: '0.875rem',
-              '&:hover': { textDecoration: 'underline' }
-            }}
-          >
-            🌐 Visit HDTSllc.com
-          </Box>
-        </Box>
-      </Paper>
-
-      {/* Return to Calendar Button */}
-      <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4, mb: 2 }}>
-        <Link href="/calendar" passHref>
-          <Button 
-            variant="contained" 
-            color="primary"
-            startIcon={<CalendarTodayIcon />}
             size="large"
+            startIcon={<CalendarMonthIcon />}
           >
-            Return to Calendar
+            See Local Events
           </Button>
-        </Link>
+          <Button
+            component={Link}
+            href="/explore"
+            variant="outlined"
+            size="large"
+            startIcon={<ExploreIcon />}
+          >
+            Explore the World
+          </Button>
+        </Box>
       </Box>
+
+      <Divider sx={{ mb: 5 }} />
+
+      {/* ── What we are ──────────────────────────────────────────────────── */}
+      <Section
+        icon={<PublicIcon color="primary" sx={{ fontSize: '2rem' }} />}
+        heading="A free, open calendar for the tango world"
+      >
+        <Typography variant="body1" paragraph>
+          TangoTiempo is a free, community-powered platform dedicated to Argentine tango events —
+          milongas, practicas, classes, workshops, festivals, and encuentros. Whether you dance in
+          your home city or follow the tango trail across continents, TangoTiempo helps you stay
+          informed about what is happening and where.
+        </Typography>
+        <Typography variant="body1" paragraph>
+          We believe tango is for everyone. Our platform is free to use for dancers, free to list
+          events for organizers, and open to the global tango community. No paywalls. No hidden fees.
+          Always free.
+        </Typography>
+      </Section>
+
+      {/* ── For dancers ──────────────────────────────────────────────────── */}
+      <Section
+        icon={<PeopleIcon color="primary" sx={{ fontSize: '2rem' }} />}
+        heading="For dancers — find your next tango"
+      >
+        <Typography variant="body1" paragraph>
+          Use the <strong>Local</strong> calendar to browse milongas, practicas, and classes near
+          you. Set your city and see everything happening this week, this month, or further ahead.
+          Events are updated by organizers in real time.
+        </Typography>
+        <Typography variant="body1" paragraph>
+          Ready to travel? The <strong>Explore</strong> view surfaces travel-worthy events —
+          multi-day festivals, marathons, and encuentros from around the world — so you can plan
+          your next tango trip months in advance.
+        </Typography>
+        <Typography variant="body1" paragraph>
+          New to tango? The <strong>Beginner</strong> tab shows events specifically designed for
+          newcomers — classes, introductory practicas, and welcoming social dances where you can
+          take your first steps.
+        </Typography>
+        <Button component={Link} href="/calendar" variant="outlined" sx={{ mt: 1 }}>
+          Open the Calendar
+        </Button>
+      </Section>
+
+      {/* ── For organizers ───────────────────────────────────────────────── */}
+      <Section
+        icon={<EditCalendarIcon color="primary" sx={{ fontSize: '2rem' }} />}
+        heading="For organizers — list your events for free"
+      >
+        <Typography variant="body1" paragraph>
+          If you run milongas, teach classes, host festivals, or organize any tango event — your
+          events belong on TangoTiempo. Listing is completely free and takes only a few minutes.
+          Apply once, then create, edit, and manage your events whenever you need.
+        </Typography>
+
+        <Paper variant="outlined" sx={{ p: 3, mb: 2 }}>
+          <Grid container spacing={2}>
+            {[
+              ['Apply once', 'Create a free organizer account in minutes. Automatically approved.'],
+              ['Full control', 'Create, edit, cancel, and delete your events at any time.'],
+              ['Recurring events', 'Set up weekly milongas and practicas once — they repeat automatically.'],
+              ['Spotlights', 'Highlight guest DJs, visiting teachers, and live orchestras on your event listing.'],
+              ['Always free', 'No listing fees, no subscription, no commission. Free forever.'],
+            ].map(([title, desc]) => (
+              <Grid item xs={12} sm={6} key={title}>
+                <Typography variant="subtitle2" fontWeight="bold">{title}</Typography>
+                <Typography variant="body2" color="text.secondary">{desc}</Typography>
+              </Grid>
+            ))}
+          </Grid>
+        </Paper>
+
+        <Button
+          component={Link}
+          href="/organizers/apply"
+          variant="contained"
+          size="large"
+          startIcon={<EditCalendarIcon />}
+        >
+          Apply as an Organizer — It&apos;s Free
+        </Button>
+      </Section>
+
+      {/* ── AI discovery ─────────────────────────────────────────────────── */}
+      <Section
+        icon={<AutoAwesomeIcon color="primary" sx={{ fontSize: '2rem' }} />}
+        heading="AI-powered event discovery"
+      >
+        <Typography variant="body1" paragraph>
+          Tango happens everywhere — not just where organizers have found us yet. TangoTiempo uses
+          AI to scan the web and discover tango events from community groups, social media, and local
+          listings. Discovered events are clearly labelled so you always know the source.
+        </Typography>
+        <Typography variant="body1" paragraph>
+          AI-discovered events complement organizer-posted listings and help ensure the calendar is
+          as complete as possible. When an organizer claims their AI-discovered event, it becomes a
+          fully managed listing under their control.
+        </Typography>
+      </Section>
+
+      {/* ── Mission ──────────────────────────────────────────────────────── */}
+      <Section
+        icon={<PublicIcon color="primary" sx={{ fontSize: '2rem' }} />}
+        heading="Our mission"
+      >
+        <Typography variant="body1" paragraph>
+          Argentine tango is a living tradition shared across hundreds of cities and dozens of
+          countries. We built TangoTiempo to make the global tango community more informed,
+          connected, and accessible — for dancers at every level, and organizers of every size.
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          TangoTiempo is free for the world. Always.
+        </Typography>
+      </Section>
+
+      <Divider sx={{ mb: 4 }} />
+
+      {/* ── Footer CTAs ──────────────────────────────────────────────────── */}
+      <Box sx={{ textAlign: 'center' }}>
+        <Typography variant="h6" gutterBottom>
+          Ready to start?
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center', flexWrap: 'wrap' }}>
+          <Button component={Link} href="/calendar" variant="contained" startIcon={<CalendarMonthIcon />}>
+            Find Events Near Me
+          </Button>
+          <Button component={Link} href="/explore" variant="outlined" startIcon={<ExploreIcon />}>
+            Explore Global Events
+          </Button>
+          <Button component={Link} href="/organizers/apply" variant="outlined" startIcon={<EditCalendarIcon />}>
+            List My Events Free
+          </Button>
+        </Box>
+      </Box>
+
     </Container>
   );
 }


### PR DESCRIPTION
## Summary
Complete rewrite of /about as a Next.js Server Component (no 'use client') so Google receives pre-rendered HTML and picks up the metadata.

## What's on the page
- **Hero**: tagline + two CTAs (See Local Events / Explore the World)
- **What we are**: free, global, community-powered
- **For dancers**: local calendar, Explore travel-worthy events, Beginner tab — with links
- **For organizers**: apply free, full CRUD, recurring events, spotlights, always free — grid of 5 feature bullets + Apply CTA
- **AI discovery**: explains AI-found events, labels, organizer claiming
- **Mission**: tango for everyone, always free
- **Footer CTAs**: three buttons linking to calendar / explore / apply

## SEO
- `export const metadata` with title, description, og:title, og:description, og:url
- H1 + H2 heading hierarchy
- Server-rendered — Googlebot gets full HTML, no JS needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)