### PR TITLE
TIEMPO-449: Browse Events lands on city-centered calendar

### DIFF
--- a/src/app/components/Providers.js
+++ b/src/app/components/Providers.js
@@ -12,6 +12,7 @@ import { LocationAPIProvider } from '@/contexts/LocationAPIContext';
 import { GeoLocationProvider, useGeoLocation } from '@/contexts/GeoLocationContext';
 import { EventDiscoveryProvider } from '@/contexts/EventDiscoveryContext';
 import UserLocationLoader from '@/components/UserLocationLoader';
+import SeoCityLinkLoader from '@/components/SeoCityLinkLoader';
 import { getCachedGeolocation } from '@/utils/trackingHelper';
 import { getCountryMapLocation } from '@/utils/countryCenter';
 import { initializeApiFailover, isUsingFailover } from '@/utils/apiUrlResolver';
@@ -196,6 +197,7 @@ const Providers = ({ children }) => {
           <LocationAPIProvider>
             <GeoLocationProvider>
               <EventDiscoveryProvider>
+                <SeoCityLinkLoader />
                 <UserLocationLoader />
                 <MapCenterModalWrapper />
                 <FailoverIndicator />

--- a/src/app/components/SeoCityLinkLoader.js
+++ b/src/app/components/SeoCityLinkLoader.js
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useGeoLocation } from '@/contexts/GeoLocationContext';
+
+const SeoCityLinkLoader = () => {
+  const searchParams = useSearchParams();
+  const { setSessionLocation } = useGeoLocation();
+  const applied = useRef(false);
+
+  useEffect(() => {
+    if (!searchParams || applied.current || !setSessionLocation) return;
+
+    const lat = parseFloat(searchParams.get('lat'));
+    const lng = parseFloat(searchParams.get('lng'));
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) return;
+
+    const radiusRaw = parseFloat(searchParams.get('radius'));
+    const cityName = searchParams.get('cityName') || undefined;
+
+    applied.current = true;
+    setSessionLocation({
+      lat,
+      lng,
+      zoomRange: Number.isFinite(radiusRaw) ? radiusRaw : 125,
+      cityName,
+      source: 'seo-city-link',
+    }).catch(() => {});
+  }, [searchParams, setSessionLocation]);
+
+  return null;
+};
+
+export default SeoCityLinkLoader;

--- a/src/app/components/UserLocationLoader.js
+++ b/src/app/components/UserLocationLoader.js
@@ -45,6 +45,16 @@ const UserLocationLoader = () => {
       return;
     }
 
+    // TIEMPO-449: Skip when URL carries SEO city-link geo params — SeoCityLinkLoader
+    // owns this navigation and we must not overwrite its session location.
+    if (typeof window !== 'undefined') {
+      const sp = new URLSearchParams(window.location.search);
+      if (sp.has('lat') && sp.has('lng')) {
+        console.log('[UserLocationLoader] Skipping mapCenter fetch — URL has SEO geo params');
+        return;
+      }
+    }
+
     const loadMapCenter = async () => {
       try {
 

--- a/src/app/tango/[country]/[city]/page.js
+++ b/src/app/tango/[country]/[city]/page.js
@@ -66,6 +66,13 @@ export default async function CityPage({ params }) {
   const { city, mode, summary, categories, topOrganizers, topEvents, cta, mapCenterUrl, nearbyCities, classifierLabels } = data;
   const isAcquisition = mode === 'organizer-acquisition';
 
+  // TIEMPO-449: compose calendar URL from city geo so the Browse button lands
+  // centered on the city. Falls back to API-supplied mapCenterUrl when geo missing.
+  // Will be superseded by CALBEAF-164 once BE composes mapCenterUrl with geo.
+  const calendarUrl = (typeof city.lat === 'number' && typeof city.lng === 'number')
+    ? `/calendar?lat=${city.lat.toFixed(4)}&lng=${city.lng.toFixed(4)}&radius=125&cityName=${encodeURIComponent(city.cityName)}`
+    : mapCenterUrl;
+
   // Event structured data
   const allTopEvents = [...(topEvents.travelWorthy || []), ...(topEvents.forBeginners || [])];
   const eventSchema = {
@@ -173,7 +180,7 @@ export default async function CityPage({ params }) {
             </Typography>
             <Button
               component={Link}
-              href={mapCenterUrl}
+              href={calendarUrl}
               variant="contained"
               size="large"
               sx={{


### PR DESCRIPTION
## Summary
Closes the SEO city → calendar handoff. Browse Events button on /tango/[country]/[city] now centers the calendar on the city instead of dropping the user on the global default.

- **City page** composes `/calendar?lat=X&lng=Y&radius=125&cityName=Boston` from `city.lat`/`city.lng` (already on the API per CALBEAF-160 + v1.30.0). Falls back to API \`mapCenterUrl\` when geo missing.
- **New `SeoCityLinkLoader`** reads URL params on /calendar mount, calls `setSessionLocation` with `source: 'seo-city-link'` — transient, does NOT overwrite logged-in user's saved cloud default.
- **`UserLocationLoader` skip** when URL has lat+lng — extends the existing Boston-route skip pattern.

## Why FE-only
Originally CALBEAF-164 was supposed to compose mapCenterUrl BE-side. Composing on the FE today using the geo the API already returns gets us end-to-end working without waiting for BE. CALBEAF-164 becomes optional polish (BE composition would let the API serve as canonical source of truth — nice-to-have).

## Test plan
- [ ] After merge, hard-reload `test.tangotiempo.com/tango/united-states/boston`
- [ ] Click "Browse Events" — calendar should center on Boston (lat 42.36, lng -71.06), 125mi radius
- [ ] Same on `/tango/united-states/portland` (Oregon, lat 45.51) — should NOT collapse to Maine Portland (Fulton's v1.30.1 disambiguation)
- [ ] Same on `/tango/australia/sydney` — international parent slug
- [ ] Logged-in user clicking SEO link does NOT overwrite saved cloud mapCenter (uses session-only)
- [ ] Console clean of UserLocationLoader fetch attempt (should log skip due to URL params)

🤖 Generated with [Claude Code](https://claude.com/claude-code)