### PR TITLE
fix(calendar): map isAllDay to FullCalendar allDay so multi-day events span (TIEMPO-351)

### DIFF
--- a/scripts/TIEMPO-351-backfill-isAllDay.mongosh.js
+++ b/scripts/TIEMPO-351-backfill-isAllDay.mongosh.js
@@ -1,0 +1,96 @@
+// TIEMPO-351 data backfill — set isAllDay: true for existing multi-day LONG events
+//
+// Purpose: existing events in MongoDB created before TIEMPO-351 fix have isAllDay=false
+// (or missing). The FE now sets isAllDay=true on save for multi-day events (>24hr
+// duration), but historical multi-day LONG events remain incorrectly rendered as
+// per-day tiles instead of spanning bars.
+//
+// Strategy: match events where the duration is >24 hours (isMultiDayEvent === true
+// in the FE) and set isAllDay=true. Categories most affected per TIEMPO-351 are
+// Festival, Marathon, Encuentro, Workshop — but the canonical signal is duration,
+// not category, so the patch keys on duration to align with FE write-side logic.
+//
+// Usage (TEST):
+//   mongosh "<TEST_MONGO_URI>" scripts/TIEMPO-351-backfill-isAllDay.mongosh.js
+//
+// Usage (PROD — requires DEPLOY-PROD authorization per PROD-DEPLOY-PROTECTION.md):
+//   mongosh "<PROD_MONGO_URI>" scripts/TIEMPO-351-backfill-isAllDay.mongosh.js
+//
+// Safety:
+//   - Idempotent: re-running has no effect on already-patched events.
+//   - Targeted: only updates events with duration >24hr AND isAllDay !== true.
+//   - Reports counts before + after for verification.
+//   - Does NOT delete or otherwise modify any other field.
+
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
+// Use the events collection in current DB (mongosh connects to a specific db)
+const events = db.events;
+
+// Pre-patch report
+const totalEvents = events.countDocuments({});
+const multiDayEvents = events.countDocuments({
+  $expr: {
+    $gt: [
+      { $subtract: ['$endDate', '$startDate'] },
+      TWENTY_FOUR_HOURS_MS
+    ]
+  }
+});
+const alreadyPatched = events.countDocuments({
+  $expr: {
+    $gt: [
+      { $subtract: ['$endDate', '$startDate'] },
+      TWENTY_FOUR_HOURS_MS
+    ]
+  },
+  isAllDay: true
+});
+const needsPatch = multiDayEvents - alreadyPatched;
+
+print('=== TIEMPO-351 backfill — pre-patch report ===');
+print(`Total events: ${totalEvents}`);
+print(`Multi-day events (>24hr duration): ${multiDayEvents}`);
+print(`  - Already patched (isAllDay=true): ${alreadyPatched}`);
+print(`  - Needs patch (isAllDay !== true): ${needsPatch}`);
+print('');
+
+if (needsPatch === 0) {
+  print('No-op: all multi-day events already have isAllDay=true. Exiting.');
+  quit(0);
+}
+
+// Apply patch
+print('Applying patch...');
+const result = events.updateMany(
+  {
+    $expr: {
+      $gt: [
+        { $subtract: ['$endDate', '$startDate'] },
+        TWENTY_FOUR_HOURS_MS
+      ]
+    },
+    isAllDay: { $ne: true }
+  },
+  { $set: { isAllDay: true } }
+);
+
+print(`Matched: ${result.matchedCount}`);
+print(`Modified: ${result.modifiedCount}`);
+print('');
+
+// Post-patch report
+const verifyPatched = events.countDocuments({
+  $expr: {
+    $gt: [
+      { $subtract: ['$endDate', '$startDate'] },
+      TWENTY_FOUR_HOURS_MS
+    ]
+  },
+  isAllDay: true
+});
+
+print('=== TIEMPO-351 backfill — post-patch report ===');
+print(`Multi-day events with isAllDay=true: ${verifyPatched}`);
+print(`Expected: ${multiDayEvents}`);
+print(verifyPatched === multiDayEvents ? 'OK — patch complete.' : `WARN — mismatch: ${multiDayEvents - verifyPatched} unpatched.`);

