### PR TITLE
TIEMPO-450: Elevate Featured Events + de-dupe event count

### DIFF
--- a/src/app/tango/[country]/[city]/page.js
+++ b/src/app/tango/[country]/[city]/page.js
@@ -104,10 +104,55 @@ export default async function CityPage({ params }) {
             <Typography variant="h3" component="h1" fontWeight="bold" gutterBottom>
               Argentine Tango in {city.cityName}
             </Typography>
-            <Typography variant="h6" color="text.secondary" sx={{ mb: 2 }}>
-              {summary.futureEventCount} upcoming events · {city.cityName}, {city.countryName}
-            </Typography>
           </Box>
+
+          {/* Featured Events — paid placements, surfaced above the fold */}
+          {topEvents.featured?.length > 0 && (
+            <Box sx={{
+              mb: 4,
+              p: 3,
+              borderRadius: 3,
+              background: 'linear-gradient(135deg, #fff8f5 0%, #fdf0f3 100%)',
+              border: '2px solid',
+              borderColor: 'secondary.main',
+            }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                <Typography variant="h5" fontWeight="bold" color="primary">
+                  Featured Events in {city.cityName}
+                </Typography>
+                <Chip label="★ Featured" size="small" color="secondary" />
+              </Box>
+              {topEvents.featured.map((e, i) => (
+                <Box
+                  key={e.eventId || e._id || `ft-${i}`}
+                  component={e.url ? Link : 'div'}
+                  href={e.url || undefined}
+                  sx={{
+                    display: 'flex',
+                    gap: 2,
+                    py: 1.5,
+                    borderBottom: i < topEvents.featured.length - 1 ? '1px solid' : 'none',
+                    borderColor: 'divider',
+                    textDecoration: 'none',
+                    color: 'inherit',
+                    '&:hover': e.url ? { bgcolor: 'action.hover' } : {},
+                    borderRadius: 1,
+                    px: 1,
+                  }}
+                >
+                  {e.featuredImage && (
+                    <Box component="img" src={e.featuredImage} alt={e.title || e.name}
+                      sx={{ width: 72, height: 72, objectFit: 'cover', borderRadius: 1, flexShrink: 0 }} />
+                  )}
+                  <Box>
+                    <Typography variant="subtitle1" fontWeight="bold">{e.title || e.name}</Typography>
+                    <Typography variant="body2" color="text.secondary">{e.venueName}</Typography>
+                    {e.categoryFirst && <Chip label={e.categoryFirst} size="small" sx={{ mt: 0.5 }} />}
+                  </Box>
+                </Box>
+              ))}
+            </Box>
+          )}
 
           {/* Upcoming events CTA box */}
           <Box sx={{
@@ -176,31 +221,6 @@ export default async function CityPage({ params }) {
             )}
           </Box>
 
-          {/* Featured events — paid placements */}
-          {data.featuredEvents?.length > 0 && (
-            <Box sx={{ mb: 4 }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
-                <Typography variant="h5" fontWeight="bold">Featured Events</Typography>
-                <Chip label="★ Featured" size="small" color="secondary" />
-              </Box>
-              {data.featuredEvents.map((e) => (
-                <Box key={e.eventId} component={Link} href={e.url}
-                  sx={{ display: 'flex', gap: 2, py: 2, borderBottom: '1px solid', borderColor: 'divider',
-                    textDecoration: 'none', color: 'inherit', '&:hover': { bgcolor: 'action.hover' }, borderRadius: 1, px: 1 }}>
-                  {e.featuredImage && (
-                    <Box component="img" src={e.featuredImage} alt={e.title}
-                      sx={{ width: 72, height: 72, objectFit: 'cover', borderRadius: 1, flexShrink: 0 }} />
-                  )}
-                  <Box>
-                    <Typography variant="subtitle1" fontWeight="bold">{e.title}</Typography>
-                    <Typography variant="body2" color="text.secondary">{e.venueName}</Typography>
-                    {e.categoryFirst && <Chip label={e.categoryFirst} size="small" sx={{ mt: 0.5 }} />}
-                  </Box>
-                </Box>
-              ))}
-            </Box>
-          )}
-
           {/* Event counts by category */}
           {categories?.length > 0 && (
             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 4 }}>
@@ -218,21 +238,6 @@ export default async function CityPage({ params }) {
               </Typography>
               {topEvents.travelWorthy.map((e, i) => (
                 <Box key={e.eventId || e._id || `tw-${i}`} sx={{ py: 1.5, borderBottom: '1px solid', borderColor: 'divider' }}>
-                  <Typography variant="subtitle1" fontWeight="bold">{e.title || e.name}</Typography>
-                  <Typography variant="body2" color="text.secondary">{e.venueName}</Typography>
-                </Box>
-              ))}
-            </Box>
-          )}
-
-          {/* Featured events (paid feature — events with isFeatured=true) */}
-          {topEvents.featured?.length > 0 && (
-            <Box sx={{ mb: 4 }}>
-              <Typography variant="h5" fontWeight="bold" gutterBottom>
-                Featured Events in {city.cityName}
-              </Typography>
-              {topEvents.featured.map((e, i) => (
-                <Box key={e.eventId || e._id || `ft-${i}`} sx={{ py: 1.5, borderBottom: '1px solid', borderColor: 'divider' }}>
                   <Typography variant="subtitle1" fontWeight="bold">{e.title || e.name}</Typography>
                   <Typography variant="body2" color="text.secondary">{e.venueName}</Typography>
                 </Box>


### PR DESCRIPTION
## Summary
- Featured Events section moved above the Upcoming Events CTA box for stronger paid-feature visibility
- Featured Events now rendered in a gradient-bordered box with ★ chip + image / category chip; rows are clickable when `e.url` is present
- Duplicate "X upcoming events" subtitle removed from the hero — count remains in the boxed CTA next to Browse button (single source)
- Removed dead `data.featuredEvents` block (Fulton dropped that field; `topEvents.featured` is canonical)

## Test plan
- [ ] After merge, hard-reload `test.tangotiempo.com/tango/united-states/boston`
- [ ] Featured Events section appears above the maroon Browse-Events CTA box
- [ ] "Milonga NUEVA!" surfaces with star chip + venue
- [ ] Hero shows only the H1, no second event count line
- [ ] Browse button still routes (lat/lng fix is separate ticket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)