### PR TITLE
DEPLOY-PROD: Save Anyway should not bypass required-field validation

### DIFF
--- a/src/app/components/Modals/CreateEvents/CreateEventDetailModal.js
+++ b/src/app/components/Modals/CreateEvents/CreateEventDetailModal.js
@@ -583,15 +583,19 @@ const CreateEventModal = ({ open, onClose, selectedDate, editMode = false, event
         throw new Error('You must be logged in to create events');
       }
       
-      // Validate fields unless skipping (for "Save Without Image")
-      if (!skipValidation) {
-        const errors = validateEventData();
-        if (errors.length > 0) {
-          setValidationErrors(errors);
-          setValidationDialogOpen(true);
-          setSaving(false);
-          return;
-        }
+      // Validate fields. "Save Anyway" (skipValidation=true) bypasses recommended-only
+      // errors (e.g. missing image), but REQUIRED errors (categoryFirstId, venueId,
+      // description, recurrence config) ALWAYS block. PROD bug 2026-05-01: an event
+      // saved with no categoryFirst because Save Anyway bypassed required validation.
+      const errors = validateEventData();
+      const blockingErrors = skipValidation
+        ? errors.filter((e) => e.required === true)
+        : errors;
+      if (blockingErrors.length > 0) {
+        setValidationErrors(blockingErrors);
+        setValidationDialogOpen(true);
+        setSaving(false);
+        return;
       }
       
       // Check if user can create events (RegionalOrganizer or RegionalAdmin)


### PR DESCRIPTION
## Summary

PROD repro earlier today: event saved without `categoryFirst` because the user clicked "Save Anyway" on the validation dialog after hitting warnings. `handleSave(skipValidation=true)` was bypassing ALL validation including required fields.

Fix: Save Anyway now only ignores recommended-only errors (`required: false`). Required errors (`required: true` — categoryFirstId, venueId, description, recurrence config) ALWAYS block.

**Authorized by Toby (DEPLOY-PROD): 2026-05-01 (third deploy of the session).**

## Tested on TEST
- Create event with no category → blocked even on Save Anyway ✓
- Create event with no image but valid required fields → Save Anyway works (image is recommended) ✓

## Risk: very low (98% confidence)
Pure additive validation tightening. Only behavioral change: Save Anyway can't silently skip required fields. No paths that worked before will break.

## Pairs with
- Fulton filing CALBEAF for BE-side Mongoose schema validator (defense-in-depth — prevents headless events via any API path)
- Toby's orphan event `69f52cc8fa4a5964fe07c4d3` (test event with no category) — separately handled (delete or backfill)

## Rollback
Single `git revert <commit>`, push to PROD, `vercel --prod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)