### PR TITLE
DEPLOY-PROD: hotfix — generateStaticParams filter empty parentSlug

### DIFF
--- a/src/app/tango/[parent]/[city]/page.js
+++ b/src/app/tango/[parent]/[city]/page.js
@@ -37,7 +37,13 @@ async function getCityPage(parentSlug, citySlug) {
 export async function generateStaticParams() {
   const summary = await getGeoSummary();
   if (!summary) return [];
-  return summary.cities.map((c) => ({ parent: c.parentSlug, city: c.citySlug }));
+  // Defensive: skip cities missing parentSlug or citySlug. Empty parent produces
+  // /tango//city which trips Next.js NormalizeError. PROD has ~14 international
+  // city-states (Berlin, Rome, etc.) without parentSlug populated yet — pending
+  // CALBEAF backfill ticket. They render via dynamic ISR if hit by URL.
+  return summary.cities
+    .filter((c) => c.parentSlug && c.citySlug)
+    .map((c) => ({ parent: c.parentSlug, city: c.citySlug }));
 }
 
 export async function generateMetadata({ params }) {

--- a/src/app/tango/[parent]/page.js
+++ b/src/app/tango/[parent]/page.js
@@ -42,7 +42,15 @@ export async function generateStaticParams() {
   if (!summary?.cities?.length) return [];
   const seen = new Set();
   return summary.cities
-    .filter((c) => { if (seen.has(c.parentSlug)) return false; seen.add(c.parentSlug); return true; })
+    // Defensive: skip cities with empty parentSlug (PROD has ~14 international
+    // city-states pending CALBEAF backfill). Empty parent produces /tango/ which
+    // trips Next.js NormalizeError.
+    .filter((c) => {
+      if (!c.parentSlug) return false;
+      if (seen.has(c.parentSlug)) return false;
+      seen.add(c.parentSlug);
+      return true;
+    })
     .map((c) => ({ parent: c.parentSlug }));
 }
 


### PR DESCRIPTION
## Summary
Hotfix on top of the failed PR #330 attempt. Vercel PROD build aborted on `/tango//berlin` (Next.js `NormalizeError`) because 14 PROD cities have empty `parentSlug` (Berlin, Rome, Naples, Frankfurt, Milan, etc. — international city-states pending BE data backfill).

This PR adds a defensive filter in both `generateStaticParams` functions to skip cities with empty parentSlug. Strictly safer than the prior bundle: filter only EXCLUDES cities that would crash the build. Working cities behave identically.

## What's in this PR (vs current PROD)

- The full TIEMPO-450 SEO bundle (21 commits already merged via PR #330 to TEST → PROD; that PR DID merge to PROD branch but Vercel build aborted before deploy went live)
- Plus PR #331 (just merged) — the parentSlug filter

## Resolution path

1. Toby merges this PR
2. Re-run `vercel --prod` (will pick up the fix, build should succeed this time)
3. Joint smoke test against pre-deploy baseline

## Excluded cities

The 14 cities will not have pre-rendered SEO pages until BE backfill ticket lands. They WILL render via dynamic ISR if accessed by URL (BE accepts the request).

Filing CALBEAF-X for BE backfill: populate `parentSlug` for international city-states (Berlin → germany, Rome → italy, etc.) so all 89 cities pre-render.

## CRK confidence (unchanged from PR #330)

| Feature | Confidence |
|---------|-----------|
| /calendar (anon, logged-in, nav, filter) | 95% |
| /calendar/boston | 97% |
| CRUD | 95% |
| /event/[id] | 97% |
| Auth | 97% |

The hotfix is strictly defensive — no new risk.

## Rollback

`git revert` PROD to `bc3ab694` (v1.28.9). Same plan as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)