### PR TITLE
TIEMPO-454: /organizers/welcome page (Option B from DECIDE doc)

### DIFF
--- a/src/app/components/Modals/UserSettings/UserSettingApplyROTerms.js
+++ b/src/app/components/Modals/UserSettings/UserSettingApplyROTerms.js
@@ -17,6 +17,9 @@ import {
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+// TIEMPO-454: ROE content lifted to a shared module so the new
+// /organizers/welcome page can render the same guidelines.
+import { ROE_SECTIONS } from '@/data/organizerGuidelines';
 
 const modalStyle = {
   position: 'absolute',
@@ -32,71 +35,6 @@ const modalStyle = {
   overflowY: 'auto',
   borderRadius: 2,
 };
-
-const ROE_SECTIONS = [
-  {
-    id: 'responsibilities',
-    title: 'Organizer Responsibilities',
-    content: `As a Regional Organizer, you agree to:
-    
-• Create and manage authentic Argentine Tango events in your assigned region
-• Maintain accurate and up-to-date event information including dates, times, locations, and descriptions
-• Upload appropriate event images that represent the tango community professionally
-• Respond to community inquiries about your events in a timely manner
-• Collaborate with other organizers to avoid scheduling conflicts when possible
-• Represent the tango community with professionalism and respect`
-  },
-  {
-    id: 'event-standards',
-    title: 'Event Quality Standards',
-    content: `IMPORTANT: Only strictly Argentine Tango events are permitted.
-    
-• Events MUST be exclusively Argentine Tango (milongas, practicas, classes, workshops)
-• NO fusion events (tango-swing, tango-salsa, etc.)
-• NO non-tango dance events
-• Events must feature traditional Argentine Tango music or live tango orchestras
-• Alternative/neo-tango events are acceptable if clearly labeled
-• Events must be kept reasonably up-to-date or may be reverted to AI-Discovered status`
-  },
-  {
-    id: 'ai-protection',
-    title: 'AI Monitoring & Protection',
-    content: `Your events will be monitored by our AI system for quality and compliance:
-    
-• AI scans all events for Argentine Tango authenticity
-• Events detected as non-tango will be flagged for review
-• Repeatedly posting non-tango events may result in organizer privileges suspension
-• Outdated events (not updated for 30+ days past event date) may be auto-archived
-• AI-discovered duplicates of your events will be merged under your organizer profile
-• You retain full control over events you create, but must maintain them actively`
-  },
-  {
-    id: 'permissions',
-    title: 'Permissions & Access',
-    content: `Your Regional Organizer role includes all Named User (NU) permissions plus:
-    
-• CREATE events in your assigned cities/regions
-• EDIT all details of events you create
-• UPLOAD images for your events
-• DELETE events you've created (with 30-day soft delete)
-• VIEW analytics for your events
-• MANAGE your organizer profile and contact information
-• REQUEST additional cities/regions through Regional Admins`
-  },
-  {
-    id: 'terms',
-    title: 'Terms of Service',
-    content: `By accepting these terms, you acknowledge:
-    
-• TangoTiempo reserves the right to modify or revoke organizer privileges
-• Violations of the Argentine Tango-only policy may result in immediate suspension
-• You are responsible for the accuracy of all information you post
-• You grant TangoTiempo license to display your event information
-• You will not use the platform for spam, harassment, or illegal activities
-• Your organizer account is non-transferable
-• These terms may be updated with notice to active organizers`
-  }
-];
 
 const ROTermsModal = ({ open, onClose, onAgree }) => {
   const [expandedSections, setExpandedSections] = useState([]);

--- a/src/app/components/Providers.js
+++ b/src/app/components/Providers.js
@@ -13,6 +13,9 @@ import { GeoLocationProvider, useGeoLocation } from '@/contexts/GeoLocationConte
 import { EventDiscoveryProvider } from '@/contexts/EventDiscoveryContext';
 import UserLocationLoader from '@/components/UserLocationLoader';
 import SeoCityLinkLoader from '@/components/SeoCityLinkLoader';
+// TIEMPO-454: Auto-redirect to /organizers/welcome on first isEnabled
+// transition (one-time, sessionStorage-gated).
+import OrganizerWelcomeRedirect from '@/components/UI/OrganizerWelcomeRedirect';
 import { getCachedGeolocation } from '@/utils/trackingHelper';
 import { getCountryMapLocation } from '@/utils/countryCenter';
 import { initializeApiFailover, isUsingFailover } from '@/utils/apiUrlResolver';
@@ -201,6 +204,7 @@ const Providers = ({ children }) => {
                 <UserLocationLoader />
                 <MapCenterModalWrapper />
                 <FailoverIndicator />
+                <OrganizerWelcomeRedirect />
                 {children}
               </EventDiscoveryProvider>
             </GeoLocationProvider>

--- a/src/app/components/UI/OrganizerWelcomeRedirect.js
+++ b/src/app/components/UI/OrganizerWelcomeRedirect.js
@@ -1,0 +1,72 @@
+// OrganizerWelcomeRedirect — TIEMPO-454.
+// Watches the Auth-context user state for the first transition into
+// `regionalOrganizerInfo.isEnabled === true` and redirects to
+// /organizers/welcome once per browser session.
+//
+// Mounted from <Providers />. No UI; purely a side-effect component.
+// Repurposes the existing `organizerWelcomeShown` sessionStorage key
+// from the now-killed YourStatusTab.showWelcome flow so users who saw
+// the old card don't get re-redirected after the upgrade.
+
+'use client';
+
+import { useContext, useEffect, useRef } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { AuthContext } from '@/contexts/AuthContext';
+
+const SESSION_KEY = 'organizerWelcomeShown';
+const WELCOME_PATH = '/organizers/welcome';
+
+const OrganizerWelcomeRedirect = () => {
+  const { user } = useContext(AuthContext);
+  const router = useRouter();
+  const pathname = usePathname();
+  const previousIsEnabled = useRef(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const isEnabled = Boolean(
+      user?.backendInfo?.regionalOrganizerInfo?.isEnabled,
+    );
+    const isApproved = Boolean(
+      user?.backendInfo?.regionalOrganizerInfo?.isApproved,
+    );
+
+    // Only redirect on the FIRST observed transition to enabled-and-approved
+    // within this session, and never if the user is already on the welcome
+    // page (or in the middle of applying).
+    const wasNotEnabledBefore = previousIsEnabled.current === false;
+    const onApplyOrWelcome =
+      pathname === WELCOME_PATH || pathname?.startsWith('/organizers/apply');
+
+    let alreadyShown = false;
+    try {
+      alreadyShown = window.sessionStorage.getItem(SESSION_KEY) === 'true';
+    } catch {
+      // private-mode / quota — treat as already-shown to avoid redirect loops
+      alreadyShown = true;
+    }
+
+    if (
+      isEnabled &&
+      isApproved &&
+      wasNotEnabledBefore &&
+      !alreadyShown &&
+      !onApplyOrWelcome
+    ) {
+      try {
+        window.sessionStorage.setItem(SESSION_KEY, 'true');
+      } catch {
+        // ignore — best-effort
+      }
+      router.push(WELCOME_PATH);
+    }
+
+    previousIsEnabled.current = isEnabled;
+  }, [user, pathname, router]);
+
+  return null;
+};
+
+export default OrganizerWelcomeRedirect;

--- a/src/app/components/UI/SidebarDrawer.js
+++ b/src/app/components/UI/SidebarDrawer.js
@@ -351,10 +351,10 @@ const SidebarDrawer = ({ open, onClose }) => {
               <Divider />
               
               {/* Only show Apply as Organizer if user is not already an approved and enabled organizer */}
-              {selectedRole !== listOfAllRoles.REGIONAL_ORGANIZER && 
-               selectedRole !== listOfAllRoles.SYSTEM_ADMIN && 
-               selectedRole !== listOfAllRoles.SYSTEM_OWNER && 
-               !(user?.backendInfo?.regionalOrganizerInfo?.isApproved && 
+              {selectedRole !== listOfAllRoles.REGIONAL_ORGANIZER &&
+               selectedRole !== listOfAllRoles.SYSTEM_ADMIN &&
+               selectedRole !== listOfAllRoles.SYSTEM_OWNER &&
+               !(user?.backendInfo?.regionalOrganizerInfo?.isApproved &&
                  user?.backendInfo?.regionalOrganizerInfo?.isEnabled) && (
                 <Link href="/organizers/apply" passHref>
                   <ListItem
@@ -365,6 +365,23 @@ const SidebarDrawer = ({ open, onClose }) => {
                       <GroupIcon sx={{ color: 'indigo' }} />
                     </ListItemIcon>
                     <ListItemText primary="Apply as Organizer" />
+                  </ListItem>
+                </Link>
+              )}
+
+              {/* TIEMPO-454: Permanent Organizer Welcome entry for approved
+                  organizers — gives a revisit path to onboarding content
+                  the post-approval Apply link no longer offers. */}
+              {user?.backendInfo?.regionalOrganizerInfo?.isApproved && (
+                <Link href="/organizers/welcome" passHref>
+                  <ListItem
+                    button="true"
+                    onClick={() => onClose()}
+                  >
+                    <ListItemIcon>
+                      <GroupIcon sx={{ color: 'indigo' }} />
+                    </ListItemIcon>
+                    <ListItemText primary="Organizer Welcome" />
                   </ListItem>
                 </Link>
               )}

--- a/src/app/data/organizerGuidelines.js
+++ b/src/app/data/organizerGuidelines.js
@@ -1,0 +1,69 @@
+// Shared source-of-truth for Regional Organizer Rules of Engagement /
+// community guidelines. Extracted from UserSettingApplyROTerms.js so the
+// welcome page (TIEMPO-454) can render the same content the apply-time
+// terms modal does.
+
+export const ROE_SECTIONS = [
+  {
+    id: 'responsibilities',
+    title: 'Organizer Responsibilities',
+    content: `As a Regional Organizer, you agree to:
+
+• Create and manage authentic Argentine Tango events in your assigned region
+• Maintain accurate and up-to-date event information including dates, times, locations, and descriptions
+• Upload appropriate event images that represent the tango community professionally
+• Respond to community inquiries about your events in a timely manner
+• Collaborate with other organizers to avoid scheduling conflicts when possible
+• Represent the tango community with professionalism and respect`,
+  },
+  {
+    id: 'event-standards',
+    title: 'Event Quality Standards',
+    content: `IMPORTANT: Only strictly Argentine Tango events are permitted.
+
+• Events MUST be exclusively Argentine Tango (milongas, practicas, classes, workshops)
+• NO fusion events (tango-swing, tango-salsa, etc.)
+• NO non-tango dance events
+• Events must feature traditional Argentine Tango music or live tango orchestras
+• Alternative/neo-tango events are acceptable if clearly labeled
+• Events must be kept reasonably up-to-date or may be reverted to AI-Discovered status`,
+  },
+  {
+    id: 'ai-protection',
+    title: 'AI Monitoring & Protection',
+    content: `Your events will be monitored by our AI system for quality and compliance:
+
+• AI scans all events for Argentine Tango authenticity
+• Events detected as non-tango will be flagged for review
+• Repeatedly posting non-tango events may result in organizer privileges suspension
+• Outdated events (not updated for 30+ days past event date) may be auto-archived
+• AI-discovered duplicates of your events will be merged under your organizer profile
+• You retain full control over events you create, but must maintain them actively`,
+  },
+  {
+    id: 'permissions',
+    title: 'Permissions & Access',
+    content: `Your Regional Organizer role includes all Named User (NU) permissions plus:
+
+• CREATE events in your assigned cities/regions
+• EDIT all details of events you create
+• UPLOAD images for your events
+• DELETE events you've created (with 30-day soft delete)
+• VIEW analytics for your events
+• MANAGE your organizer profile and contact information
+• REQUEST additional cities/regions through Regional Admins`,
+  },
+  {
+    id: 'terms',
+    title: 'Terms of Service',
+    content: `By accepting these terms, you acknowledge:
+
+• TangoTiempo reserves the right to modify or revoke organizer privileges
+• Violations of the Argentine Tango-only policy may result in immediate suspension
+• You are responsible for the accuracy of all information you post
+• You grant TangoTiempo license to display your event information
+• You will not use the platform for spam, harassment, or illegal activities
+• Your organizer account is non-transferable
+• These terms may be updated with notice to active organizers`,
+  },
+];

--- a/src/app/organizers/apply/components/OutreachApplyForm.js
+++ b/src/app/organizers/apply/components/OutreachApplyForm.js
@@ -450,7 +450,8 @@ const OutreachApplyForm = () => {
     return <AuthGateSection />;
   }
 
-  // --- Render: Already an organizer ---
+  // --- Render: Already an organizer (TIEMPO-454: short excerpt + CTA to
+  // /organizers/welcome instead of static terminal panel) ---
   if (isAlreadyOrganizer) {
     return (
       <Box sx={{ textAlign: 'center', py: 4 }}>
@@ -459,11 +460,17 @@ const OutreachApplyForm = () => {
           You&apos;re already an organizer!
         </Typography>
         <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
-          Your organizer profile is set up. You can start adding events right away.
+          Visit your Organizer Welcome page for orientation, guidelines, and
+          (soon) videos &amp; tips.
         </Typography>
-        <Button variant="contained" href="/calendar">
-          Go to Calendar
-        </Button>
+        <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center', flexWrap: 'wrap' }}>
+          <Button variant="contained" href="/organizers/welcome">
+            Visit your Organizer Welcome →
+          </Button>
+          <Button variant="outlined" href="/calendar">
+            Go to Calendar
+          </Button>
+        </Box>
       </Box>
     );
   }

--- a/src/app/organizers/apply/components/tabs/ApplicationFormTab.js
+++ b/src/app/organizers/apply/components/tabs/ApplicationFormTab.js
@@ -1,24 +1,21 @@
 'use client';
 
 import React, { useContext } from 'react';
+import Link from 'next/link';
 import {
   Box,
   Typography,
   Paper,
   Alert,
-  List,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
   Stepper,
   Step,
   StepLabel,
-  StepContent
+  StepContent,
+  Button,
 } from '@mui/material';
 import { AuthContext } from '@/contexts/AuthContext';
 import { useUsers } from '@/hooks/useUsers';
 import PersonAddIcon from '@mui/icons-material/PersonAdd';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import UserSettingsApply from '@/components/Modals/UserSettings/UserSettingsApply';
 
 const ApplicationFormTab = () => {
@@ -88,45 +85,28 @@ const ApplicationFormTab = () => {
     );
   }
 
-  // If user is already an approved organizer
+  // If user is already an approved organizer (TIEMPO-454: short excerpt + CTA
+  // to /organizers/welcome instead of static "you're done" terminal panel).
   if (userData?.regionalOrganizerInfo?.isApproved) {
     return (
       <Box>
         <Typography variant="h4" component="h3" gutterBottom sx={{ mb: 3 }}>
-          You&apos;re Already an Organizer!
+          You&apos;re an Organizer!
         </Typography>
-        
         <Alert severity="success" sx={{ mb: 3 }}>
           <Typography variant="body1">
-            Congratulations! You are an approved TangoTiempo organizer.
+            Your application is approved. Visit your Organizer Welcome page
+            for orientation, guidelines, and (soon) videos &amp; tips.
           </Typography>
         </Alert>
-
-        <Paper elevation={1} sx={{ p: 3 }}>
-          <Typography variant="h6" gutterBottom>
-            Your Organizer Status
-          </Typography>
-          <List>
-            <ListItem>
-              <ListItemIcon>
-                <CheckCircleIcon color="success" />
-              </ListItemIcon>
-              <ListItemText 
-                primary="Application Approved" 
-                secondary="You can now create and manage events"
-              />
-            </ListItem>
-            <ListItem>
-              <ListItemIcon>
-                <CheckCircleIcon color="success" />
-              </ListItemIcon>
-              <ListItemText 
-                primary="Organizer ID" 
-                secondary={userData.regionalOrganizerInfo.organizerId || 'Assigned'}
-              />
-            </ListItem>
-          </List>
-        </Paper>
+        <Button
+          component={Link}
+          href="/organizers/welcome"
+          variant="contained"
+          size="large"
+        >
+          Visit your Organizer Welcome →
+        </Button>
       </Box>
     );
   }

--- a/src/app/organizers/apply/components/tabs/YourStatusTab.js
+++ b/src/app/organizers/apply/components/tabs/YourStatusTab.js
@@ -28,7 +28,6 @@ import PersonIcon from '@mui/icons-material/Person';
 import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
 import SettingsIcon from '@mui/icons-material/Settings';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
-import CelebrationIcon from '@mui/icons-material/Celebration';
 import { useUsers } from '@/hooks/useUsers';
 import { AuthContext } from '@/contexts/AuthContext';
 import ROTermsModal from '@/components/Modals/UserSettings/UserSettingApplyROTerms';
@@ -58,11 +57,12 @@ const YourStatusTab = () => {
     // Check if restart is needed
     const needsRestart = sessionStorage.getItem('organizerRestartNeeded') === 'true';
     if (needsRestart) return 'restartRequired';
-    
-    // Check if welcome should be shown
-    const hasSeenWelcome = sessionStorage.getItem('organizerWelcomeShown') === 'true';
-    if (isEnabled && !hasSeenWelcome) return 'showWelcome';
-    
+
+    // TIEMPO-454: Welcome celebration moved to dedicated /organizers/welcome
+    // page. Auto-redirect on first isEnabled transition is handled by
+    // <OrganizerWelcomeRedirect /> mounted in Providers; this tab no longer
+    // renders an inline welcome card.
+
     return 'fullyActive';
   };
 
@@ -96,12 +96,6 @@ const YourStatusTab = () => {
 
   const handleRestartComplete = () => {
     sessionStorage.removeItem('organizerRestartNeeded');
-    window.location.reload();
-  };
-
-  const handleWelcomeDismiss = () => {
-    sessionStorage.setItem('organizerWelcomeShown', 'true');
-    // Force re-render
     window.location.reload();
   };
 
@@ -277,31 +271,7 @@ const YourStatusTab = () => {
       </Card>
     ),
 
-    showWelcome: (
-      <Card elevation={3} sx={{ background: 'linear-gradient(45deg, #2196F3 30%, #21CBF3 90%)' }}>
-        <CardContent sx={{ textAlign: 'center', p: 4, color: 'white' }}>
-          <CelebrationIcon sx={{ fontSize: 80, mb: 2 }} />
-          <Typography variant="h4" gutterBottom>
-            Welcome, Regional Organizer!
-          </Typography>
-          <Typography variant="h6" paragraph>
-            You&apos;re all set to create Argentine Tango events.
-          </Typography>
-          <Button 
-            variant="contained" 
-            sx={{ 
-              bgcolor: 'white', 
-              color: 'primary.main',
-              '&:hover': { bgcolor: 'grey.100' }
-            }}
-            size="large"
-            onClick={handleWelcomeDismiss}
-          >
-            Get Started
-          </Button>
-        </CardContent>
-      </Card>
-    ),
+    // TIEMPO-454: showWelcome renderer removed — superseded by /organizers/welcome page.
 
     fullyActive: (
       <Card elevation={2}>

--- a/src/app/organizers/welcome/page.js
+++ b/src/app/organizers/welcome/page.js
@@ -1,0 +1,192 @@
+// /organizers/welcome — Regional Organizer welcome / reference page (TIEMPO-454).
+// Built per Option B of MasterCalendar/docs/DECIDE-ORGANIZER-WELCOME-FLOW.md
+// (LOCKED 2026-05-05). Supersedes the orphaned YourStatusTab.showWelcome card.
+//
+// v1 content: welcome message + collapsible Rules of Engagement guidelines
+// (sourced from src/app/data/organizerGuidelines.js — same content the apply-
+// time terms modal renders). Placeholder structure for future videos / images
+// / tips that Toby will add later.
+//
+// Auto-redirect on first isEnabled transition is wired by
+// <OrganizerWelcomeRedirect /> in src/app/components/UI/OrganizerWelcomeRedirect.js
+// (mounted from Providers).
+
+'use client';
+
+import React, { useContext, useEffect } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import {
+  Box,
+  Container,
+  Typography,
+  Button,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Alert,
+  Card,
+  CardContent,
+  Divider,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import CelebrationIcon from '@mui/icons-material/Celebration';
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
+import { AuthContext } from '@/contexts/AuthContext';
+import { ROE_SECTIONS } from '@/data/organizerGuidelines';
+
+// Sentinel for the one-time auto-redirect. Repurposes the existing
+// `organizerWelcomeShown` key from the now-killed YourStatusTab.showWelcome
+// flow so an upgrade doesn't re-fire for users who already saw the old card.
+export const ORGANIZER_WELCOME_SHOWN_KEY = 'organizerWelcomeShown';
+
+const OrganizerWelcomePage = () => {
+  const { user, loading } = useContext(AuthContext);
+  const router = useRouter();
+
+  // Mark the welcome as seen on render so the auto-redirect doesn't fire again
+  // this session. Backend-tracked dismissal is gold-plating per locked spec — defer.
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        window.sessionStorage.setItem(ORGANIZER_WELCOME_SHOWN_KEY, 'true');
+      } catch {
+        // sessionStorage can throw in private-mode / quota-exceeded — non-fatal
+      }
+    }
+  }, []);
+
+  // Anonymous gate — sign in first.
+  if (!loading && !user) {
+    return (
+      <Container maxWidth="md" sx={{ py: 6 }}>
+        <Alert severity="info">
+          <Typography variant="body1">
+            Please sign in to view the Organizer Welcome content.
+          </Typography>
+          <Button onClick={() => router.push('/')} sx={{ mt: 2 }} variant="outlined">
+            Back to Home
+          </Button>
+        </Alert>
+      </Container>
+    );
+  }
+
+  const isApproved = Boolean(user?.backendInfo?.regionalOrganizerInfo?.isApproved);
+  const isEnabled = Boolean(user?.backendInfo?.regionalOrganizerInfo?.isEnabled);
+
+  return (
+    <Container maxWidth="md" sx={{ py: 4 }}>
+      {/* Hero / celebration block */}
+      <Card
+        elevation={3}
+        sx={{
+          background: 'linear-gradient(45deg, #2196F3 30%, #21CBF3 90%)',
+          color: 'white',
+          mb: 4,
+        }}
+      >
+        <CardContent sx={{ textAlign: 'center', p: { xs: 3, md: 5 } }}>
+          <CelebrationIcon sx={{ fontSize: { xs: 56, md: 80 }, mb: 2 }} />
+          <Typography variant="h4" component="h1" gutterBottom fontWeight="bold">
+            Welcome, Regional Organizer!
+          </Typography>
+          <Typography variant="h6" sx={{ mb: 3, opacity: 0.95 }}>
+            You&apos;re part of the team that keeps Argentine Tango thriving across the calendar.
+          </Typography>
+          <Button
+            component={Link}
+            href="/calendar"
+            variant="contained"
+            startIcon={<CalendarMonthIcon />}
+            size="large"
+            sx={{
+              bgcolor: 'white',
+              color: 'primary.main',
+              '&:hover': { bgcolor: 'grey.100' },
+            }}
+          >
+            Go to Calendar
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* Status callouts */}
+      {isApproved && !isEnabled && (
+        <Alert severity="warning" sx={{ mb: 3 }}>
+          <Typography variant="body2" fontWeight="bold" gutterBottom>
+            Your profile is approved but not yet enabled.
+          </Typography>
+          <Typography variant="body2">
+            Open the menu (☰) → switch role to <strong>Organizer/Artist</strong> →
+            open <strong>Event Organizer Settings</strong> → complete the Status
+            tab to activate event creation.
+          </Typography>
+        </Alert>
+      )}
+
+      {/* Welcome / orientation */}
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h5" component="h2" gutterBottom fontWeight="bold">
+          Getting Started
+        </Typography>
+        <Typography variant="body1" paragraph>
+          This is your home base for orientation and reference. We&apos;ll add
+          videos, walkthroughs, and tips here over time — for now, the most
+          important reading is the community guidelines below. They cover
+          what to post, how AI monitoring works, and what your role permits.
+        </Typography>
+        <Typography variant="body1" paragraph>
+          You can revisit this page any time from the menu (☰) →
+          <strong> Organizer Welcome</strong>.
+        </Typography>
+      </Box>
+
+      <Divider sx={{ mb: 3 }} />
+
+      {/* Community guidelines — collapsible, lifted from ROTermsModal source */}
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h5" component="h2" gutterBottom fontWeight="bold">
+          Community Guidelines (Rules of Engagement)
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          The standards every organizer agreed to at signup. Refresh whenever
+          you need.
+        </Typography>
+        {ROE_SECTIONS.map((section) => (
+          <Accordion key={section.id} sx={{ mb: 1 }}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Typography fontWeight="medium">{section.title}</Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Typography
+                variant="body2"
+                sx={{ whiteSpace: 'pre-line', lineHeight: 1.6 }}
+              >
+                {section.content}
+              </Typography>
+            </AccordionDetails>
+          </Accordion>
+        ))}
+      </Box>
+
+      <Divider sx={{ mb: 3 }} />
+
+      {/* Placeholder for future content (videos / images / tips) */}
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h5" component="h2" gutterBottom fontWeight="bold">
+          Videos &amp; Tips
+        </Typography>
+        <Alert severity="info">
+          <Typography variant="body2">
+            Walkthrough videos, common-question tips, and organizer
+            spotlight content are coming soon. Check back here as the system
+            evolves.
+          </Typography>
+        </Alert>
+      </Box>
+    </Container>
+  );
+};
+
+export default OrganizerWelcomePage;


### PR DESCRIPTION
## Summary
Implements Option B from `MasterCalendar/docs/DECIDE-ORGANIZER-WELCOME-FLOW.md` (LOCKED 2026-05-05 by Toby). New dedicated `/organizers/welcome` page; auto-redirect on first `isEnabled` transition; sidebar entry for revisit; replaces the two static "Already an Organizer" terminal panels with excerpts that link to the new page; removes the orphan `YourStatusTab.showWelcome` card.

## New files
- `src/app/organizers/welcome/page.js` — the new route (client component, hero, Getting Started, collapsible ROE guidelines, placeholder for future content)
- `src/app/data/organizerGuidelines.js` — shared `ROE_SECTIONS` source (lifted from `UserSettingApplyROTerms.js`)
- `src/app/components/UI/OrganizerWelcomeRedirect.js` — side-effect client component for one-time auto-redirect

## Modified files
- `src/app/components/Providers.js` — mounts `<OrganizerWelcomeRedirect />`
- `src/app/components/UI/SidebarDrawer.js` — adds permanent "Organizer Welcome" entry visible to `isApproved=true` users
- `src/app/components/Modals/UserSettings/UserSettingApplyROTerms.js` — imports `ROE_SECTIONS` from shared module
- `src/app/organizers/apply/components/tabs/ApplicationFormTab.js` — replaces lines 91-132 already-organizer panel with short excerpt + CTA
- `src/app/organizers/apply/components/OutreachApplyForm.js` — replaces lines 453-469 already-organizer panel with matched excerpt + CTA
- `src/app/organizers/apply/components/tabs/YourStatusTab.js` — removed orphan showWelcome card, branch from `getApplicationPhase`, dismiss handler, unused `CelebrationIcon` import

## Decisions (per Toby's locked spec)
- Sidebar link visible at `isApproved=true` (gives revisit path the post-approval Apply link loses)
- Auto-redirect one-time per session via `organizerWelcomeShown` sessionStorage key (repurposes the old YourStatusTab key — no double-fire for users who saw the old card)
- Backend-tracked dismissal deferred (gold-plating per spec)
- v1 content = welcome + guidelines + placeholders; videos/images/tips Toby adds later

## Sequencing
- Doesn't bundle with M5 (CALBEAF-173) — separate cycle
- Drop everything if M5 fires per Quinn's pivot rule

## Test plan after Vercel TEST deploy
- [ ] Quinn diff ratify
- [ ] `/organizers/welcome` renders on TEST (anon → sign-in nudge; signed-in → page renders; isApproved+!isEnabled → setup callout visible)
- [ ] Sidebar "Organizer Welcome" entry appears for approved organizers, navigates correctly
- [ ] `/organizers/apply` already-organizer branch shows excerpt + CTA (both `ApplicationFormTab` standard flow and `OutreachApplyForm` outreach flow)
- [ ] Auto-redirect: log in as a fresh-isEnabled user, expect /organizers/welcome on first session; revisit / hard-reload session → no second redirect
- [ ] No regression on `/organizers/apply` apply flow for not-yet-organizer users (Stepper renders, UserSettingsApply embed works)
- [ ] No regression on `YourStatusTab` other phases (anonymous/loading/readyToApply/pendingApproval/setupRequired/restartRequired/fullyActive)
- [ ] CRK doc + regression test before PROD per Stacked Gates

## JIRA
- TIEMPO-454 (this PR)
- Spec doc: `MasterCalendar/docs/DECIDE-ORGANIZER-WELCOME-FLOW.md` (LOCKED 2026-05-05)

🤖 Generated with [Claude Code](https://claude.com/claude-code)