--- a/src/app/components/Modals/CreateEvents/CreateEventDetailModal.js
+++ b/src/app/components/Modals/CreateEvents/CreateEventDetailModal.js
@@ -779,6 +779,10 @@ const CreateEventModal = ({ open, onClose, selectedDate, editMode = false, event
         // TIEMPO-362: Force isRepeating=false for multi-day events (festivals, marathons)
         isRepeating: isMultiDay ? false : eventData.isRepeating,
         recurrenceRule: isMultiDay ? null : eventData.recurrenceRule,
+        // TIEMPO-351: Set isAllDay=true for multi-day events (>24hr duration) so they
+        // render as a single spanning bar in the calendar instead of N per-day tiles.
+        // Single-day timed events keep isAllDay=false (preserves existing behavior).
+        isAllDay: isMultiDay ? true : (eventData.isAllDay || false),
         masteredRegionName: eventData.masteredRegionName || (user?.backendInfo?.localUserInfo?.userDefaults?.region?.name || 'Default Region'),
         categoryFirst: eventData.categoryFirst || 'Other',
         selectedRole: selectedRole, // Add selectedRole for backend validation

--- a/src/app/utils/transformEvents.js
+++ b/src/app/utils/transformEvents.js
@@ -39,6 +39,10 @@ export function transformEvents(events) {
     // For FullCalendar RRULE plugin, we need to handle recurring events differently
     const baseEvent = {
       title: event.title, // Use the 'title' field from the API
+      // TIEMPO-351: Map isAllDay to FullCalendar's allDay so multi-day events render as
+      // a single spanning bar instead of N separate per-day tiles. Default false for
+      // single-day timed events (which is the vast majority).
+      allDay: event.isAllDay || false,
       extendedProps: {
         // Any additional data
         _id: event._id,


### PR DESCRIPTION
## Summary

Phase D Story 4.1 round-trip fix per UC-0019 routing handoff (Quinn 20:47Z). First FE-lane Phase D Routing v0 textbook pattern from Sarah-side per the pre-committed-fix-in-same-arc commitment standing since 17:20Z.

**UC-0019 classifier verdict (clean both-axes routing):**
- `code-bug` @ 0.97 confidence, rule lane
- signals_fired: `[\"data_shape\", \"diff_since_last_green\"]`
- target_persona: `sarah` (target_app=TT FE + signals → FE owner; both axes align)

## Bug
LONG-category multi-day events (Festival / Marathon / Encuentro spanning 24+ hr; FLEX Workshop spanning 48+ hr) render as N separate per-day tiles instead of one spanning bar across the calendar. **FullCalendar only renders spanning bars for events with `allDay: true`** — TT FE was never setting `allDay` on transformed events (missing read-side mapping) AND never wiring `isMultiDayEvent` → `isAllDay` on save (missing write-side).

## Reproduce evidence (Gauge UC-0019 against TEST)
3 events in TEST DB triggering the bug:
- `OPEN ROLE TANGO FESTIVAL` (Festival, 2026-03-20 → 2026-03-23)
- `Amatissima Spring Tango Marathon` (Marathon, 2026-05-01 → 2026-05-03)
- `sdf` (Encuentro, 2026-05-01 → 2026-05-05)

Test 2 FAILED at `transformEvents.js` lines 239-244 — non-recurring event return lacked `allDay: event.isAllDay || false`.

## Fixes

### Fix A — `src/app/utils/transformEvents.js` (read-side)
Add `allDay: event.isAllDay || false` to `baseEvent`. Single-line addition propagates to all return paths (recurring + non-recurring + error fallbacks) via `baseEvent` spread. Default `false` preserves existing single-day timed-event behavior.

### Fix B — `src/app/components/Modals/CreateEvents/CreateEventDetailModal.js` (write-side)
Add `isAllDay: isMultiDay ? true : (eventData.isAllDay || false)` to `eventDataWithDefaults`. `isMultiDay` already computed at line ~768 (existing >24hr duration check). New multi-day events post-deploy will render correctly without manual data fix.

### Data backfill — `scripts/TIEMPO-351-backfill-isAllDay.mongosh.js`
Idempotent mongosh script setting `isAllDay=true` on existing events with duration >24hr. Pre/post counts for verification. Safe to re-run.

**Run on TEST:**
\`\`\`bash
mongosh \"<TEST_MONGO_URI>\" scripts/TIEMPO-351-backfill-isAllDay.mongosh.js
\`\`\`

**Run on PROD:** requires DEPLOY-PROD authorization per `PROD-DEPLOY-PROTECTION.md`.

## What's NOT in this PR
- **Fix C optional All Day toggle** — JIRA description marks this optional; not required for UC-0019 green-flip; deferred to follow-on PR if Toby wants the explicit user-facing control. Current UX: multi-day events auto-set isAllDay=true (transparent to user; matches existing isMultiDayEvent semantics already used to disable repeating).

## Validation pathway (Phase D Routing v0)
- [x] Code fixes match Gauge reproduce evidence (transformEvents.js line 239-244 baseEvent map)
- [x] Idempotent mongosh data-patch with pre/post verification
- [ ] **Gauge re-spawn UC-0019 against TEST after merge** validates green-flip (~3-hour cycle baseline per UC-0013/CALBEAF-83 precedent)
- [ ] mongosh data-patch run on TEST DB (sequence: merge → deploy → mongosh patch → Gauge re-spawn)

## §18.1 maintenance rule scope check
- No `data-testid` added/renamed/removed → §0/§11 update NOT required
- No label-based form field added → §0.2 cheat-sheet update NOT required
- No modal surface added → §11 modal taxonomy update NOT required
- Selectors unchanged

§18.1 rule does NOT trigger for this PR.

## ETA per Sarah's pre-commitment
30-45 min from handoff (20:47Z) to PR open. **Met:** PR opened ~20:55Z (~8 min).

## Cross-references
- JIRA TIEMPO-351 — original bug ticket (FE Discovery Tier-1 #2 per PR #356 corpus)
- UC-0019 spec: `e2e-calendar-framework/usecases/escalated/UC-0019.yaml`
- UC-0019 test: `e2e-calendar-framework/tests/tt/UC-0019.spec.ts`
- Audit log: `triage/decisions/run-20260507-2040.jsonl`
- Phase D Story 4.1 charter: `e2e-calendar-framework/docs/PLAN-AUTONOMOUS-TESTING.md` §EPIC 4
- PR #356 Sarah's FE Discovery corpus (TIEMPO-351 Tier-1 entry)
- PR #355 v0.7 stacked-septet (E2E-TESTING-REFERENCE — Gauge consult per SAD Step 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)