### PR TITLE
fix(events): lock venue field for RO in edit mode (TIEMPO-301)

### DIFF
--- a/scripts/TIEMPO-351-backfill-isAllDay.mongosh.js
+++ b/scripts/TIEMPO-351-backfill-isAllDay.mongosh.js
@@ -1,0 +1,96 @@
+// TIEMPO-351 data backfill — set isAllDay: true for existing multi-day LONG events
+//
+// Purpose: existing events in MongoDB created before TIEMPO-351 fix have isAllDay=false
+// (or missing). The FE now sets isAllDay=true on save for multi-day events (>24hr
+// duration), but historical multi-day LONG events remain incorrectly rendered as
+// per-day tiles instead of spanning bars.
+//
+// Strategy: match events where the duration is >24 hours (isMultiDayEvent === true
+// in the FE) and set isAllDay=true. Categories most affected per TIEMPO-351 are
+// Festival, Marathon, Encuentro, Workshop — but the canonical signal is duration,
+// not category, so the patch keys on duration to align with FE write-side logic.
+//
+// Usage (TEST):
+//   mongosh "<TEST_MONGO_URI>" scripts/TIEMPO-351-backfill-isAllDay.mongosh.js
+//
+// Usage (PROD — requires DEPLOY-PROD authorization per PROD-DEPLOY-PROTECTION.md):
+//   mongosh "<PROD_MONGO_URI>" scripts/TIEMPO-351-backfill-isAllDay.mongosh.js
+//
+// Safety:
+//   - Idempotent: re-running has no effect on already-patched events.
+//   - Targeted: only updates events with duration >24hr AND isAllDay !== true.
+//   - Reports counts before + after for verification.
+//   - Does NOT delete or otherwise modify any other field.
+
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
+// Use the events collection in current DB (mongosh connects to a specific db)
+const events = db.events;
+
+// Pre-patch report
+const totalEvents = events.countDocuments({});
+const multiDayEvents = events.countDocuments({
+  $expr: {
+    $gt: [
+      { $subtract: ['$endDate', '$startDate'] },
+      TWENTY_FOUR_HOURS_MS
+    ]
+  }
+});
+const alreadyPatched = events.countDocuments({
+  $expr: {
+    $gt: [
+      { $subtract: ['$endDate', '$startDate'] },
+      TWENTY_FOUR_HOURS_MS
+    ]
+  },
+  isAllDay: true
+});
+const needsPatch = multiDayEvents - alreadyPatched;
+
+print('=== TIEMPO-351 backfill — pre-patch report ===');
+print(`Total events: ${totalEvents}`);
+print(`Multi-day events (>24hr duration): ${multiDayEvents}`);
+print(`  - Already patched (isAllDay=true): ${alreadyPatched}`);
+print(`  - Needs patch (isAllDay !== true): ${needsPatch}`);
+print('');
+
+if (needsPatch === 0) {
+  print('No-op: all multi-day events already have isAllDay=true. Exiting.');
+  quit(0);
+}
+
+// Apply patch
+print('Applying patch...');
+const result = events.updateMany(
+  {
+    $expr: {
+      $gt: [
+        { $subtract: ['$endDate', '$startDate'] },
+        TWENTY_FOUR_HOURS_MS
+      ]
+    },
+    isAllDay: { $ne: true }
+  },
+  { $set: { isAllDay: true } }
+);
+
+print(`Matched: ${result.matchedCount}`);
+print(`Modified: ${result.modifiedCount}`);
+print('');
+
+// Post-patch report
+const verifyPatched = events.countDocuments({
+  $expr: {
+    $gt: [
+      { $subtract: ['$endDate', '$startDate'] },
+      TWENTY_FOUR_HOURS_MS
+    ]
+  },
+  isAllDay: true
+});
+
+print('=== TIEMPO-351 backfill — post-patch report ===');
+print(`Multi-day events with isAllDay=true: ${verifyPatched}`);
+print(`Expected: ${multiDayEvents}`);
+print(verifyPatched === multiDayEvents ? 'OK — patch complete.' : `WARN — mismatch: ${multiDayEvents - verifyPatched} unpatched.`);

