### PR TITLE
DEPLOY-PROD: organizers-copy reframe + orphan-parent guard + venue field normalization

### DIFF
--- a/src/app/hooks/useEvents.js
+++ b/src/app/hooks/useEvents.js
@@ -513,6 +513,21 @@ export function useEventOperations() {
       if (!user) {
         throw new Error('You must be logged in to create events');
       }
+
+      // FIELD-NAMING-HYGIENE Phase A Entity #1 — Venue normalization
+      // Form state has both venueId (canonical) and locationID (legacy WP-era).
+      // BE response/validator paths use venueID (uppercase, mongoose-style).
+      // Normalize all three at the boundary so downstream consumers don't trip
+      // on case-mismatch (RegionalAdmin event-create bug 2026-05-01).
+      // See MasterCalendar/docs/FIELD-NAMING-HYGIENE.md
+      if (eventData) {
+        const _vid = eventData.venueID || eventData.venueId || eventData.locationID;
+        if (_vid) {
+          eventData.venueID = _vid;
+          eventData.venueId = _vid;
+          eventData.locationID = _vid;
+        }
+      }
       
       // Get a fresh token for the request
       let token;
@@ -741,6 +756,17 @@ export function useEventOperations() {
       // Check if user is authenticated
       if (!user) {
         throw new Error('You must be logged in to update events');
+      }
+
+      // FIELD-NAMING-HYGIENE Phase A Entity #1 — Venue normalization (mirrors createEvent).
+      // See MasterCalendar/docs/FIELD-NAMING-HYGIENE.md
+      if (eventData) {
+        const _vid = eventData.venueID || eventData.venueId || eventData.locationID;
+        if (_vid) {
+          eventData.venueID = _vid;
+          eventData.venueId = _vid;
+          eventData.locationID = _vid;
+        }
       }
       
       // Get a fresh token for the request

--- a/src/app/tango/[parent]/[city]/page.js
+++ b/src/app/tango/[parent]/[city]/page.js
@@ -298,7 +298,16 @@ export default async function CityPage({ params }) {
                 <Typography variant="body2">{summary.futureEventCount} upcoming events</Typography>
                 {summary.travelWorthyCount > 0 && <Typography variant="body2">{summary.travelWorthyCount} travel-worthy</Typography>}
                 {summary.forBeginnersCount > 0 && <Typography variant="body2">{summary.forBeginnersCount} beginner-friendly</Typography>}
-                <Typography variant="body2">{summary.organizerCount} local organizers</Typography>
+                {summary.organizerCount > 0 ? (
+                  <Typography variant="body2">{summary.organizerCount} TangoTiempo registered organizers</Typography>
+                ) : (
+                  <Typography variant="body2">
+                    0 TangoTiempo registered organizers —{' '}
+                    <Link href="/organizers/apply" style={{ color: '#8B1538', fontWeight: 600 }}>
+                      be the first to apply free!
+                    </Link>
+                  </Typography>
+                )}
               </Box>
             </CardContent>
           </Card>

--- a/src/app/tango/[parent]/page.js
+++ b/src/app/tango/[parent]/page.js
@@ -83,7 +83,13 @@ export default async function ParentPage({ params }) {
   const parentName = cities[0].parentName || cities[0].countryName;
   const countryName = cities[0].countryName;
   const totalEvents = cities.reduce((n, c) => n + c.futureEventCount, 0);
-  const events = await getCountryEvents(cities[0].countryId);
+  // Defensive: only fetch country-wide events when this parent has multiple cities.
+  // Single-city parents (Massachusetts→Boston, Colorado→Denver, Oregon→Portland, etc.)
+  // would otherwise show country-wide events (often Boston-spillover) which misrepresents
+  // the parent's actual scene. CALBEAF-171 will normalize parents[] coverage; until then
+  // this prevents user-visible "Boston events on /tango/colorado" leakage.
+  const isSingleCity = cities.length === 1;
+  const events = isSingleCity ? [] : await getCountryEvents(cities[0].countryId);
 
   const eventSchema = events.slice(0, 5).map((e) => ({
     '@type': 'Event',


### PR DESCRIPTION
## Summary

Three small fixes bundled, all merged to TEST and tested:

### Bug 1 — Organizers copy reframe (PR #334)
City sidebar "X local organizers" → "X TangoTiempo registered organizers" (with apply CTA when 0). Fixes misleading "0 local organizers" reading as "no tango here" on cities with no registered orgs yet.

### Bug 2 — Orphan-parent event leak guard (PR #334)
`/tango/colorado` (and 28 other single-city parents) was rendering 6 country-wide events in the "Upcoming Events" section — surfaced Boston event spillover on Colorado/Utah/Oregon/etc. Defensive: skip the country-wide events fetch when `cities.length === 1`. Pairs with Fulton's incoming CALBEAF-171 (BE-side `parentMin` lowering tomorrow).

### Phase A Entity 1a — Venue field normalization (PR #335)
Solves the RegionalAdmin event-create bug from earlier today. Form state had three names for the venue (`venueId`, `venueID`, `locationID`); `useEvents.js` validator checked `venueID` (uppercase ID) — case-mismatch threw. Defensive normalization at `createEvent + updateEvent` boundary: write all three names from any one. Strictly additive — never strips a valid value. See `MasterCalendar/docs/FIELD-NAMING-HYGIENE.md` for the full 3-phase plan.

**Authorized by Toby (DEPLOY-PROD): 2026-05-01 (this session, second deploy of the day).**

## TEST verification
- ✅ Bug 1: Boston (9 orgs) shows "9 TangoTiempo registered organizers"; zero-org cities show apply CTA
- ✅ Bug 2: `/tango/colorado` (Denver only), `/tango/utah` (SLC only), `/tango/oregon` (Portland only) — events section hidden. `/tango/australia` (multi-city) still renders events normally.
- ✅ Bug 3 / Phase A: Toby (the only RA) tested event create with selected venue on TEST — saves clean, no error.

## CRK confidence per existing feature
- /calendar viewing: 99%
- Event create RA: 97% (TEST verified)
- Event create RO/SystemAdmin: 96% (untested, but normalization is additive — no path that worked before could break)
- /tango/[parent] multi-city: 99% (logic unchanged when cities.length > 1)
- /tango/[parent] single-city: 98% (events section hidden — intentional)
- City sidebar copy: 99% (conditional render on organizerCount)

## Rollback
Single `git revert <commit-sha>` per PR (#334 and #335 independent), push to PROD, `vercel --prod`. ~5 min each.

## Post-deploy smoke (10 min)
- [ ] `/calendar` anon renders events
- [ ] `/tango/colorado` no events leak
- [ ] `/tango/australia` events still render
- [ ] `/tango/massachusetts/boston` sidebar shows "X TangoTiempo registered organizers"
- [ ] Zero-org city shows apply CTA
- [ ] Login as RA, create event with venue → saves clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)