### PR TITLE
chore(events): drop redundant RA-specific venueID assertion

### DIFF
--- a/src/app/hooks/useEvents.js
+++ b/src/app/hooks/useEvents.js
@@ -698,14 +698,13 @@ export function useEventOperations() {
         }
       }
 
-      // Validate required fields for RA endpoint
-      if (selectedRole === 'RegionalAdmin') {
-        if (!preparedData.ownerOrganizerID) {
-          throw new Error('RegionalAdmin must specify an ownerOrganizerID for the event');
-        }
-        if (!preparedData.venueID) {
-          throw new Error('RegionalAdmin must specify a venueID for the event');
-        }
+      // RA-specific assertion: ownerOrganizerID must be explicit on submit.
+      // RO has owner implicit (= self, auto-filled), but RA picks an owner from
+      // a dropdown — this catches an empty selection with a clear FE error.
+      // Venue is required for ALL events and validated at form-submit time
+      // (CreateEventDetailModal:519), so no role-specific venue check needed.
+      if (selectedRole === 'RegionalAdmin' && !preparedData.ownerOrganizerID) {
+        throw new Error('RegionalAdmin must specify an ownerOrganizerID for the event');
       }
 
 // TIEMPO-276: Security cleanup - removed logging


### PR DESCRIPTION
Venue required for ALL events regardless of role (form already validates at CreateEventDetailModal:519). RA-specific throw in useEvents was duplicate paranoia. Owner assertion stays (RA picks; RO implicit). Bells list now clean: 3 legit divergences.