### PR TITLE
fix(seo): organizer links from city pages accept shortName

### DIFF
--- a/src/app/organizers/[slug]/page.js
+++ b/src/app/organizers/[slug]/page.js
@@ -125,6 +125,8 @@ export async function generateStaticParams() {
 }
 
 // Function to get organizer data based on slug
+// Accepts either the compound slug (shortname-region-division-city, pre-rendered)
+// OR a bare shortName (case-insensitive) — used by city-page topOrganizers links.
 async function getOrganizerData(slug) {
   logger.info(`Fetching organizer data for slug: ${slug}`);
   try {
@@ -132,7 +134,15 @@ async function getOrganizerData(slug) {
     const data = fs.readFileSync(filePath, 'utf-8');
     const organizersDataList = JSON.parse(data);
 
-    const organizer = organizersDataList.find((org) => org.slug === slug);
+    // 1. Exact compound-slug match (existing pre-rendered URLs)
+    let organizer = organizersDataList.find((org) => org.slug === slug);
+    if (organizer) return organizer;
+
+    // 2. Fallback: bare shortName match (case-insensitive) — used by SEO city pages
+    const slugLower = slug.toLowerCase();
+    organizer = organizersDataList.find(
+      (org) => (org.shortName || '').toLowerCase() === slugLower
+    );
 
     return organizer || null;
   } catch (error) {

--- a/src/app/tango/[parent]/[city]/page.js
+++ b/src/app/tango/[parent]/[city]/page.js
@@ -261,7 +261,7 @@ export default async function CityPage({ params }) {
               </Typography>
               <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
                 {topOrganizers.map((org) => (
-                  <Box key={org.organizerId} component={Link} href={`/organizers/${org.shortName}`}
+                  <Box key={org.organizerId} component={Link} href={`/organizers/${(org.shortName || '').toLowerCase()}`}
                     sx={{ display: 'flex', alignItems: 'center', gap: 1.5, textDecoration: 'none', color: 'inherit',
                       p: 1.5, border: '1px solid', borderColor: 'divider', borderRadius: 1,
                       '&:hover': { bgcolor: 'action.hover' } }}>


### PR DESCRIPTION
## Summary
City-page \`topOrganizers\` cards were linking to \`/organizers/SOCIETY\` (uppercase shortName) but the route only matched compound slugs like \`society-massachusetts-boston-boston\`. **All org cards on city SEO pages were 404'ing.**

Toby flagged this on \`/organizers/MILT-CORI\` — that one has the additional issue of \`wantRender: false\`, which Fulton is fixing BE-side via filter on \`topOrganizers\`.

## Changes
- \`/organizers/[slug]/page.js\` — \`getOrganizerData\` now also matches by \`shortName\` (case-insensitive) when compound slug doesn't match. Existing pre-rendered compound URLs unaffected (same lookup, additional fallback).
- City page — lowercase the \`shortName\` in href so URLs are clean.

## Test plan
- [ ] Hard-reload \`test.tangotiempo.com/tango/massachusetts/boston\`
- [ ] Click any organizer card (e.g. SOCIETY, SUENO) → loads the org profile page (not 404)
- [ ] Old compound URLs still work: \`/organizers/society-massachusetts-boston-boston\` (no SEO regression)
- [ ] After Fulton ships \`wantRender\` filter: MILT-CORI disappears from topOrganizers entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)