### PR TITLE
CALBEAF-173 FE swap: wire /tango/[parent] to parent-scoped events query

### DIFF
--- a/cypress/e2e/01-readonly/seo-tango-parent-region-assertion.cy.js
+++ b/cypress/e2e/01-readonly/seo-tango-parent-region-assertion.cy.js
@@ -1,0 +1,117 @@
+// SEO /tango/[parent] region-assertion test — CALBEAF-173 (Track C)
+//
+// Supersedes the bug-shaped PR #345 regression test once Track C ships.
+// Both can co-exist; this one is the canonical contract-level assertion.
+//
+// What this asserts (REGION CORRECTNESS, positive set-membership):
+//   For every parent (CA, NY, AU, MA):
+//     1. BE endpoint returns events whose masteredCountryName matches the
+//        parent's expected country (positive single-value membership)
+//     2. BE endpoint returns events with non-empty masteredCityName
+//        (rules out null short-circuit hazards)
+//     3. State-level disjointness: events from /api/events?parentSlug=california
+//        do NOT appear in /api/events?parentSlug=massachusetts (catches
+//        state-level leaks that country-only checks would miss)
+//     4. FE page renders successfully with parent name in title
+//
+// Test-hygiene rule (from Fulton's M3 self-catch, codified in
+// feedback_tests_fail_before_pass.md):
+//   ✗ DO NOT anchor on potentially-null fields with truthy-guard inequality
+//     (e.g. `e.masteredDivisionName && e.masteredDivisionName !== 'California'`)
+//     — short-circuits to silent pass when the field is null.
+//   ✓ DO anchor on always-populated fields with positive set membership.
+//
+// Field availability (verified 2026-05-04 against TEST + PROD):
+//   - masteredCityId       always populated
+//   - masteredCityName     always populated  ← anchor here
+//   - masteredCountryName  always populated  ← anchor here
+//   - masteredDivisionName NOT populated     ← do NOT anchor
+//
+// Why not geo-summary as expected city set:
+//   geo-summary?parentSlug=california returns 4 cities (event-windowed),
+//   but masteredcities + events endpoint resolve to a broader set
+//   (e.g. Orange County also shows up). geo-summary is curated for SEO
+//   display, not authoritative for region assertion.
+//
+// Lifecycle:
+//   - Pre-Track-C (Track A `events = []`): N/A — empty results valid by contract
+//   - Post-Track-C (parent-scoped fetch):  PASS — country/city checks hold,
+//                                                cross-state disjoint holds
+//   - Future regression (BE returns wrong region): FAIL — country mismatch
+//                                                 OR cross-state overlap
+
+const PARENTS = [
+  { slug: 'california', country: 'United States', kind: 'multi-city-state' },
+  { slug: 'new-york', country: 'United States', kind: 'multi-city-state' },
+  { slug: 'australia', country: 'Australia', kind: 'multi-city-country' },
+  { slug: 'massachusetts', country: 'United States', kind: 'single-city-state' },
+];
+
+function eventsRequest(parentSlug, limit = 50) {
+  const now = new Date().toISOString();
+  const end = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
+  return cy.request(
+    `/api/events?appId=1&parentSlug=${parentSlug}&start=${now}&end=${end}&limit=${limit}`,
+  );
+}
+
+describe('SEO /tango/[parent] region assertion (CALBEAF-173)', () => {
+  PARENTS.forEach(({ slug, country, kind }) => {
+    context(`Parent: ${slug} (${kind})`, () => {
+      it(`BE events all have masteredCountryName="${country}" and populated masteredCityName`, () => {
+        eventsRequest(slug).then((resp) => {
+          expect(resp.status).to.eq(200);
+          const events = resp.body.events || [];
+          // Empty results are acceptable per fail-closed contract.
+          events.forEach((e) => {
+            expect(
+              e.masteredCityName,
+              `event ${e._id || e.title} masteredCityName must be populated string`,
+            ).to.be.a('string').and.not.empty;
+            expect(
+              e.masteredCountryName,
+              `event ${e._id || e.title} ("${e.masteredCityName}") masteredCountryName must be "${country}"`,
+            ).to.eq(country);
+          });
+          cy.log(`${slug}: ${events.length} events, all country=${country}, cityName populated`);
+        });
+      });
+
+      it('FE /tango page renders with parent name in title', () => {
+        cy.request(`/tango/${slug}`).then((resp) => {
+          expect(resp.status).to.eq(200);
+          expect(resp.body).to.include('Argentine Tango Events in');
+          expect(resp.body).to.include('Tango Cities in');
+        });
+      });
+    });
+  });
+
+  context('Cross-state disjointness — California ⊄ Massachusetts (state-level leak guard)', () => {
+    it('no event ID returned for parentSlug=california appears in parentSlug=massachusetts', () => {
+      let caIds = new Set();
+      eventsRequest('california', 100).then((caResp) => {
+        expect(caResp.status).to.eq(200);
+        caIds = new Set((caResp.body.events || []).map((e) => e._id));
+        eventsRequest('massachusetts', 100).then((maResp) => {
+          expect(maResp.status).to.eq(200);
+          const maIds = (maResp.body.events || []).map((e) => e._id);
+          const overlap = maIds.filter((id) => caIds.has(id));
+          expect(
+            overlap,
+            `CA and MA event sets must be disjoint; overlap: ${JSON.stringify(overlap)}`,
+          ).to.have.length(0);
+        });
+      });
+    });
+  });
+
+  context('Negative case: unknown parent slug fails closed', () => {
+    it('BE returns empty events for nonexistent parent', () => {
+      eventsRequest('this-parent-does-not-exist-zzz').then((resp) => {
+        expect(resp.status).to.eq(200);
+        expect(resp.body.events || []).to.have.length(0);
+      });
+    });
+  });
+});

