### PR TITLE
fix(seo): organizer profile fetches API at runtime (fixes /organizers/society 404)

### DIFF
--- a/src/app/organizers/[slug]/page.js
+++ b/src/app/organizers/[slug]/page.js
@@ -127,24 +127,78 @@ export async function generateStaticParams() {
 // Function to get organizer data based on slug
 // Accepts either the compound slug (shortname-region-division-city, pre-rendered)
 // OR a bare shortName (case-insensitive) — used by city-page topOrganizers links.
+//
+// Fetches from API at runtime (not from a build-time file write — that pattern
+// was unreliable on Vercel; the file wasn't always bundled into the deploy).
+// Cached via Next.js fetch revalidate so we don't hammer the BE.
 async function getOrganizerData(slug) {
   logger.info(`Fetching organizer data for slug: ${slug}`);
   try {
-    const filePath = path.join(process.cwd(), 'public', 'organizersList.json');
-    const data = fs.readFileSync(filePath, 'utf-8');
-    const organizersDataList = JSON.parse(data);
+    const beUrl = getApiBaseUrl();
 
-    // 1. Exact compound-slug match (existing pre-rendered URLs)
-    let organizer = organizersDataList.find((org) => org.slug === slug);
-    if (organizer) return organizer;
+    // Fetch active+enabled+wantRender organizers
+    const orgsRes = await fetch(
+      `${beUrl}/api/organizers?isActive=true&isEnabled=true&wantRender=true`,
+      { next: { revalidate: 3600 } }
+    );
+    if (!orgsRes.ok) {
+      logger.warn(`organizers API returned ${orgsRes.status}`);
+      return null;
+    }
+    const organizers = await orgsRes.json();
+    if (!Array.isArray(organizers) || organizers.length === 0) return null;
+
+    // Fetch regions for compound-slug computation (used to build the canonical slug)
+    let regions = [];
+    try {
+      const regionsRes = await fetch(`${beUrl}/api/regions/activeRegions`, {
+        next: { revalidate: 3600 },
+      });
+      if (regionsRes.ok) regions = await regionsRes.json();
+    } catch { /* regions optional — fallback slug just uses shortName */ }
+
+    const slugLower = slug.toLowerCase();
+
+    // Helper: enrich an org with its region/division/city + computed compound slug
+    const enrich = (org) => {
+      const region = regions.find((r) => r._id === org.organizerRegion) || {};
+      const division = (region.divisions || []).find((d) => d._id === org.organizerDivision) || {};
+      const city = (division.majorCities || []).find((c) => c._id === org.organizerCity) || {};
+      const compoundSlug = [
+        slugify(org.shortName || '', { lower: true }),
+        slugify(region.regionName || 'unknown-region', { lower: true }),
+        slugify(division.divisionName || 'unknown-division', { lower: true }),
+        slugify(city.cityName || 'unknown-city', { lower: true }),
+      ].join('-');
+      return {
+        id: org._id,
+        slug: compoundSlug,
+        name: org.name || org.organizerName || org.shortName,
+        shortName: org.shortName,
+        description: org.description,
+        images: org.images,
+        phone: org.phone,
+        publicEmail: org.publicEmail,
+        url: org.url,
+        regionName: region.regionName || 'Unknown Region',
+        divisionName: division.divisionName || 'Unknown Division',
+        cityName: city.cityName || 'Unknown City',
+      };
+    };
+
+    // 1. Exact compound-slug match — match by computing each org's compound slug
+    for (const org of organizers) {
+      const enriched = enrich(org);
+      if (enriched.slug === slug) return enriched;
+    }
 
     // 2. Fallback: bare shortName match (case-insensitive) — used by SEO city pages
-    const slugLower = slug.toLowerCase();
-    organizer = organizersDataList.find(
-      (org) => (org.shortName || '').toLowerCase() === slugLower
+    const byShortName = organizers.find(
+      (o) => (o.shortName || '').toLowerCase() === slugLower
     );
+    if (byShortName) return enrich(byShortName);
 
-    return organizer || null;
+    return null;
   } catch (error) {
     logger.error('Error in getOrganizerData', { error: error.message });
     return null;


### PR DESCRIPTION
## Root cause
`/organizers/society` returned 404 on TEST. `getOrganizerData` reads `public/organizersList.json` which is committed empty in git, and the build-time `fs.writeFileSync` in `generateStaticParams` does NOT persist into the Vercel deployment bundle. Result: file empty at runtime, every org slug resolves to null, notFound() fires.

## Fix
`getOrganizerData` now fetches from `/api/organizers` and `/api/regions/activeRegions` at runtime, cached via Next.js fetch revalidate (1hr). Computes the compound slug per org for primary match, falls back to shortName lookup case-insensitive.

## Test
- [ ] After merge, `test.tangotiempo.com/organizers/society` renders SOCIETY profile
- [ ] `test.tangotiempo.com/organizers/sueno` works
- [ ] Compound URLs still work: `/organizers/society-{compound}`
- [ ] `/organizers/milt-cori` also works (Toby flipped wantRender=true earlier)
- [ ] Empty image case (MILT-CORI) still shows no image, just text

## Follow-up
`sitemap.js` and `organizers/page.js` (index) also depend on `organizersList.json` for their data — both similarly broken on TEST. Same refactor (fetch from API) is the fix. Will file as separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)