--- a/src/app/components/Modals/CreateEvents/CreateEventDetailModal.js
+++ b/src/app/components/Modals/CreateEvents/CreateEventDetailModal.js
@@ -779,6 +779,10 @@ const CreateEventModal = ({ open, onClose, selectedDate, editMode = false, event
         // TIEMPO-362: Force isRepeating=false for multi-day events (festivals, marathons)
         isRepeating: isMultiDay ? false : eventData.isRepeating,
         recurrenceRule: isMultiDay ? null : eventData.recurrenceRule,
+        // TIEMPO-351: Set isAllDay=true for multi-day events (>24hr duration) so they
+        // render as a single spanning bar in the calendar instead of N per-day tiles.
+        // Single-day timed events keep isAllDay=false (preserves existing behavior).
+        isAllDay: isMultiDay ? true : (eventData.isAllDay || false),
         masteredRegionName: eventData.masteredRegionName || (user?.backendInfo?.localUserInfo?.userDefaults?.region?.name || 'Default Region'),
         categoryFirst: eventData.categoryFirst || 'Other',
         selectedRole: selectedRole, // Add selectedRole for backend validation

--- a/src/app/components/Modals/CreateEvents/CreateEventDetailsBasic.js
+++ b/src/app/components/Modals/CreateEvents/CreateEventDetailsBasic.js
@@ -495,6 +495,11 @@ const CreateEventDetailsBasic = ({ eventData, setEventData, editMode = false, or
               id="venue-autocomplete"
               options={venueOptions}
               loading={loadingVenues}
+              // TIEMPO-301: lock venue field for RO in edit mode — venue changes affect
+              // event location/timezone/venue-specific data and break the
+              // organizer↔venue association invariant. Higher-privilege roles
+              // (RegionalAdmin / SystemAdmin) retain edit capability for admin overrides.
+              disabled={editMode && selectedRole === 'RegionalOrganizer'}
               value={selectedVenue}
               onChange={handleVenueChange}
               onInputChange={handleVenueInputChange}

--- a/src/app/utils/transformEvents.js
+++ b/src/app/utils/transformEvents.js
@@ -39,6 +39,10 @@ export function transformEvents(events) {
     // For FullCalendar RRULE plugin, we need to handle recurring events differently
     const baseEvent = {
       title: event.title, // Use the 'title' field from the API
+      // TIEMPO-351: Map isAllDay to FullCalendar's allDay so multi-day events render as
+      // a single spanning bar instead of N separate per-day tiles. Default false for
+      // single-day timed events (which is the vast majority).
+      allDay: event.isAllDay || false,
       extendedProps: {
         // Any additional data
         _id: event._id,


### PR DESCRIPTION
## Summary

Phase D Story 4.1 round-trip-closure fix per UC-0020 static-confirmation handoff (Quinn 21:30Z). Pre-committed-fix-in-same-arc per Sarah's standing offer 17:20Z.

**Queued behind PR #357 (TIEMPO-351 / UC-0019)** per Quinn 21:30Z "doesn't pre-burn bandwidth" guidance — Toby can batch review TIEMPO-351 + TIEMPO-301 fixes together when his review-window opens.

## UC-0020 classifier verdict (compound-fault-class)
- **Primary** `env-bug` @ 0.88 conf rule-lane (E2EUSER credential persistence gap; blocked dynamic execution — Sarah+Fulton+Quinn cross-team triangulation in flight)
- **Secondary** `code-bug` @ 0.96 conf static analysis (TIEMPO-301 confirmed at `CreateEventDetailsBasic.js` `<Autocomplete id="venue-autocomplete">` line 494; missing `disabled` prop conditioned on `editMode && selectedRole === 'RegionalOrganizer'`)

## Bug
RegionalOrganizer editing existing event sees editable venue Autocomplete. Venue changes affect:
- Event location (geo-coordinates)
- Timezone (venue's IANA tz)
- Venue-specific display data
- Organizer↔venue association invariant

Per JIRA-301: venue field should be disabled (read-only) in edit mode for RO. Higher privilege roles (RegionalAdmin/SystemAdmin) retain edit capability for admin overrides.

## Fix (single-line change)

```diff
  <Autocomplete
    id="venue-autocomplete"
    options={venueOptions}
    loading={loadingVenues}
+   // TIEMPO-301: lock venue field for RO in edit mode
+   disabled={editMode && selectedRole === 'RegionalOrganizer'}
    value={selectedVenue}
    onChange={handleVenueChange}
    onInputChange={handleVenueInputChange}
```

Plus 4-line comment explaining rationale (organizer↔venue invariant + admin-role override).

## Scope analysis
- `editMode` is a prop (default `false`; passed by `CreateEventDetailModal` when opening for edit). Create flow remains unaffected.
- `selectedRole` comes from `AuthContext.useContext`. Source-of-truth for current effective role.
- RA / SA / SO retain venue-edit capability (admin overrides for re-association).
- Spotlighter / NamedUser typically can't reach this modal in edit mode (role-gates upstream); rule applies harmlessly if they do.

## Dynamic validation pathway (deferred per UC-0020 escalation)
- UC-0020 dynamic re-spawn requires E2EUSER credential persistence resolution (Quinn Gap 1)
- Sarah+Fulton+Quinn cross-team triangulation in flight on path (a) gitignored credential persist OR path (b) Firebase custom-token injection
- Sprint 5 retro candidate noted; this fix lands on static evidence which is sufficient per ADR-0006 ≥85% conf threshold (0.96 conf rule-lane)

## §18.1 maintenance rule scope check
- No `data-testid` added/renamed/removed → §0/§11 update NOT required
- No label-based form field added → §0.2 cheat-sheet update NOT required
- No modal surface added → §11 modal taxonomy update NOT required
- Selectors unchanged

§18.1 rule does NOT trigger for this PR.

## Phase D Story 4.1 Acceptance impact (post UC-0020 escalation)
- ✓ UC-0013 cleanly-honored (BE baseline #1)
- ✓ UC-0018 cleanly-honored (BE baseline #2 post-routing-override)
- N/A UC-0015 pre-flight regression-guard
- ⏳ UC-0019 PR #357 HOLD pending Toby
- 🟡 UC-0020 escalated with compound-fault-class (this PR closes secondary code-bug; primary env-bug pending credential strategy)
- 3-of-3 honored routing UNCHANGED

## Cross-references
- JIRA TIEMPO-301 — bug ticket (FE Discovery Tier-1 #3 per PR #356 corpus; verified DORMANT 20:25Z)
- UC-0020 spec: `e2e-calendar-framework/usecases/escalated/UC-0020.yaml`
- Audit: `triage/decisions/run-20260507-2120.jsonl`
- PR #356 Sarah's FE Discovery corpus (TIEMPO-301 Tier-1 #3 entry; UC-0020 follow-on per Q1 ordering)
- PR #355 v0.9 stacked-septet (E2E-TESTING-REFERENCE — Gauge consult per SAD Step 0)
- PR #357 (TIEMPO-351 / UC-0019) — Toby-review-window queue-mate

🤖 Generated with [Claude Code](https://claude.com/claude-code)