### PR TITLE
fix(auth): setUserData self-heals on userlogins 404 (TIEMPO-453)

### DIFF
--- a/src/app/contexts/AuthContext.js
+++ b/src/app/contexts/AuthContext.js
@@ -145,17 +145,36 @@ export const AuthProvider = ({ children }) => {
 
 // TIEMPO-276: Security cleanup - removed logging
 
-      // TIEMPO-257: Use dedupeFetch to prevent duplicate calls
-      const response = await dedupeFetch(
-        `${getApiBaseUrl()}/api/userlogins/firebase/${firebaseUser.uid}`,
-        {
-          headers: {
-            Authorization: `Bearer ${idToken}`,
-          },
-          params: { appId: process.env.NEXT_PUBLIC_APPLICATION_ID },
-          timeout: 10000 // 10 second timeout
-        }
-      );
+      // TIEMPO-257: Use dedupeFetch to prevent duplicate calls.
+      // TIEMPO-453: Self-heal — if BE returns 404 (Firebase session restored
+      // but no userlogin record exists), fall back to handleBackendUser POST
+      // and re-GET. BE intentionally does not auto-create on 404 (that path
+      // is reserved for cross-app provisioning); FE must create on first
+      // bootstrap. handleBackendUser already runs from explicit sign-ins;
+      // this covers onAuthStateChanged auto-restore too.
+      let response;
+      try {
+        response = await dedupeFetch(
+          `${getApiBaseUrl()}/api/userlogins/firebase/${firebaseUser.uid}`,
+          {
+            headers: { Authorization: `Bearer ${idToken}` },
+            params: { appId: process.env.NEXT_PUBLIC_APPLICATION_ID },
+            timeout: 10000,
+          }
+        );
+      } catch (err) {
+        if (err?.response?.status !== 404) throw err;
+        // TIEMPO-453: GET 404 — create the record, then re-GET.
+        await handleBackendUser(firebaseUser);
+        response = await dedupeFetch(
+          `${getApiBaseUrl()}/api/userlogins/firebase/${firebaseUser.uid}`,
+          {
+            headers: { Authorization: `Bearer ${idToken}` },
+            params: { appId: process.env.NEXT_PUBLIC_APPLICATION_ID },
+            timeout: 10000,
+          }
+        );
+      }
 // TIEMPO-276: Security cleanup - removed logging
 
       const backendInfo = response.data;


### PR DESCRIPTION
## Summary

- **Root cause:** `onAuthStateChanged` auto-restore path called `setUserData` directly without going through `handleBackendUser` self-heal. When Firebase session restored but BE userlogins record missing, GET returned 404 → setUserData threw → `userData` stayed null → Apply-organizer button (and any `!userData`-gated UI) silently disabled forever
- **Fix:** Wrap the GET in `setUserData` with try/catch; on 404 fall through to `handleBackendUser` (which already runs GET→POST self-heal from explicit sign-in paths), then re-GET. Single-function patch within `AuthContext.js:148-178`
- **Discovered:** 2026-05-05 during CALBEAF-171 verify (Toby alt-account "tobin.balsley@gmail.com" hit it on TEST). Re-surfaced 2026-05-06 as Phase B Story 2.3 / UC-0003 spawn root-cause blocker
- **Out of scope:** PROD-tier fix (this lands TEST first per Toby directive 2026-05-06T23:23); TIEMPO-453 follows standard DEVL→TEST→PROD progression after Phase B Exit closes

## Test plan

- [ ] **Vercel TEST deploy passes** (auto on merge to TEST)
- [ ] Sarah + Quinn agree fix is good (per Toby directive 23:23 — review build success + sanity-check `test.tangotiempo.com`)
- [ ] **UC-0003 Gauge re-spawn GREEN** (validates fix end-to-end via Pattern B signup → apply path; previously stalled on this exact bug)
- [ ] No regression on TIEMPO-454 / TIEMPO-455 / TIEMPO-456 organizer-flow tests already on TEST (sanity check via existing manual smoke or test suite)
- [ ] AuthContext bootstrap on existing-user-with-record path unchanged (happy path: GET 200 → setUserData populates user; no behavior delta)

## Code change

```js
// AuthContext.js setUserData function (lines 148-178)
let response;
try {
  response = await dedupeFetch(/* GET userlogins */);
} catch (err) {
  if (err?.response?.status !== 404) throw err;
  // TIEMPO-453: GET 404 — create the record, then re-GET.
  await handleBackendUser(firebaseUser);
  response = await dedupeFetch(/* re-GET */);
}
```

30 insertions / 11 deletions in single file (`src/app/contexts/AuthContext.js`). ESLint clean (0 errors).

## References

- TIEMPO-453 (BACKLOG → moving to In Review on PR)
- Sister-class to TIEMPO-44 / TIEMPO-51 (PROD stub userLogins; different mechanism, same theme of FE-not-self-healing-from-BE-desync)
- Phase B Story 2.3 / UC-0003 spawn unblock (Sprint 2 Phase B Exit DoD 5/5 UCs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)