### PR TITLE
TIEMPO-454 smoke test: /organizers/welcome browser render

### DIFF
--- a/cypress/e2e/01-readonly/organizer-welcome-smoke.cy.js
+++ b/cypress/e2e/01-readonly/organizer-welcome-smoke.cy.js
@@ -1,0 +1,33 @@
+// /organizers/welcome smoke — TIEMPO-454
+// Browser-side rendering check. The page is a 'use client' Next.js page so
+// SSR HTML is just the layout shell; content materializes after hydration.
+// curl can't see it; Cypress can.
+
+describe('SEO /organizers/welcome — smoke (TIEMPO-454)', () => {
+  it('renders welcome content for an anonymous visitor (sign-in nudge OR welcome page)', () => {
+    cy.visit('/organizers/welcome');
+    // Either the anonymous gate alert or the welcome heading should appear.
+    // Anon gate appears if AuthContext resolves with no user; welcome page
+    // appears if loading stays true (initial state). Either is correct
+    // unauthenticated render.
+    cy.get('body').should('contain.text', 'Tango');
+    // Specifically: anon-gate nudge OR welcome hero — at least one must be present
+    cy.contains(/Please sign in to view the Organizer Welcome|Welcome, Regional Organizer/, {
+      timeout: 10000,
+    }).should('exist');
+  });
+
+  it('does NOT render the new "Already an Organizer" excerpt on /organizers/apply for anonymous users', () => {
+    cy.visit('/organizers/apply');
+    // Anon gets the AuthGate / signup prompt, not the already-organizer excerpt.
+    cy.contains('Visit your Organizer Welcome').should('not.exist');
+  });
+
+  it('serves /organizers/welcome with HTTP 200', () => {
+    cy.request('/organizers/welcome').its('status').should('eq', 200);
+  });
+
+  it('does NOT regress /organizers/apply route', () => {
+    cy.request('/organizers/apply').its('status').should('eq', 200);
+  });
+});


### PR DESCRIPTION
## Summary
Companion to PR #348 (welcome page, already merged to TEST). Adds the regression smoke test required by Stacked Gates pre-PROD.

## Why this didn't ride in PR #348
Test file was authored after the welcome page commit during the post-merge verification step. Same pattern as PR #344 (hotfix) + PR #345 (regression test) for TIEMPO-451.

## Verified
4/4 green on TEST: https://test.tangotiempo.com/organizers/welcome
- Page serves HTTP 200
- Renders welcome heading OR anon-gate nudge for unauthenticated visitors
- /organizers/apply unchanged for anonymous users (no excerpt CTA)
- /organizers/apply route still 200

## Lifecycle
- Stays valid through any future welcome-page changes (asserts on stable strings)
- Asserts contracts not implementation; doesn't gate on auth or backend state

🤖 Generated with [Claude Code](https://claude.com/claude-code)