### PR TITLE
TIEMPO-456: surface full shortname rules on apply form

### DIFF
--- a/src/app/components/Modals/UserSettings/UserSettingsApply.js
+++ b/src/app/components/Modals/UserSettings/UserSettingsApply.js
@@ -12,6 +12,7 @@ import { useOrganizers } from '@/hooks/useOrganizers';
 import { useActivityLogger } from '@/hooks/useActivityLogger';
 import { getApiBaseUrl } from '@/utils/apiUrlResolver';
 import { validateShortName } from '@/utils/shortnameRules';
+import ShortnameRulesHint from '@/components/UI/ShortnameRulesHint';
 import ROTermsModal from './UserSettingApplyROTerms.js';
 
 // TIEMPO-442 stopgap: client-side helper to find a unique shortName via the
@@ -428,8 +429,7 @@ const UserSettingsApply = () => {
             helperText={
               shortNameStatus.checking
                 ? 'Checking…'
-                : shortNameStatus.message ||
-                  '3–12 characters. Must start with 3 letters. Letters, numbers, and hyphens after that.'
+                : shortNameStatus.message || ' '
             }
             error={shortNameStatus.available === false}
             InputProps={{
@@ -443,6 +443,9 @@ const UserSettingsApply = () => {
             }}
             disabled={applicationStatus === 'loading'}
           />
+          {/* TIEMPO-456: always-visible naming rules so users see all 7
+              constraints at once instead of one-at-a-time on validation error. */}
+          <ShortnameRulesHint />
           <TextField
             label="Description"
             placeholder="Tell people who you are and what you organize."

--- a/src/app/components/UI/ShortnameRulesHint.js
+++ b/src/app/components/UI/ShortnameRulesHint.js
@@ -1,0 +1,63 @@
+// ShortnameRulesHint — TIEMPO-456.
+// Always-visible bulleted block surfacing the full organizer shortname
+// constraint set. Sits under the Short Name field on the apply form so
+// users see all rules while typing (helper-text-only would surface 1
+// rule at a time on error, hiding the rest).
+//
+// Rules sourced from BE via the FE mirror at @/utils/shortnameRules
+// (TIEMPO-455). If rules change there, update the bullets here too.
+
+'use client';
+
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+
+const RULES = [
+  '3–12 characters total',
+  'Must start with 3 letters (A–Z)',
+  'Then letters, numbers, or hyphens (e.g. TOBY-DJ)',
+  'Cannot end with a hyphen',
+  'No consecutive hyphens (no “--”)',
+  'Reserved words: CHANGE, TANGO',
+  'Case-insensitive (normalized to UPPERCASE)',
+];
+
+const ShortnameRulesHint = () => (
+  <Box
+    component="aside"
+    aria-label="Short name rules"
+    sx={{
+      mt: 0.5,
+      pl: 1,
+      borderLeft: '2px solid',
+      borderColor: 'divider',
+    }}
+  >
+    <Typography
+      variant="caption"
+      color="text.secondary"
+      component="div"
+      fontWeight="medium"
+    >
+      Naming rules
+    </Typography>
+    <Box
+      component="ul"
+      sx={{
+        m: 0,
+        pl: 2.5,
+        '& li': {
+          fontSize: '0.75rem',
+          lineHeight: 1.4,
+          color: 'text.secondary',
+        },
+      }}
+    >
+      {RULES.map((rule) => (
+        <li key={rule}>{rule}</li>
+      ))}
+    </Box>
+  </Box>
+);
+
+export default ShortnameRulesHint;


### PR DESCRIPTION
## Summary
Per Toby's ask 2026-05-05 + Quinn's design-shape: small always-visible bulleted block listing all 7 shortname constraints, sits under the Short Name field on the apply form. Helper text only had room for one rule at a time.

## Changes

### New file
- `src/app/components/UI/ShortnameRulesHint.js` — self-contained MUI bulleted aside. Caption-styled, bordered left, fits naturally below a TextField. Rules cite the BE source-of-truth via the FE mirror at `@/utils/shortnameRules` (TIEMPO-455).

### Modified
- `UserSettingsApply.js` — imports the new component, drops the verbose helper-text fallback (replaced with single space so the helperText line doesn't visually disappear and reflow), and renders `<ShortnameRulesHint />` right under the Short Name TextField.

### Visual shape (from spec)
```
Short Name: [input]
Status helper: "Available" | "Already taken" | rule-violation message

| Naming rules
|  • 3–12 characters total
|  • Must start with 3 letters (A–Z)
|  • Then letters, numbers, or hyphens (e.g. TOBY-DJ)
|  • Cannot end with a hyphen
|  • No consecutive hyphens (no "--")
|  • Reserved words: CHANGE, TANGO
|  • Case-insensitive (normalized to UPPERCASE)
```

## Sequencing
- Doesn't bundle with M5 / Track C / TIEMPO-454 / TIEMPO-455
- Stacked Gates pre-PROD on its own cycle (or could ride with TIEMPO-455's eventual M5 carry — your call)
- FE-only, no BE coupling

## Test plan
- [ ] Quinn diff ratify
- [ ] Vercel TEST deploy renders the new aside under the Short Name field on `/organizers/apply` when user is in not-yet-organizer state
- [ ] Manual: rules visible at all times (typing, focus, blur, error states); rules don't shift around as the helperText changes
- [ ] No regression on existing ApplicationFormTab apply flow (anon gate, already-organizer excerpt for approved users)

## Future-prep flag
`<ShortnameRulesHint />` is self-contained — drops in elsewhere if organizer naming surfaces beyond the apply form.

## JIRA
- TIEMPO-456 (this PR)
- Related: TIEMPO-455 (rule alignment, the source-of-truth this hint reflects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)