--- a/src/app/tango/[parent]/page.js
+++ b/src/app/tango/[parent]/page.js
@@ -23,6 +23,20 @@ async function getGeoSummary(params = '') {
   } catch { return null; }
 }
 
+async function getParentEvents(parentSlug) {
+  try {
+    const now = new Date().toISOString();
+    const end = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
+    const res = await fetch(
+      `${API_URL}/api/events?appId=1&parentSlug=${encodeURIComponent(parentSlug)}&start=${now}&end=${end}&limit=6`,
+      { next: { revalidate: 3600 } }
+    );
+    if (!res.ok) return [];
+    const data = await res.json();
+    return data.events || [];
+  } catch { return []; }
+}
+
 export async function generateStaticParams() {
   const summary = await getGeoSummary();
   if (!summary?.cities?.length) return [];
@@ -69,12 +83,11 @@ export default async function ParentPage({ params }) {
   const parentName = cities[0].parentName || cities[0].countryName;
   const countryName = cities[0].countryName;
   const totalEvents = cities.reduce((n, c) => n + c.futureEventCount, 0);
-  // TIEMPO-451 hotfix for CALBEAF-173: country-wide event fetch was leaking
-  // Boston/MA events into multi-city parents (e.g. /tango/california). PR #334
-  // fixed only the single-city case; multi-city kept calling getCountryEvents
-  // and rendered wrong-region events SSR. Disabled entirely until CALBEAF-173
-  // ships a parent-scoped events query.
-  const events = [];
+  // CALBEAF-173: parent-scoped events query. BE resolves parentSlug → cityIds
+  // via masteredcities, then events.find({ masteredCityId: { $in: cityIds } }).
+  // Fail-closed: orphan/empty parent returns { events: [] }, never falls
+  // through to country-wide. Supersedes Track A's `events = []` (TIEMPO-451).
+  const events = await getParentEvents(params.parent);
 
   const eventSchema = events.slice(0, 5).map((e) => ({
     '@type': 'Event',


### PR DESCRIPTION
## Summary
Track C M4 — supersedes Track A's `events = []` hotfix (TIEMPO-451). Wires `/tango/[parent]` to the new parent-scoped events endpoint Fulton shipped in `calendar-be-af` v1.33.0 (CALBEAF-173).

## Changes
- `src/app/tango/[parent]/page.js`:
  - Added `getParentEvents(parentSlug)` — fetches `/api/events?appId=1&parentSlug=...` with same date window + ISR config as Track A's removed `getCountryEvents`
  - Replaced `const events = [];` with `const events = await getParentEvents(params.parent)`
  - Updated comment to reflect Track C wiring (was: "disabled until 173 ships")

- `cypress/e2e/01-readonly/seo-tango-parent-region-assertion.cy.js` — NEW
  - Region-assertion test, supersedes bug-shape PR #345 going forward (both can co-exist)
  - Anchors on `masteredCountryName` (always populated) and `masteredCityName` (always populated)
  - Avoids `masteredDivisionName` (verified NOT populated on TEST + PROD — would short-circuit silently per Fulton's M3 self-catch hygiene rule)
  - Cross-state disjointness check (CA event IDs vs MA event IDs) — catches the regression class that triggered TIEMPO-451
  - Negative case: unknown parent slug fails closed `{events: []}`

## Verified on TEST (BE-side, FE pre-deploy)
```
SEO /tango/[parent] region assertion (CALBEAF-173)
  Parent: california (multi-city-state)        ✓ ✓
  Parent: new-york (multi-city-state)          ✓ ✓
  Parent: australia (multi-city-country)       ✓ ✓
  Parent: massachusetts (single-city-state)    ✓ ✓
  Cross-state disjointness                     ✓
  Negative case: unknown parent fails closed   ✓
10 passing (5s)
```

## Real finding during test development (worth noting)
geo-summary?parentSlug=california returns 4 cities (event-windowed for SEO display); /api/events?parentSlug=california returns events from 5 cities (incl. Orange County, 2 events). geo-summary is curated, events endpoint resolves the broader masteredcities set. Test correctly anchors on country/cross-state instead of geo-summary's curated list. Worth a separate note for product but NOT a bug — both behaviors are intentional.

## Test plan after merge to TEST
- [ ] Vercel auto-deploy completes
- [ ] Re-run region-assertion spec: still 10/10
- [ ] Re-run PR #345 bug-shape spec: still 6/6
- [ ] Full /tango/* sweep (all 26 parents + 45 cities) — events block should now appear on multi-city parents with region-correct events
- [ ] CRK doc + Quinn ratification
- [ ] Fresh Toby Telegram DEPLOY-PROD reauth (separate from PR #346 auth)
- [ ] Cherry-pick mechanism if held FE bundle still on TEST

## JIRA
- CALBEAF-173 (Track C, this PR's home)
- TIEMPO-451 (Track A, Done — superseded here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)