### PR TITLE
Task #4: Lock URL shape at /tango/[parent]/[city]

### DIFF
--- a/src/app/tango/[parent]/[city]/page.js
+++ b/src/app/tango/[parent]/[city]/page.js
@@ -1,4 +1,5 @@
-// /tango/[country]/[city] — City-level tango SEO landing page
+// /tango/[parent]/[city] — City-level tango SEO landing page
+// parent = state slug for US (e.g. "oregon", "massachusetts"), country slug for international (e.g. "australia")
 // Adaptive: "organizer-acquisition" mode (<7 organizers) vs "user-acquisition" (≥7)
 // Data: Fulton's /api/seo/city-page endpoint (single fetch, pre-assembled)
 // Server Component, ISR 1hr, generateStaticParams from geo-summary
@@ -22,10 +23,10 @@ async function getGeoSummary() {
   } catch { return null; }
 }
 
-async function getCityPage(countrySlug, citySlug) {
+async function getCityPage(parentSlug, citySlug) {
   try {
     const res = await fetch(
-      `${API_URL}/api/seo/city-page?appId=1&regionSlug=${countrySlug}&citySlug=${citySlug}`,
+      `${API_URL}/api/seo/city-page?appId=1&parentSlug=${parentSlug}&citySlug=${citySlug}`,
       { next: { revalidate: 3600 } }
     );
     if (!res.ok) return null;
@@ -36,11 +37,11 @@ async function getCityPage(countrySlug, citySlug) {
 export async function generateStaticParams() {
   const summary = await getGeoSummary();
   if (!summary) return [];
-  return summary.cities.map((c) => ({ country: c.countrySlug, city: c.citySlug }));
+  return summary.cities.map((c) => ({ parent: c.parentSlug, city: c.citySlug }));
 }
 
 export async function generateMetadata({ params }) {
-  const data = await getCityPage(params.country, params.city);
+  const data = await getCityPage(params.parent, params.city);
   if (!data) return {};
   const { city, summary } = data;
   return {
@@ -49,18 +50,18 @@ export async function generateMetadata({ params }) {
     openGraph: {
       title: `Tango Events in ${city.cityName}, ${city.countryName} | TangoTiempo`,
       description: `Discover Argentine tango in ${city.cityName} — milongas, practicas, classes, and workshops near you.`,
-      url: `${BASE_URL}/tango/${params.country}/${params.city}`,
+      url: `${BASE_URL}/tango/${params.parent}/${params.city}`,
       siteName: 'TangoTiempo',
       type: 'website',
       images: [{ url: `${BASE_URL}/brand/Brand-MCB-Light-V-WIDE-1.png`, width: 1200 }],
     },
-    alternates: { canonical: `${BASE_URL}/tango/${params.country}/${params.city}` },
+    alternates: { canonical: `${BASE_URL}/tango/${params.parent}/${params.city}` },
     robots: { index: true, follow: true },
   };
 }
 
 export default async function CityPage({ params }) {
-  const data = await getCityPage(params.country, params.city);
+  const data = await getCityPage(params.parent, params.city);
   if (!data) notFound();
 
   const { city, mode, summary, categories, topOrganizers, topEvents, cta, mapCenterUrl, nearbyCities, classifierLabels } = data;
@@ -303,7 +304,7 @@ export default async function CityPage({ params }) {
                 <Typography variant="h6" fontWeight="bold" gutterBottom>Tango Nearby</Typography>
                 {nearbyCities.map((nc) => (
                   <Box key={nc.cityId} component={Link}
-                    href={`/tango/${params.country}/${nc.citySlug}`}
+                    href={`/tango/${nc.parentSlug || params.parent}/${nc.citySlug}`}
                     sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center',
                       py: 1, textDecoration: 'none', color: 'inherit', '&:hover': { color: 'primary.main' } }}>
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
@@ -333,9 +334,11 @@ export default async function CityPage({ params }) {
       {/* Breadcrumb */}
       <Box sx={{ mt: 5, pt: 3, borderTop: '1px solid', borderColor: 'divider' }}>
         <Typography variant="body2" color="text.secondary">
-          <Link href="/tango" style={{ color: 'inherit' }}>Tango Events USA</Link>
+          <Link href="/tango" style={{ color: 'inherit' }}>Argentine Tango Events Worldwide</Link>
           {' → '}
-          <Link href={`/tango/${params.country}`} style={{ color: 'inherit' }}>{city.countryName}</Link>
+          <Link href={`/tango/${params.parent}`} style={{ color: 'inherit', textTransform: 'capitalize' }}>
+            {params.parent.replace(/-/g, ' ')}
+          </Link>
           {' → '}{city.cityName}
         </Typography>
       </Box>

--- a/src/app/tango/[parent]/page.js
+++ b/src/app/tango/[parent]/page.js
@@ -1,4 +1,5 @@
-// /tango/[country] — State-level tango SEO landing page
+// /tango/[parent] — Parent-level tango SEO landing page
+// parent = state slug for US (e.g. "oregon", "massachusetts"), country slug for international (e.g. "australia")
 // Server Component, ISR 1hr, pre-rendered via generateStaticParams
 // Slugs are server-computed by Fulton's geo-summary — never roll your own
 
@@ -41,36 +42,37 @@ export async function generateStaticParams() {
   if (!summary?.cities?.length) return [];
   const seen = new Set();
   return summary.cities
-    .filter((c) => { if (seen.has(c.countrySlug)) return false; seen.add(c.countrySlug); return true; })
-    .map((c) => ({ country: c.countrySlug }));
+    .filter((c) => { if (seen.has(c.parentSlug)) return false; seen.add(c.parentSlug); return true; })
+    .map((c) => ({ parent: c.parentSlug }));
 }
 
 export async function generateMetadata({ params }) {
-  const summary = await getGeoSummary(`&countrySlug=${params.country}`);
+  const summary = await getGeoSummary(`&parentSlug=${params.parent}`);
   if (!summary?.cities?.length) return {};
-  const countryName = summary.cities[0].countryName;
+  const parentName = summary.cities[0].parentName || summary.cities[0].countryName;
   const totalEvents = summary.cities.reduce((n, c) => n + c.futureEventCount, 0);
   return {
-    title: `Argentine Tango Events in ${countryName} | TangoTiempo`,
-    description: `Find milongas, practicas, workshops, and tango festivals across ${countryName}. ${totalEvents}+ upcoming events. Free tango calendar.`,
+    title: `Argentine Tango Events in ${parentName} | TangoTiempo`,
+    description: `Find milongas, practicas, workshops, and tango festivals across ${parentName}. ${totalEvents}+ upcoming events. Free tango calendar.`,
     openGraph: {
-      title: `Tango Events in ${countryName} | TangoTiempo`,
-      description: `Discover Argentine tango in ${countryName} — milongas, practicas, classes, and festivals.`,
-      url: `${BASE_URL}/tango/${params.country}`,
+      title: `Tango Events in ${parentName} | TangoTiempo`,
+      description: `Discover Argentine tango in ${parentName} — milongas, practicas, classes, and festivals.`,
+      url: `${BASE_URL}/tango/${params.parent}`,
       siteName: 'TangoTiempo',
       type: 'website',
       images: [{ url: `${BASE_URL}/brand/Brand-MCB-Light-V-WIDE-1.png`, width: 1200 }],
     },
-    alternates: { canonical: `${BASE_URL}/tango/${params.country}` },
+    alternates: { canonical: `${BASE_URL}/tango/${params.parent}` },
     robots: { index: true, follow: true },
   };
 }
 
-export default async function CountryPage({ params }) {
-  const summary = await getGeoSummary(`&countrySlug=${params.country}`);
+export default async function ParentPage({ params }) {
+  const summary = await getGeoSummary(`&parentSlug=${params.parent}`);
   if (!summary?.cities?.length) notFound();
 
   const cities = summary.cities;
+  const parentName = cities[0].parentName || cities[0].countryName;
   const countryName = cities[0].countryName;
   const totalEvents = cities.reduce((n, c) => n + c.futureEventCount, 0);
   const events = await getCountryEvents(cities[0].countryId);
@@ -98,10 +100,10 @@ export default async function CountryPage({ params }) {
 
       <Box sx={{ mb: 4 }}>
         <Typography variant="h3" component="h1" fontWeight="bold" gutterBottom>
-          Argentine Tango Events in {countryName}
+          Argentine Tango Events in {parentName}
         </Typography>
         <Typography variant="h6" color="text.secondary" sx={{ mb: 2 }}>
-          {totalEvents} upcoming events across {cities.length} cities
+          {totalEvents} upcoming events across {cities.length} {cities.length === 1 ? 'city' : 'cities'}
         </Typography>
         <Button component={Link} href="/calendar" variant="contained" startIcon={<CalendarMonthIcon />} size="large">
           Browse Full Calendar
@@ -109,12 +111,12 @@ export default async function CountryPage({ params }) {
       </Box>
 
       <Typography variant="h5" fontWeight="bold" gutterBottom sx={{ mb: 2 }}>
-        Tango Cities in {countryName}
+        Tango Cities in {parentName}
       </Typography>
       <Grid container spacing={2} sx={{ mb: 5 }}>
         {cities.sort((a, b) => b.futureEventCount - a.futureEventCount).map((city) => (
           <Grid item xs={6} sm={4} md={3} key={city.cityId}>
-            <Card component={Link} href={`/tango/${params.country}/${city.citySlug}`}
+            <Card component={Link} href={`/tango/${params.parent}/${city.citySlug}`}
               sx={{ textDecoration: 'none', '&:hover': { boxShadow: 3 } }}>
               <CardContent sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                 <Box>
@@ -131,7 +133,7 @@ export default async function CountryPage({ params }) {
       {events.length > 0 && (
         <>
           <Typography variant="h5" fontWeight="bold" gutterBottom>
-            Upcoming Tango Events in {countryName}
+            Upcoming Tango Events in {parentName}
           </Typography>
           <Box sx={{ mb: 4 }}>
             {events.map((event) => (
@@ -145,7 +147,7 @@ export default async function CountryPage({ params }) {
             ))}
           </Box>
           <Button component={Link} href="/calendar" variant="outlined">
-            See all {countryName} tango events →
+            See all {parentName} tango events →
           </Button>
         </>
       )}
@@ -154,6 +156,7 @@ export default async function CountryPage({ params }) {
         <Typography variant="body2" color="text.secondary">
           <Link href="/tango" style={{ color: 'inherit' }}>Argentine Tango Events Worldwide</Link>
           {' → '}{countryName}
+          {parentName !== countryName && ` → ${parentName}`}
         </Typography>
       </Box>
     </Container>


### PR DESCRIPTION
## Summary
Pre-PROD URL-shape migration. Moves from country-scoped to parent-scoped routes:
- `/tango/united-states/boston` → `/tango/massachusetts/boston`
- `/tango/united-states/portland` → `/tango/oregon/portland` (no more Portland-OR vs ME ambiguity in the URL itself)
- `/tango/australia/sydney` → unchanged (international parent = country)

## Why now
Pre-PROD = no SEO migration cost. Once Google crawls country-scoped URLs, migration becomes a 301-redirect maintenance burden forever. Locking parent-scoped now is a free reorg.

## Changes
- `git mv src/app/tango/[country]/ → [parent]/` (history preserved)
- City page: API call uses `parentSlug`, `generateStaticParams` pulls `c.parentSlug`, OG/canonical URLs use `params.parent`
- Parent page: dedupe by `parentSlug`, display `parentName` ("Oregon" not "United States"), breadcrumb shows hierarchy when parent ≠ country
- `nearbyCities` link prefers `nc.parentSlug` (when Fulton adds), falls back to current `params.parent`
- Breadcrumb on city page: `Worldwide → {parent} → {city}`

## Backward compat
- BE accepts `regionSlug`/`countrySlug` as aliases for `parentSlug` (Fulton's note from yesterday)
- Old country-scoped URLs are NOT pre-rendered anymore (`generateStaticParams` only emits parent-scoped) — pre-PROD so no Google crawl impact

## Test plan
- [ ] After merge, hard-reload `test.tangotiempo.com/tango/massachusetts/boston` → renders Boston page with Featured Events
- [ ] `test.tangotiempo.com/tango/oregon/portland` → Oregon Portland (lat 45.51), not Maine
- [ ] `test.tangotiempo.com/tango/australia/sydney` → international slug works, parentName shows "Australia"
- [ ] `test.tangotiempo.com/tango/oregon` → state-level landing shows Portland in city grid
- [ ] Browse Events button still routes to `/calendar?lat=...&lng=...&radius=125&cityName=...`
- [ ] Breadcrumb at bottom: `Worldwide → Massachusetts → Boston` (capitalized from slug)

## Follow-up
Filing CALBEAF-X to ask Fulton to add `parentSlug` + `parentName` to the city-page response city object and `nearbyCities` entries — current FE uses fallbacks but could be cleaner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)