### PR TITLE
feat(seo): city/country landing pages /tango/[country]/[city] (TIEMPO-450)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,6 +286,8 @@ START OF FILE: YBOTBOT-BRANCH-AUTONOMY.md
 1. READ `/Users/tobybalsley/MyDocs/AppDev/MasterCalendar/docs/PROD-DEPLOY-PROTECTION.md`
 2. Follow DEPLOY-PROD confirmation protocol
 3. No exceptions - "yes" and "sure" are NOT valid confirmations
+4. NEVER run `gh pr merge` — ANY flags. DEPLOY-PROD only authorizes creating the PR. After creating it: post the URL, STOP, and wait for Toby to confirm "merged" in GitHub UI.
+5. `gh pr merge --admin` additionally requires `ADMIN-OVERRIDE` phrase (emergency only)
 
 **These reads are NOT optional.** Operations without reading the relevant documents first are prohibited.
 

--- a/src/app/tango/[country]/[city]/page.js
+++ b/src/app/tango/[country]/[city]/page.js
@@ -1,0 +1,256 @@
+// /tango/[country]/[city] — City-level tango SEO landing page
+// Adaptive: "organizer-acquisition" mode (<7 organizers) vs "user-acquisition" (≥7)
+// Data: Fulton's /api/seo/city-page endpoint (single fetch, pre-assembled)
+// Server Component, ISR 1hr, generateStaticParams from geo-summary
+
+import Link from 'next/link';
+import { Box, Container, Typography, Button, Chip, Avatar, Grid, Card, CardContent } from '@mui/material';
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
+import PersonIcon from '@mui/icons-material/Person';
+import PlaceIcon from '@mui/icons-material/Place';
+import { getApiBaseUrl } from '@/utils/apiUrlResolver';
+import { notFound } from 'next/navigation';
+
+const API_URL = getApiBaseUrl();
+const BASE_URL = 'https://tangotiempo.com';
+
+async function getGeoSummary() {
+  try {
+    const res = await fetch(`${API_URL}/api/seo/geo-summary?appId=1`, { next: { revalidate: 3600 } });
+    if (!res.ok) return null;
+    return res.json();
+  } catch { return null; }
+}
+
+async function getCityPage(countrySlug, citySlug) {
+  try {
+    const res = await fetch(
+      `${API_URL}/api/seo/city-page?appId=1&regionSlug=${countrySlug}&citySlug=${citySlug}`,
+      { next: { revalidate: 3600 } }
+    );
+    if (!res.ok) return null;
+    return res.json();
+  } catch { return null; }
+}
+
+export async function generateStaticParams() {
+  const summary = await getGeoSummary();
+  if (!summary) return [];
+  return summary.cities.map((c) => ({ country: c.countrySlug, city: c.citySlug }));
+}
+
+export async function generateMetadata({ params }) {
+  const data = await getCityPage(params.country, params.city);
+  if (!data) return {};
+  const { city, summary } = data;
+  return {
+    title: `Argentine Tango Events in ${city.cityName}, ${city.countryName} | TangoTiempo`,
+    description: `Find milongas, practicas, workshops, and tango classes in ${city.cityName}. ${summary.futureEventCount} upcoming events. Free Argentine tango calendar.`,
+    openGraph: {
+      title: `Tango Events in ${city.cityName}, ${city.countryName} | TangoTiempo`,
+      description: `Discover Argentine tango in ${city.cityName} — milongas, practicas, classes, and workshops near you.`,
+      url: `${BASE_URL}/tango/${params.country}/${params.city}`,
+      siteName: 'TangoTiempo',
+      type: 'website',
+      images: [{ url: `${BASE_URL}/brand/Brand-MCB-Light-V-WIDE-1.png`, width: 1200 }],
+    },
+    alternates: { canonical: `${BASE_URL}/tango/${params.country}/${params.city}` },
+    robots: { index: true, follow: true },
+  };
+}
+
+export default async function CityPage({ params }) {
+  const data = await getCityPage(params.country, params.city);
+  if (!data) notFound();
+
+  const { city, mode, summary, categories, topOrganizers, topEvents, cta, mapCenterUrl, nearbyCities, classifierLabels } = data;
+  const isAcquisition = mode === 'organizer-acquisition';
+
+  // Event structured data
+  const allTopEvents = [...(topEvents.travelWorthy || []), ...(topEvents.forBeginners || [])];
+  const eventSchema = {
+    '@context': 'https://schema.org',
+    '@graph': allTopEvents.map((e) => ({
+      '@type': 'Event',
+      name: e.title || e.name,
+      startDate: e.startDate,
+      location: {
+        '@type': 'Place',
+        name: e.venueName || city.cityName,
+        address: { '@type': 'PostalAddress', addressLocality: city.cityName, addressRegion: city.countryName, addressCountry: 'US' },
+      },
+      organizer: { '@type': 'Organization', name: e.ownerOrganizerName || 'TangoTiempo', url: BASE_URL },
+      image: e.featuredImage || `${BASE_URL}/brand/Brand-Simple-Light-WIDE-1.png`,
+      url: `${BASE_URL}/calendar`,
+      eventStatus: 'https://schema.org/EventScheduled',
+      eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+    })),
+  };
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(eventSchema) }} />
+
+      {/* Brand hero */}
+      <Box
+        component="img"
+        src="/brand/Brand-MCB-Light-V-WIDE-1.png"
+        alt="TangoTiempo — Move. Connect. Belong."
+        sx={{ width: '100%', maxHeight: { xs: 100, md: 140 }, objectFit: 'cover', borderRadius: 2, mb: 3 }}
+      />
+
+      <Grid container spacing={4}>
+        {/* Main column */}
+        <Grid item xs={12} md={8}>
+
+          {/* Hero */}
+          <Box sx={{ mb: 4 }}>
+            <Typography variant="h3" component="h1" fontWeight="bold" gutterBottom>
+              Argentine Tango in {city.cityName}
+            </Typography>
+            <Typography variant="h6" color="text.secondary" sx={{ mb: 2 }}>
+              {summary.futureEventCount} upcoming events · {city.cityName}, {city.countryName}
+            </Typography>
+            <Button component={Link} href={mapCenterUrl} variant="contained" startIcon={<CalendarMonthIcon />} size="large">
+              Browse {city.cityName} Events
+            </Button>
+          </Box>
+
+          {/* Adaptive CTA block */}
+          <Box sx={{ bgcolor: 'primary.main', color: 'primary.contrastText', p: 3, borderRadius: 2, mb: 4, textAlign: 'center' }}>
+            <Typography variant="h6" fontWeight="bold" gutterBottom>{cta.headline}</Typography>
+            <Typography variant="body1" sx={{ mb: 2, opacity: 0.9 }}>{cta.body}</Typography>
+            {isAcquisition ? (
+              <Button component={Link} href={cta.applyPath} variant="contained"
+                sx={{ bgcolor: 'white', color: 'primary.main', '&:hover': { bgcolor: 'grey.100' } }}>
+                {cta.applyLabel}
+              </Button>
+            ) : (
+              <Button component={Link} href={cta.loginPath} variant="contained"
+                sx={{ bgcolor: 'white', color: 'primary.main', '&:hover': { bgcolor: 'grey.100' } }}>
+                {cta.loginLabel}
+              </Button>
+            )}
+          </Box>
+
+          {/* Event counts by category */}
+          {categories?.length > 0 && (
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 4 }}>
+              {categories.map((cat) => (
+                <Chip key={cat.name} label={`${cat.label}: ${cat.count}`} variant="outlined" />
+              ))}
+            </Box>
+          )}
+
+          {/* Travel-worthy events */}
+          {topEvents.travelWorthy?.length > 0 && (
+            <Box sx={{ mb: 4 }}>
+              <Typography variant="h5" fontWeight="bold" gutterBottom>
+                {classifierLabels.travelWorthy} in {city.cityName}
+              </Typography>
+              {topEvents.travelWorthy.map((e) => (
+                <Box key={e._id || e.name} sx={{ py: 1.5, borderBottom: '1px solid', borderColor: 'divider' }}>
+                  <Typography variant="subtitle1" fontWeight="bold">{e.title || e.name}</Typography>
+                  <Typography variant="body2" color="text.secondary">{e.venueName}</Typography>
+                </Box>
+              ))}
+            </Box>
+          )}
+
+          {/* Beginner-friendly events */}
+          {topEvents.forBeginners?.length > 0 && (
+            <Box sx={{ mb: 4 }}>
+              <Typography variant="h5" fontWeight="bold" gutterBottom>
+                {classifierLabels.forBeginners} in {city.cityName}
+              </Typography>
+              {topEvents.forBeginners.map((e) => (
+                <Box key={e._id || e.name} sx={{ py: 1.5, borderBottom: '1px solid', borderColor: 'divider' }}>
+                  <Typography variant="subtitle1" fontWeight="bold">{e.title || e.name}</Typography>
+                  <Typography variant="body2" color="text.secondary">{e.venueName}</Typography>
+                </Box>
+              ))}
+            </Box>
+          )}
+
+          {/* Organizers */}
+          {topOrganizers?.length > 0 && (
+            <Box sx={{ mb: 4 }}>
+              <Typography variant="h5" fontWeight="bold" gutterBottom>
+                {isAcquisition ? `Organizers Already in ${city.cityName}` : `Tango Organizers in ${city.cityName}`}
+              </Typography>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+                {topOrganizers.map((org) => (
+                  <Box key={org.organizerId} component={Link} href={`/organizers/${org.shortName}`}
+                    sx={{ display: 'flex', alignItems: 'center', gap: 1, textDecoration: 'none', color: 'inherit',
+                      p: 1.5, border: '1px solid', borderColor: 'divider', borderRadius: 1, '&:hover': { bgcolor: 'action.hover' } }}>
+                    <Avatar sx={{ width: 28, height: 28 }}><PersonIcon fontSize="small" /></Avatar>
+                    <Typography variant="body2" fontWeight="bold">{org.name}</Typography>
+                  </Box>
+                ))}
+              </Box>
+            </Box>
+          )}
+        </Grid>
+
+        {/* Sidebar */}
+        <Grid item xs={12} md={4}>
+
+          {/* Summary stats */}
+          <Card variant="outlined" sx={{ mb: 3 }}>
+            <CardContent>
+              <Typography variant="h6" fontWeight="bold" gutterBottom>At a glance</Typography>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                <Typography variant="body2">{summary.futureEventCount} upcoming events</Typography>
+                {summary.travelWorthyCount > 0 && <Typography variant="body2">{summary.travelWorthyCount} travel-worthy</Typography>}
+                {summary.forBeginnersCount > 0 && <Typography variant="body2">{summary.forBeginnersCount} beginner-friendly</Typography>}
+                <Typography variant="body2">{summary.organizerCount} local organizers</Typography>
+              </Box>
+            </CardContent>
+          </Card>
+
+          {/* Nearby cities */}
+          {nearbyCities?.length > 0 && (
+            <Card variant="outlined" sx={{ mb: 3 }}>
+              <CardContent>
+                <Typography variant="h6" fontWeight="bold" gutterBottom>Tango Nearby</Typography>
+                {nearbyCities.map((nc) => (
+                  <Box key={nc.cityId} component={Link}
+                    href={`/tango/${params.country}/${nc.citySlug}`}
+                    sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                      py: 1, textDecoration: 'none', color: 'inherit', '&:hover': { color: 'primary.main' } }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                      <PlaceIcon fontSize="small" color="disabled" />
+                      <Typography variant="body2">{nc.cityName}</Typography>
+                    </Box>
+                    <Typography variant="caption" color="text.secondary">{Math.round(nc.distanceMiles)} mi</Typography>
+                  </Box>
+                ))}
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Secondary CTA */}
+          <Box sx={{ p: 2, border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
+            <Typography variant="body2" fontWeight="bold" gutterBottom>Not an organizer?</Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              Share TangoTiempo with your local tango community.
+            </Typography>
+            <Button component={Link} href="/calendar" size="small" variant="outlined" fullWidth>
+              Find Events Near Me
+            </Button>
+          </Box>
+        </Grid>
+      </Grid>
+
+      {/* Breadcrumb */}
+      <Box sx={{ mt: 5, pt: 3, borderTop: '1px solid', borderColor: 'divider' }}>
+        <Typography variant="body2" color="text.secondary">
+          <Link href="/tango" style={{ color: 'inherit' }}>Tango Events USA</Link>
+          {' → '}
+          <Link href={`/tango/${params.country}`} style={{ color: 'inherit' }}>{city.countryName}</Link>
+          {' → '}{city.cityName}
+        </Typography>
+      </Box>
+    </Container>
+  );
+}

