### PR TITLE
chore(release): v1.26.0 — Window 1 PROD-promote prep

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
- "version": "1.25.0",
+ "version": "1.26.0",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",


### PR DESCRIPTION
**Window 1 Step 4 prep — version bump only**

Bumps `package.json` from `1.25.0` → `1.26.0` (minor; new features warrant minor: TIEMPO-454 organizer welcome page, TIEMPO-456 shortname hint UI, sitemap additions).

Standalone PR to land on TEST first; once merged, the TEST → PROD Window 1 bundle PR will include this version bump in the promote commit.

Per Quinn beat-16 Window 1 sequence + MasterCalendar rule "no promotion without version increment."

Standard CalOps/CalBE pattern (cf. calops#35 v1.11.0 bump, Dash 2026-05-12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)