### PR TITLE
fix(events): Save Anyway should not bypass required-field validation

### DIFF
--- a/src/app/components/Modals/CreateEvents/CreateEventDetailModal.js
+++ b/src/app/components/Modals/CreateEvents/CreateEventDetailModal.js
@@ -583,15 +583,19 @@ const CreateEventModal = ({ open, onClose, selectedDate, editMode = false, event
         throw new Error('You must be logged in to create events');
       }
       
-      // Validate fields unless skipping (for "Save Without Image")
-      if (!skipValidation) {
-        const errors = validateEventData();
-        if (errors.length > 0) {
-          setValidationErrors(errors);
-          setValidationDialogOpen(true);
-          setSaving(false);
-          return;
-        }
+      // Validate fields. "Save Anyway" (skipValidation=true) bypasses recommended-only
+      // errors (e.g. missing image), but REQUIRED errors (categoryFirstId, venueId,
+      // description, recurrence config) ALWAYS block. PROD bug 2026-05-01: an event
+      // saved with no categoryFirst because Save Anyway bypassed required validation.
+      const errors = validateEventData();
+      const blockingErrors = skipValidation
+        ? errors.filter((e) => e.required === true)
+        : errors;
+      if (blockingErrors.length > 0) {
+        setValidationErrors(blockingErrors);
+        setValidationDialogOpen(true);
+        setSaving(false);
+        return;
       }
       
       // Check if user can create events (RegionalOrganizer or RegionalAdmin)


### PR DESCRIPTION
PROD repro: event saved without categoryFirst because Save Anyway skipped ALL validation. Required errors (category, venue, description) now always block. Fulton filing CALBEAF for BE schema validator defense-in-depth.