### PR TITLE
hotfix(seo): generateStaticParams filter empty parentSlug (unblocks PROD build)

### DIFF
--- a/src/app/tango/[parent]/[city]/page.js
+++ b/src/app/tango/[parent]/[city]/page.js
@@ -37,7 +37,13 @@ async function getCityPage(parentSlug, citySlug) {
 export async function generateStaticParams() {
   const summary = await getGeoSummary();
   if (!summary) return [];
-  return summary.cities.map((c) => ({ parent: c.parentSlug, city: c.citySlug }));
+  // Defensive: skip cities missing parentSlug or citySlug. Empty parent produces
+  // /tango//city which trips Next.js NormalizeError. PROD has ~14 international
+  // city-states (Berlin, Rome, etc.) without parentSlug populated yet — pending
+  // CALBEAF backfill ticket. They render via dynamic ISR if hit by URL.
+  return summary.cities
+    .filter((c) => c.parentSlug && c.citySlug)
+    .map((c) => ({ parent: c.parentSlug, city: c.citySlug }));
 }
 
 export async function generateMetadata({ params }) {

--- a/src/app/tango/[parent]/page.js
+++ b/src/app/tango/[parent]/page.js
@@ -42,7 +42,15 @@ export async function generateStaticParams() {
   if (!summary?.cities?.length) return [];
   const seen = new Set();
   return summary.cities
-    .filter((c) => { if (seen.has(c.parentSlug)) return false; seen.add(c.parentSlug); return true; })
+    // Defensive: skip cities with empty parentSlug (PROD has ~14 international
+    // city-states pending CALBEAF backfill). Empty parent produces /tango/ which
+    // trips Next.js NormalizeError.
+    .filter((c) => {
+      if (!c.parentSlug) return false;
+      if (seen.has(c.parentSlug)) return false;
+      seen.add(c.parentSlug);
+      return true;
+    })
     .map((c) => ({ parent: c.parentSlug }));
 }
 


### PR DESCRIPTION
Vercel PROD build aborted on `/tango//berlin` NormalizeError. 14 cities have empty parentSlug. Defensive filter; strictly safer.