### PR TITLE
DEPLOY-PROD: TIEMPO-451 hotfix + regression test (cherry-pick)

### DIFF
--- a/cypress/e2e/01-readonly/seo-tango-parent-regression.cy.js
+++ b/cypress/e2e/01-readonly/seo-tango-parent-regression.cy.js
@@ -1,0 +1,81 @@
+// SEO /tango/[parent] regression test — TIEMPO-451 / CALBEAF-173
+//
+// Bug history: PR #334 added an "orphan-parent event leak guard" that fixed
+// only single-city parents. Multi-city parents (CA, NY, FL, AU, IT, etc.)
+// continued calling getCountryEvents(masteredCountryId) and rendered country-
+// wide events SSR. Tangotiempo's heaviest event density is Boston/MA, so
+// /tango/california displayed Massachusetts events server-side.
+//
+// What this test asserts (BUG INVARIANT, not implementation invariant):
+//   /tango/<multi-city-parent> SSR HTML must NOT contain known
+//   Massachusetts/Boston venue strings. The events that DO render must
+//   belong to the parent region, not leak from the country at large.
+//
+// Lifecycle resilience:
+//   - Pre-fix code (#330/#334-era):     FAILS — MA venues present in HTML
+//   - Track A (#344, events = []):      PASSES — no events render
+//   - Track C (CALBEAF-173, scoped fetch): PASSES — only region events render
+//
+// Test runs against SSR HTML via cy.request, not the hydrated DOM —
+// catches server-side leaks (which is where the bug lived).
+
+describe('SEO /tango/[parent] — country-wide event leak regression (TIEMPO-451)', () => {
+  // Known Massachusetts venue strings observed leaking on PROD pre-hotfix.
+  // Captured 2026-05-04 from /tango/california SSR HTML on tangotiempo.com.
+  // Add to this list if future leaks surface other regions' venues.
+  const MA_VENUE_STRINGS = [
+    'Ultimate Tango',                    // Boston tango venue (well-known)
+    'First Churches of Northampton',     // Northampton, MA
+    'Practica del Valle',                // MA-based event
+  ];
+
+  // Multi-city parents: where the leak surfaced. Single-city parents
+  // (Massachusetts, Oregon, Colorado) were already protected by PR #334's
+  // isSingleCity guard, so they're not the regression target — but they're
+  // included as controls to confirm we didn't break them.
+  const MULTI_CITY_PARENTS = ['california', 'new-york', 'australia'];
+  const SINGLE_CITY_PARENTS = ['massachusetts', 'oregon'];
+
+  function assertNoMassachusettsLeak(parentSlug) {
+    cy.request(`/tango/${parentSlug}`).then((resp) => {
+      expect(resp.status, `${parentSlug} HTTP status`).to.eq(200);
+      MA_VENUE_STRINGS.forEach((venue) => {
+        expect(resp.body, `${parentSlug} SSR must not contain "${venue}"`)
+          .to.not.include(venue);
+      });
+    });
+  }
+
+  context('Multi-city parents (regression target)', () => {
+    MULTI_CITY_PARENTS.forEach((slug) => {
+      it(`/tango/${slug} SSR contains no MA venue strings`, () => {
+        assertNoMassachusettsLeak(slug);
+      });
+    });
+  });
+
+  context('Single-city parents (control — already correct pre-hotfix)', () => {
+    SINGLE_CITY_PARENTS.forEach((slug) => {
+      it(`/tango/${slug} SSR remains clean`, () => {
+        // Single-city parents that ARE Massachusetts (e.g. /tango/massachusetts)
+        // would legitimately surface MA venues — exclude that case from the
+        // assertion. Only run leak-check for non-MA single-city parents.
+        if (slug !== 'massachusetts') {
+          assertNoMassachusettsLeak(slug);
+        } else {
+          // For massachusetts itself, just assert page renders successfully.
+          cy.request(`/tango/${slug}`).its('status').should('eq', 200);
+        }
+      });
+    });
+  });
+
+  context('Page skeleton intact (smoke)', () => {
+    it('multi-city parent renders landing skeleton', () => {
+      cy.visit('/tango/california');
+      cy.contains('h1', 'Argentine Tango Events in California').should('exist');
+      cy.contains('Tango Cities in California').should('exist');
+      cy.contains('Browse Full Calendar').should('exist');
+    });
+  });
+});

--- a/src/app/tango/[parent]/page.js
+++ b/src/app/tango/[parent]/page.js
@@ -23,20 +23,6 @@ async function getGeoSummary(params = '') {
   } catch { return null; }
 }
 
