### PR TITLE
fix(events): fail-closed on missing venue geo (no [0,0] write-side fallback)

### DIFF
--- a/scripts/TIEMPO-351-backfill-isAllDay.mongosh.js
+++ b/scripts/TIEMPO-351-backfill-isAllDay.mongosh.js
@@ -1,0 +1,96 @@
+// TIEMPO-351 data backfill — set isAllDay: true for existing multi-day LONG events
+//
+// Purpose: existing events in MongoDB created before TIEMPO-351 fix have isAllDay=false
+// (or missing). The FE now sets isAllDay=true on save for multi-day events (>24hr
+// duration), but historical multi-day LONG events remain incorrectly rendered as
+// per-day tiles instead of spanning bars.
+//
+// Strategy: match events where the duration is >24 hours (isMultiDayEvent === true
+// in the FE) and set isAllDay=true. Categories most affected per TIEMPO-351 are
+// Festival, Marathon, Encuentro, Workshop — but the canonical signal is duration,
+// not category, so the patch keys on duration to align with FE write-side logic.
+//
+// Usage (TEST):
+//   mongosh "<TEST_MONGO_URI>" scripts/TIEMPO-351-backfill-isAllDay.mongosh.js
+//
+// Usage (PROD — requires DEPLOY-PROD authorization per PROD-DEPLOY-PROTECTION.md):
+//   mongosh "<PROD_MONGO_URI>" scripts/TIEMPO-351-backfill-isAllDay.mongosh.js
+//
+// Safety:
+//   - Idempotent: re-running has no effect on already-patched events.
+//   - Targeted: only updates events with duration >24hr AND isAllDay !== true.
+//   - Reports counts before + after for verification.
+//   - Does NOT delete or otherwise modify any other field.
+
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
+// Use the events collection in current DB (mongosh connects to a specific db)
+const events = db.events;
+
+// Pre-patch report
+const totalEvents = events.countDocuments({});
+const multiDayEvents = events.countDocuments({
+  $expr: {
+    $gt: [
+      { $subtract: ['$endDate', '$startDate'] },
+      TWENTY_FOUR_HOURS_MS
+    ]
+  }
+});
+const alreadyPatched = events.countDocuments({
+  $expr: {
+    $gt: [
+      { $subtract: ['$endDate', '$startDate'] },
+      TWENTY_FOUR_HOURS_MS
+    ]
+  },
+  isAllDay: true
+});
+const needsPatch = multiDayEvents - alreadyPatched;
+
+print('=== TIEMPO-351 backfill — pre-patch report ===');
+print(`Total events: ${totalEvents}`);
+print(`Multi-day events (>24hr duration): ${multiDayEvents}`);
+print(`  - Already patched (isAllDay=true): ${alreadyPatched}`);
+print(`  - Needs patch (isAllDay !== true): ${needsPatch}`);
+print('');
+
+if (needsPatch === 0) {
+  print('No-op: all multi-day events already have isAllDay=true. Exiting.');
+  quit(0);
+}
+
+// Apply patch
+print('Applying patch...');
+const result = events.updateMany(
+  {
+    $expr: {
+      $gt: [
+        { $subtract: ['$endDate', '$startDate'] },
+        TWENTY_FOUR_HOURS_MS
+      ]
+    },
+    isAllDay: { $ne: true }
+  },
+  { $set: { isAllDay: true } }
+);
+
+print(`Matched: ${result.matchedCount}`);
+print(`Modified: ${result.modifiedCount}`);
+print('');
+
+// Post-patch report
+const verifyPatched = events.countDocuments({
+  $expr: {
+    $gt: [
+      { $subtract: ['$endDate', '$startDate'] },
+      TWENTY_FOUR_HOURS_MS
+    ]
+  },
+  isAllDay: true
+});
+
+print('=== TIEMPO-351 backfill — post-patch report ===');
+print(`Multi-day events with isAllDay=true: ${verifyPatched}`);
+print(`Expected: ${multiDayEvents}`);
+print(verifyPatched === multiDayEvents ? 'OK — patch complete.' : `WARN — mismatch: ${multiDayEvents - verifyPatched} unpatched.`);

