### PR TITLE
TIEMPO-451 hotfix: /tango/[parent] — disable country-wide event fetch

### DIFF
--- a/src/app/tango/[parent]/page.js
+++ b/src/app/tango/[parent]/page.js
@@ -23,20 +23,6 @@ async function getGeoSummary(params = '') {
   } catch { return null; }
 }
 
-async function getCountryEvents(countryId) {
-  try {
-    const now = new Date().toISOString();
-    const end = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
-    const res = await fetch(
-      `${API_URL}/api/events?appId=1&masteredCountryId=${countryId}&start=${now}&end=${end}&limit=6`,
-      { next: { revalidate: 3600 } }
-    );
-    if (!res.ok) return [];
-    const data = await res.json();
-    return data.events || [];
-  } catch { return []; }
-}
-
 export async function generateStaticParams() {
   const summary = await getGeoSummary();
   if (!summary?.cities?.length) return [];
@@ -83,13 +69,13 @@ export default async function ParentPage({ params }) {
   const parentName = cities[0].parentName || cities[0].countryName;
   const countryName = cities[0].countryName;
   const totalEvents = cities.reduce((n, c) => n + c.futureEventCount, 0);
-  // Defensive: only fetch country-wide events when this parent has multiple cities.
-  // Single-city parents (Massachusetts→Boston, Colorado→Denver, Oregon→Portland, etc.)
-  // would otherwise show country-wide events (often Boston-spillover) which misrepresents
-  // the parent's actual scene. CALBEAF-171 will normalize parents[] coverage; until then
-  // this prevents user-visible "Boston events on /tango/colorado" leakage.
-  const isSingleCity = cities.length === 1;
-  const events = isSingleCity ? [] : await getCountryEvents(cities[0].countryId);
+  // TIEMPO-451 hotfix: country-wide event fetch leaks Boston/MA events into
+  // multi-city parents (e.g. /tango/california). PR #334 fixed only the
+  // single-city case; multi-city kept calling getCountryEvents and showed
+  // wrong-region events SSR. Disabled entirely until BE parent-scoped events
+  // query lands (Track C, new CALBEAF ticket — note: existing CALBEAF-171 is
+  // unrelated despite earlier comment here).
+  const events = [];
 
   const eventSchema = events.slice(0, 5).map((e) => ({
     '@type': 'Event',

--- a/src/app/tango/[parent]/page.js
+++ b/src/app/tango/[parent]/page.js
@@ -69,12 +69,11 @@ export default async function ParentPage({ params }) {
   const parentName = cities[0].parentName || cities[0].countryName;
   const countryName = cities[0].countryName;
   const totalEvents = cities.reduce((n, c) => n + c.futureEventCount, 0);
-  // TIEMPO-451 hotfix: country-wide event fetch leaks Boston/MA events into
-  // multi-city parents (e.g. /tango/california). PR #334 fixed only the
-  // single-city case; multi-city kept calling getCountryEvents and showed
-  // wrong-region events SSR. Disabled entirely until BE parent-scoped events
-  // query lands (Track C, new CALBEAF ticket — note: existing CALBEAF-171 is
-  // unrelated despite earlier comment here).
+  // TIEMPO-451 hotfix for CALBEAF-173: country-wide event fetch was leaking
+  // Boston/MA events into multi-city parents (e.g. /tango/california). PR #334
+  // fixed only the single-city case; multi-city kept calling getCountryEvents
+  // and rendered wrong-region events SSR. Disabled entirely until CALBEAF-173
+  // ships a parent-scoped events query.
   const events = [];
 
   const eventSchema = events.slice(0, 5).map((e) => ({


### PR DESCRIPTION
## Summary
- 1-line hotfix: drop `getCountryEvents()` call from `/tango/[parent]/page.js`. Multi-city parents (CA, NY, FL, foreign multi-city countries) were SSR-rendering Boston/MA events on /tango/california etc.
- Track A of A+C plan agreed by Toby via Number2; Track C (BE parent-scoped events query) is a separate Quinn-orchestrated thread.

## Why this is needed
PR #334's "orphan-parent event leak guard" only fixed single-city parents. Multi-city continued calling `getCountryEvents(masteredCountryId)` and rendered country-wide events. Confirmed via PROD curl: `/tango/california` HTML contained "Practica Chiquita at Ultimate Tango" (Boston venue) and "Practica del Valle at First Churches of Northampton" (MA).

## Change
- Removed `getCountryEvents` function (single caller)
- Replaced `events = isSingleCity ? [] : await getCountryEvents(...)` with `events = []`
- Updated stale CALBEAF-171 comment (existing CALBEAF-171 is BE category validation, unrelated)
- City pills, summary stats, JSON-LD scaffold unchanged
- Existing `{events.length > 0 && ...}` guard means the events section simply doesn't render now

## Test plan
- [ ] TEST `/tango/california` — no "Upcoming Tango Events in California" section, city pills + summary visible
- [ ] TEST `/tango/massachusetts` (single-city) — unchanged behavior, no events section
- [ ] TEST `/tango/argentina` (multi-city foreign) — no events section, city pills visible
- [ ] TEST `/tango/california/los-angeles` (city-level page) — unchanged, still renders city-scoped data via `/api/seo/city-page`
- [ ] Quinn ratification before TEST→PROD
- [ ] Fresh Toby Telegram reauth required for DEPLOY-PROD per standing rule

## JIRA
- TIEMPO-451 (this hotfix)
- New CALBEAF ticket TBD (Track C, Quinn-filing)

## Sequencing
Standalone — does NOT ride with held FE bundle (PRs #339-#343 still gated by RA-Create stub admin patch). Per Quinn's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)