-async function getCountryEvents(countryId) {
-  try {
-    const now = new Date().toISOString();
-    const end = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
-    const res = await fetch(
-      `${API_URL}/api/events?appId=1&masteredCountryId=${countryId}&start=${now}&end=${end}&limit=6`,
-      { next: { revalidate: 3600 } }
-    );
-    if (!res.ok) return [];
-    const data = await res.json();
-    return data.events || [];
-  } catch { return []; }
-}
-
 export async function generateStaticParams() {
   const summary = await getGeoSummary();
   if (!summary?.cities?.length) return [];
@@ -83,13 +69,13 @@ export default async function ParentPage({ params }) {
   const parentName = cities[0].parentName || cities[0].countryName;
   const countryName = cities[0].countryName;
   const totalEvents = cities.reduce((n, c) => n + c.futureEventCount, 0);
-  // Defensive: only fetch country-wide events when this parent has multiple cities.
-  // Single-city parents (Massachusetts→Boston, Colorado→Denver, Oregon→Portland, etc.)
-  // would otherwise show country-wide events (often Boston-spillover) which misrepresents
-  // the parent's actual scene. CALBEAF-171 will normalize parents[] coverage; until then
-  // this prevents user-visible "Boston events on /tango/colorado" leakage.
-  const isSingleCity = cities.length === 1;
-  const events = isSingleCity ? [] : await getCountryEvents(cities[0].countryId);
+  // TIEMPO-451 hotfix: country-wide event fetch leaks Boston/MA events into
+  // multi-city parents (e.g. /tango/california). PR #334 fixed only the
+  // single-city case; multi-city kept calling getCountryEvents and showed
+  // wrong-region events SSR. Disabled entirely until BE parent-scoped events
+  // query lands (Track C, new CALBEAF ticket — note: existing CALBEAF-171 is
+  // unrelated despite earlier comment here).
+  const events = [];
 
   const eventSchema = events.slice(0, 5).map((e) => ({
     '@type': 'Event',

--- a/src/app/tango/[parent]/page.js
+++ b/src/app/tango/[parent]/page.js
@@ -69,12 +69,11 @@ export default async function ParentPage({ params }) {
   const parentName = cities[0].parentName || cities[0].countryName;
   const countryName = cities[0].countryName;
   const totalEvents = cities.reduce((n, c) => n + c.futureEventCount, 0);
-  // TIEMPO-451 hotfix: country-wide event fetch leaks Boston/MA events into
-  // multi-city parents (e.g. /tango/california). PR #334 fixed only the
-  // single-city case; multi-city kept calling getCountryEvents and showed
-  // wrong-region events SSR. Disabled entirely until BE parent-scoped events
-  // query lands (Track C, new CALBEAF ticket — note: existing CALBEAF-171 is
-  // unrelated despite earlier comment here).
+  // TIEMPO-451 hotfix for CALBEAF-173: country-wide event fetch was leaking
+  // Boston/MA events into multi-city parents (e.g. /tango/california). PR #334
+  // fixed only the single-city case; multi-city kept calling getCountryEvents
+  // and rendered wrong-region events SSR. Disabled entirely until CALBEAF-173
+  // ships a parent-scoped events query.
   const events = [];
 
   const eventSchema = events.slice(0, 5).map((e) => ({


### PR DESCRIPTION
## Summary
- DEPLOY-PROD authorized by Toby on `DEPLOY-PROD PR #344` (relayed via Number2 2026-05-04T16:54).
- **Cherry-pick mechanism** (Quinn-approved): literal TEST→PROD would carry the held FE bundle (PRs #339-#343) which is NOT authorized for PROD. Held bundle is gated on a separate RA-Create stub-admin track. This branch contains ONLY the 3 commits Toby authorized.

## Commits (cherry-picked from TEST)
- `04243857` ← `f2f0dafc` — fix(seo): /tango/[parent] — disable country-wide event fetch (TIEMPO-451)
- `ec3a91c5` ← `a1a82054` — chore(seo): point /tango/[parent] hotfix comment at CALBEAF-173
- `84c4f0ba` ← `2037f57d` — test(seo): regression for /tango/[parent] country-wide event leak (TIEMPO-451)

## What this fixes (PROD bug)
PR #334's "orphan-parent event leak guard" only fixed single-city parents. Multi-city parents (CA, NY, FL, AU, IT) kept calling `getCountryEvents(masteredCountryId)` and rendered country-wide events SSR. /tango/california displayed Massachusetts events ("Practica Chiquita at Ultimate Tango", "Practica del Valle at First Churches of Northampton" — confirmed in PROD HTML pre-fix).

## Track A fix (this PR)
Drops `getCountryEvents()` and sets `events = []` in `src/app/tango/[parent]/page.js`. Empty events block elides via existing `{events.length > 0 && ...}` guard. City pills + summary stats unchanged. JSON-LD scaffold renders empty `@graph`.

## Track C (separate, Quinn-orchestrated, NOT this PR)
CALBEAF-173 — BE parent-scoped events query. When that ships, FE swaps `events = []` for the new fetch. Bug-invariant regression test in this PR stays valid through Track C.

## Stacked gates cleared
1. ✅ Quinn diff ratify (PR #344 + PR #345)
2. ✅ Full TEST sweep (26/26 parents pass; 4 city anomalies pre-existing data, not hotfix-caused)
3. ✅ Regression test PR #345 ratified — verified FAIL on PROD pre-fix (2/3 multi-city catch the leak), PASS on TEST post-fix (6/6 green)
4. ✅ CRK doc `MasterCalendar/docs/PRE-PROD-CRK-2026-05-04-pr344.md` (Quinn-drafted, 98% aggregate confidence)
5. ✅ DEPLOY-PROD reauth from Toby

## Related links
- PR #344 (the hotfix on TEST, already merged): https://github.com/ybotman/tangotiempo.com/pull/344
- PR #345 (regression test on TEST, already merged): https://github.com/ybotman/tangotiempo.com/pull/345
- JIRA TIEMPO-451 (this hotfix)
- JIRA CALBEAF-173 (Track C, scheduled)

## Test plan after merge
**Sarah executes per Number2's checklist:**
- [ ] Toby merges this PR in GitHub UI (no `gh pr merge`)
- [ ] `vercel --prod` (manual; Vercel PROD auto-deploy is disabled)
- [ ] Cypress regression spec against PROD: expect 6/6 GREEN
- [ ] /tango/california, /tango/new-york, /tango/australia → no MA venue strings
- [ ] /tango/california/los-angeles → city-scoped, unchanged
- [ ] /tango/massachusetts → unchanged
- [ ] /calendar smoke (anon + logged-in)
- [ ] Browser console clean on /tango/california

## Rollback
Single-revert on the merge commit per CRK lines 138-148. Equivalent to current PROD state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)