--- a/src/app/components/Modals/CreateEvents/CreateEventDetailModal.js
+++ b/src/app/components/Modals/CreateEvents/CreateEventDetailModal.js
@@ -779,6 +779,10 @@ const CreateEventModal = ({ open, onClose, selectedDate, editMode = false, event
         // TIEMPO-362: Force isRepeating=false for multi-day events (festivals, marathons)
         isRepeating: isMultiDay ? false : eventData.isRepeating,
         recurrenceRule: isMultiDay ? null : eventData.recurrenceRule,
+        // TIEMPO-351: Set isAllDay=true for multi-day events (>24hr duration) so they
+        // render as a single spanning bar in the calendar instead of N per-day tiles.
+        // Single-day timed events keep isAllDay=false (preserves existing behavior).
+        isAllDay: isMultiDay ? true : (eventData.isAllDay || false),
         masteredRegionName: eventData.masteredRegionName || (user?.backendInfo?.localUserInfo?.userDefaults?.region?.name || 'Default Region'),
         categoryFirst: eventData.categoryFirst || 'Other',
         selectedRole: selectedRole, // Add selectedRole for backend validation

--- a/src/app/hooks/useEvents.js
+++ b/src/app/hooks/useEvents.js
@@ -618,7 +618,18 @@ export function useEventOperations() {
         };
 // TIEMPO-276: Security cleanup - removed logging
       } else if (eventData.venueID) {
-        // We have a venue but no coordinates - need to fetch them
+        // We have a venue but no coordinates - need to fetch them.
+        //
+        // FAIL-CLOSED on missing venue geo (per `feedback_no_location_fallback.md`
+        // HARD RULE generalized to write-side). Previous behavior silently wrote
+        // `coordinates: [0, 0]` (null island, off the African coast) when the
+        // venue lookup failed or returned malformed data. That made the event
+        // invisible to every legitimate geo-radius filter and was indistinguishable
+        // from "missing event" in user-facing reports.
+        //
+        // Refusing to save loudly is the right discipline: the user immediately
+        // knows the venue record is broken and can either pick a different venue
+        // or escalate to admin to fix the venue's geocoding.
         try {
           const { getVenueById } = await import('@/services/venueService');
           const venueData = await getVenueById(eventData.venueID);
@@ -629,18 +640,25 @@ export function useEventOperations() {
               coordinates: [parseFloat(venueData.longitude), parseFloat(venueData.latitude)]
             };
           } else {
-            console.warn('Could not retrieve venue coordinates for venueID:', eventData.venueID);
-            preparedData.venueGeolocation = {
-              type: "Point",
-              coordinates: [0, 0]
-            };
+            // Venue exists but lacks coordinates — data-shape problem on venue record
+            const venueLabel = venueData?.name || eventData.venueName || eventData.venueID;
+            throw new Error(
+              `Venue "${venueLabel}" is missing geolocation coordinates. ` +
+              `Please pick a different venue, or contact an admin to fix the venue record.`
+            );
           }
         } catch (venueError) {
+          // Re-throw with our own framed message if it's a fetch failure (network/server)
+          // to avoid leaking implementation detail to the user. Pass through our own
+          // thrown error from the inner branch unchanged.
+          if (venueError instanceof Error && venueError.message?.startsWith('Venue "')) {
+            throw venueError;
+          }
           console.error('Error fetching venue data:', venueError);
-          preparedData.venueGeolocation = {
-            type: "Point",
-            coordinates: [0, 0]
-          };
+          throw new Error(
+            `Could not verify venue coordinates (network or server error). ` +
+            `Please retry, or contact an admin if the problem persists.`
+          );
         }
       }
 
@@ -854,7 +872,10 @@ export function useEventOperations() {
           coordinates: [parseFloat(eventData.venueLongitude), parseFloat(eventData.venueLatitude)]
         };
       } else if (eventData.venueID) {
-        // We have a venue but no coordinates - need to fetch them
+        // We have a venue but no coordinates - need to fetch them.
+        // FAIL-CLOSED on missing venue geo (mirrors createEvent above; see header
+        // comment there for rationale: `feedback_no_location_fallback.md` HARD RULE
+        // generalized to write-side; refuse to save rather than write [0, 0]).
         try {
           const { getVenueById } = await import('@/services/venueService');
           const venueData = await getVenueById(eventData.venueID);
@@ -865,18 +886,21 @@ export function useEventOperations() {
               coordinates: [parseFloat(venueData.longitude), parseFloat(venueData.latitude)]
             };
           } else {
-            console.warn('Could not retrieve venue coordinates for venueID:', eventData.venueID);
-            preparedData.venueGeolocation = {
-              type: "Point",
-              coordinates: [0, 0]
-            };
+            const venueLabel = venueData?.name || eventData.venueName || eventData.venueID;
+            throw new Error(
+              `Venue "${venueLabel}" is missing geolocation coordinates. ` +
+              `Please pick a different venue, or contact an admin to fix the venue record.`
+            );
           }
         } catch (venueError) {
+          if (venueError instanceof Error && venueError.message?.startsWith('Venue "')) {
+            throw venueError;
+          }
           console.error('Error fetching venue data for update:', venueError);
-          preparedData.venueGeolocation = {
-            type: "Point",
-            coordinates: [0, 0]
-          };
+          throw new Error(
+            `Could not verify venue coordinates (network or server error). ` +
+            `Please retry, or contact an admin if the problem persists.`
+          );
         }
       }
 

