### PR TITLE
chore: bump version 1.25.0 for PROD bundle (TIEMPO-450)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
- "version": "1.24.0",
+ "version": "1.25.0",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",


### PR DESCRIPTION
Version bump only — branding P1+P2 ready for PROD promotion.