--- a/src/app/tango/[country]/page.js
+++ b/src/app/tango/[country]/page.js
@@ -1,0 +1,165 @@
+// /tango/[country] — State-level tango SEO landing page
+// Server Component, ISR 1hr, pre-rendered via generateStaticParams
+// Slugs are server-computed by Fulton's geo-summary — never roll your own
+
+import Link from 'next/link';
+import { Box, Container, Typography, Grid, Card, CardContent, Button, Chip } from '@mui/material';
+import PlaceIcon from '@mui/icons-material/Place';
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
+import { getApiBaseUrl } from '@/utils/apiUrlResolver';
+import { notFound } from 'next/navigation';
+
+const API_URL = getApiBaseUrl();
+const BASE_URL = 'https://tangotiempo.com';
+
+async function getGeoSummary(params = '') {
+  try {
+    const res = await fetch(`${API_URL}/api/seo/geo-summary?appId=1${params}`, {
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) return null;
+    return res.json();
+  } catch { return null; }
+}
+
+async function getCountryEvents(countryId) {
+  try {
+    const now = new Date().toISOString();
+    const end = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
+    const res = await fetch(
+      `${API_URL}/api/events?appId=1&masteredCountryId=${countryId}&start=${now}&end=${end}&limit=6`,
+      { next: { revalidate: 3600 } }
+    );
+    if (!res.ok) return [];
+    const data = await res.json();
+    return data.events || [];
+  } catch { return []; }
+}
+
+export async function generateStaticParams() {
+  const summary = await getGeoSummary();
+  if (!summary?.cities?.length) return [];
+  const seen = new Set();
+  return summary.cities
+    .filter((c) => { if (seen.has(c.countrySlug)) return false; seen.add(c.countrySlug); return true; })
+    .map((c) => ({ country: c.countrySlug }));
+}
+
+export async function generateMetadata({ params }) {
+  const summary = await getGeoSummary(`&countrySlug=${params.country}`);
+  if (!summary?.cities?.length) return {};
+  const countryName = summary.cities[0].countryName;
+  const totalEvents = summary.cities.reduce((n, c) => n + c.futureEventCount, 0);
+  return {
+    title: `Argentine Tango Events in ${countryName} | TangoTiempo`,
+    description: `Find milongas, practicas, workshops, and tango festivals across ${countryName}. ${totalEvents}+ upcoming events. Free tango calendar.`,
+    openGraph: {
+      title: `Tango Events in ${countryName} | TangoTiempo`,
+      description: `Discover Argentine tango in ${countryName} — milongas, practicas, classes, and festivals.`,
+      url: `${BASE_URL}/tango/${params.country}`,
+      siteName: 'TangoTiempo',
+      type: 'website',
+      images: [{ url: `${BASE_URL}/brand/Brand-MCB-Light-V-WIDE-1.png`, width: 1200 }],
+    },
+    alternates: { canonical: `${BASE_URL}/tango/${params.country}` },
+    robots: { index: true, follow: true },
+  };
+}
+
+export default async function CountryPage({ params }) {
+  const summary = await getGeoSummary(`&countrySlug=${params.country}`);
+  if (!summary?.cities?.length) notFound();
+
+  const cities = summary.cities;
+  const countryName = cities[0].countryName;
+  const totalEvents = cities.reduce((n, c) => n + c.futureEventCount, 0);
+  const events = await getCountryEvents(cities[0].countryId);
+
+  const eventSchema = events.slice(0, 5).map((e) => ({
+    '@type': 'Event',
+    name: e.title,
+    startDate: e.startDate,
+    location: {
+      '@type': 'Place',
+      name: e.venueName || countryName,
+      address: { '@type': 'PostalAddress', addressRegion: countryName, addressCountry: 'US' },
+    },
+    organizer: { '@type': 'Organization', name: e.ownerOrganizerName || 'TangoTiempo' },
+    url: `${BASE_URL}/calendar`,
+  }));
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({ '@context': 'https://schema.org', '@graph': eventSchema }) }} />
+
+      {/* Brand hero */}
+      <Box
+        component="img"
+        src="/brand/Brand-MCB-Light-V-WIDE-1.png"
+        alt="TangoTiempo — Move. Connect. Belong."
+        sx={{ width: '100%', maxHeight: { xs: 100, md: 140 }, objectFit: 'cover', borderRadius: 2, mb: 3 }}
+      />
+
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h3" component="h1" fontWeight="bold" gutterBottom>
+          Argentine Tango Events in {countryName}
+        </Typography>
+        <Typography variant="h6" color="text.secondary" sx={{ mb: 2 }}>
+          {totalEvents} upcoming events across {cities.length} cities
+        </Typography>
+        <Button component={Link} href="/calendar" variant="contained" startIcon={<CalendarMonthIcon />} size="large">
+          Browse Full Calendar
+        </Button>
+      </Box>
+
+      <Typography variant="h5" fontWeight="bold" gutterBottom sx={{ mb: 2 }}>
+        Tango Cities in {countryName}
+      </Typography>
+      <Grid container spacing={2} sx={{ mb: 5 }}>
+        {cities.sort((a, b) => b.futureEventCount - a.futureEventCount).map((city) => (
+          <Grid item xs={6} sm={4} md={3} key={city.cityId}>
+            <Card component={Link} href={`/tango/${params.country}/${city.citySlug}`}
+              sx={{ textDecoration: 'none', '&:hover': { boxShadow: 3 } }}>
+              <CardContent sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <Box>
+                  <Typography variant="subtitle2" fontWeight="bold">{city.cityName}</Typography>
+                  <Typography variant="caption" color="text.secondary">{city.futureEventCount} events</Typography>
+                </Box>
+                <PlaceIcon color="primary" fontSize="small" />
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+
+      {events.length > 0 && (
+        <>
+          <Typography variant="h5" fontWeight="bold" gutterBottom>
+            Upcoming Tango Events in {countryName}
+          </Typography>
+          <Box sx={{ mb: 4 }}>
+            {events.map((event) => (
+              <Box key={event._id} sx={{ py: 1.5, borderBottom: '1px solid', borderColor: 'divider' }}>
+                <Typography variant="subtitle1" fontWeight="bold">{event.title}</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {event.venueName}
+                  {event.categoryFirst && <Chip label={event.categoryFirst} size="small" sx={{ ml: 1 }} />}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+          <Button component={Link} href="/calendar" variant="outlined">
+            See all {countryName} tango events →
+          </Button>
+        </>
+      )}
+
+      <Box sx={{ mt: 5, pt: 3, borderTop: '1px solid', borderColor: 'divider' }}>
+        <Typography variant="body2" color="text.secondary">
+          <Link href="/tango" style={{ color: 'inherit' }}>Argentine Tango Events Worldwide</Link>
+          {' → '}{countryName}
+        </Typography>
+      </Box>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- `/tango/[country]` — country landing page with city grid, event preview, structured data
- `/tango/[country]/[city]` — adaptive city page (user-acquisition vs organizer-acquisition mode)
- Uses Fulton's `geo-summary` + `city-page` endpoints with countrySlug/citySlug routing
- Event JSON-LD structured data for Google rich results
- Brand hero, nearbyCities sidebar, organizer recruitment CTA
- `generateStaticParams` pre-renders 39 cities across 6 countries (US, Australia, UK, Czechia, Germany, Italy)
- organizerCount correctly derived from `isDiscovered=false` events

## Test plan
- [ ] `test.tangotiempo.com/tango/united-states` — US page shows city grid
- [ ] `test.tangotiempo.com/tango/united-states/boston` — user-acquisition mode, 10 organizers
- [ ] `test.tangotiempo.com/tango/australia/sydney` — city page loads
- [ ] `test.tangotiempo.com/tango/czechia/prague` — international city loads
- [ ] View source: og:title and JSON-LD present
- [ ] Breadcrumb nav works

🤖 Generated with [Claude Code](https://claude.com/claude-code)