### PR TITLE
fix(seo): organizers-copy reframe + orphan-parent event leak

### DIFF
--- a/src/app/tango/[parent]/[city]/page.js
+++ b/src/app/tango/[parent]/[city]/page.js
@@ -298,7 +298,16 @@ export default async function CityPage({ params }) {
                 <Typography variant="body2">{summary.futureEventCount} upcoming events</Typography>
                 {summary.travelWorthyCount > 0 && <Typography variant="body2">{summary.travelWorthyCount} travel-worthy</Typography>}
                 {summary.forBeginnersCount > 0 && <Typography variant="body2">{summary.forBeginnersCount} beginner-friendly</Typography>}
-                <Typography variant="body2">{summary.organizerCount} local organizers</Typography>
+                {summary.organizerCount > 0 ? (
+                  <Typography variant="body2">{summary.organizerCount} TangoTiempo registered organizers</Typography>
+                ) : (
+                  <Typography variant="body2">
+                    0 TangoTiempo registered organizers —{' '}
+                    <Link href="/organizers/apply" style={{ color: '#8B1538', fontWeight: 600 }}>
+                      be the first to apply free!
+                    </Link>
+                  </Typography>
+                )}
               </Box>
             </CardContent>
           </Card>

--- a/src/app/tango/[parent]/page.js
+++ b/src/app/tango/[parent]/page.js
@@ -83,7 +83,13 @@ export default async function ParentPage({ params }) {
   const parentName = cities[0].parentName || cities[0].countryName;
   const countryName = cities[0].countryName;
   const totalEvents = cities.reduce((n, c) => n + c.futureEventCount, 0);
-  const events = await getCountryEvents(cities[0].countryId);
+  // Defensive: only fetch country-wide events when this parent has multiple cities.
+  // Single-city parents (Massachusetts→Boston, Colorado→Denver, Oregon→Portland, etc.)
+  // would otherwise show country-wide events (often Boston-spillover) which misrepresents
+  // the parent's actual scene. CALBEAF-171 will normalize parents[] coverage; until then
+  // this prevents user-visible "Boston events on /tango/colorado" leakage.
+  const isSingleCity = cities.length === 1;
+  const events = isSingleCity ? [] : await getCountryEvents(cities[0].countryId);
 
   const eventSchema = events.slice(0, 5).map((e) => ({
     '@type': 'Event',


### PR DESCRIPTION
Bug 1: city sidebar 'X local organizers' reframed to 'X TangoTiempo registered organizers' with apply CTA at 0. Bug 2: parent page skips country-wide events fetch when single-city parent (prevents Boston events showing on /tango/colorado etc). Pairs with Fulton's CALBEAF-171.