--- a/src/app/utils/transformEvents.js
+++ b/src/app/utils/transformEvents.js
@@ -39,6 +39,10 @@ export function transformEvents(events) {
     // For FullCalendar RRULE plugin, we need to handle recurring events differently
     const baseEvent = {
       title: event.title, // Use the 'title' field from the API
+      // TIEMPO-351: Map isAllDay to FullCalendar's allDay so multi-day events render as
+      // a single spanning bar instead of N separate per-day tiles. Default false for
+      // single-day timed events (which is the vast majority).
+      allDay: event.isAllDay || false,
       extendedProps: {
         // Any additional data
         _id: event._id,


### PR DESCRIPTION
## Summary

Per `feedback_no_location_fallback.md` HARD RULE generalized to write-side: refuse to save rather than silently substitute defaults. **Three-domain coverage** of the rule: render layer (TT-original) + test-assertion layer (§0.6 v0.6) + now write-side (this PR).

## Bug
`createEvent` (`useEvents.js:620+`) and `updateEvent` (`useEvents.js:874+`) both silently wrote `coordinates: [0, 0]` when the venue lookup failed or returned malformed data. `[0, 0]` is **null island** (off the African coast). The event was saved but **invisible to every legitimate geo-radius filter** — indistinguishable from "missing event" in user-facing reports.

## Trigger
Surfaced during Vicky/BDU incident audit 2026-05-09T23:53Z. **Vicky's events were NOT affected** (Fulton confirmed all 50 of her events have valid coords) — but the `[0,0]` fallback class is the same shape as a real fault that would cause "events that exist but seem missing" reports. The exact pattern of the Vicky-investigation hypothesis space (rejected as her cause; codified as a real concern).

## Fix
Both `createEvent` and `updateEvent` now throw user-facing errors instead of silently substituting `[0, 0]`:

```diff
- preparedData.venueGeolocation = { type: "Point", coordinates: [0, 0] };
+ throw new Error(`Venue "${venueLabel}" is missing geolocation coordinates. Please pick a different venue, or contact an admin to fix the venue record.`);
```

Two error variants:
- **Venue exists but lacks coords** (data-shape problem on venue record): "Venue \"<name>\" is missing geolocation coordinates. Please pick a different venue, or contact an admin to fix the venue record."
- **Fetch fails** (network/server problem): "Could not verify venue coordinates (network or server error). Please retry, or contact an admin if the problem persists."

## Behavior change
Events that previously **saved-with-[0,0]** (silently broken) now **fail-to-save** (loudly broken). This is the correct discipline — loud-failure > silent-broken-data. The user immediately knows the venue record is broken; can pick a different venue or escalate.

## Migration ask (Fulton/Dash lane)
**Recommend:** before this fix reaches PROD users, run a one-time mongosh to identify any current TT events with `venueGeolocation.coordinates: [0, 0]`:

```js
db.events.find({ 'venueGeolocation.coordinates': [0, 0], appId: 1 }).count()
```

If any exist, they can be cleaned up by re-geocoding against the venue record (or flagging for organizer attention). Otherwise organizers attempting to edit one of those events will see the new error and may be confused. Coordination with Fulton (calendar-be-af) + Dash (CalOps admin tools) for the data-cleanup pass.

## §18.1 maintenance rule scope check
- No `data-testid` added/renamed/removed → §0/§11 update NOT required
- No label-based form field added → §0.2 cheat-sheet update NOT required
- No modal surface added → §11 modal taxonomy update NOT required
- Selectors unchanged

§18.1 rule does NOT trigger for this PR.

## Quinn ratification trail
- Sprint 5 audit 2026-05-09T23:48Z surfaced finding (Sarah save-flow audit Pattern #2)
- Quinn 2026-05-09T23:52Z explicitly ratified Sarah-update PR queue: "the 'no fallback' rule generalizes from data-load to test-assertion to write-side. Three-domain-coverage now."
- Queue position: behind PR #357 (TIEMPO-351) + PR #358 (TIEMPO-301) for Toby-review-window

## Cross-references
- HARD RULE memory: `feedback_no_location_fallback.md` (Toby 2026-04-19)
- Render-layer instance: original rule (TT calendar render)
- Test-assertion-layer instance: `docs/E2E-TESTING-REFERENCE.md` §0.6 v0.6 (PR #355 stack)
- Write-side instance: this PR
- Vicky/BDU incident audit (no JIRA ticket; multi-persona thread; Quinn synthesizing to Number2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)