### PR TITLE
fix(analytics): MapCenterTrack POST forwards 3-tier flat geo fields (TIEMPO-324 backfill, Invariant 8)

### DIFF
--- a/src/app/calendar/layout.js
+++ b/src/app/calendar/layout.js
@@ -94,6 +94,16 @@ const RootLayout = ({ children }) => {
       try {
         const afUrl = process.env.NEXT_PUBLIC_AF_URL || 'http://localhost:7071';
 
+        // TIEMPO-324 backfill (Geolocation cycle Phase 6, beat-65): 3-tier
+        // geolocation flat fields (browser GPS → Google API → ipinfo fallback)
+        // — matches the existing VisitorTrack + UserLoginTrack writers so BE
+        // source-attribution chain (GoogleBrowser > GoogleGeolocation > IPInfoIO)
+        // can stamp the canonical source per Invariant 8. Without this call,
+        // MapCenterTrack POSTs only the nested {cloudflare, google, ipapi}
+        // shape, which fails the BE's flat-field priority chain and falls
+        // through to 100% IPInfoIO attribution.
+        const browserGeoData = await getGeolocationData();
+
         // PHASE 1.2: Use 1-hour cache for map center changes
         const geoData = await fetchAllGeolocationData(60);
 
@@ -112,7 +122,13 @@ const RootLayout = ({ children }) => {
             timezoneOffset: -new Date().getTimezoneOffset(),
             cloudflare: geoData.cloudflare,
             google: geoData.google,
-            ipapi: geoData.ipapi
+            ipapi: geoData.ipapi,
+            // TIEMPO-324 backfill: 3-tier flat fields (Invariant 8 contract)
+            google_browser_lat: browserGeoData.google_browser_lat,
+            google_browser_long: browserGeoData.google_browser_long,
+            google_browser_accuracy: browserGeoData.google_browser_accuracy,
+            google_api_lat: browserGeoData.google_api_lat,
+            google_api_long: browserGeoData.google_api_long
           })
         });
       } catch (error) {


### PR DESCRIPTION
## 🟢 HITM-READY (pending Quinn ratification) — Geolocation cycle Phase 6 (Quinn beat-65 trigger)

**Target:** DEVL → TEST promotion per Quinn beat-66; PROD promotion is a separate later cycle.

---

# CRK — Full 6-dimension per Quinn beat-40 + 4-precondition gate per Gotan beat-49

## Confidence: 92%

## Scope

**Geolocation cycle Phase 6 — TIEMPO-324 partial-coverage backfill for MapCenterTrack FE caller**

Single-file FE-only change: `src/app/calendar/layout.js:87-133` (MapCenterTrack body builder inside `useEffect([user])` callback for `locationEventBus.LOCATION_CHANGED`). Adds `getGeolocationData()` call + merges 5 flat-named geolocation fields into POST body per the established UserLoginTrack/VisitorTrack pattern.

**Pattern source:** VisitorTrack at `calendar/layout.js:28` + `:69-74` (working, in-context, verified pre-existing). Byte-pattern identical merge.

**Diff:** +17 / -1 lines (1 added import line was already present; the 17/-1 is the body-builder fields + the explanatory inline comment block + the `getGeolocationData()` call).

## Risks (LOW)

(a) `getGeolocationData()` is an existing, already-imported, already-used-by-2-sibling-writers helper. No new dependency, no new behavior at the helper level.
(b) MapCenterTrack callback already gracefully handles errors via outer `try { ... } catch (error) { console.warn(...) }` — adding another async call adds no new failure mode beyond existing semantics (any throw propagates to same catch).
(c) Localhost skip-guard at line 89 preserved — fix only activates on non-localhost (TT TEST + TT PROD).
(d) BE side unchanged — contract has been correct since `calendar-be-af@40b4afc4` (CALBEAF-53). Fix is FE-only.

## Knowledge gaps

(a) Local DevTools probe not feasible from CLI authoring environment. Validation relies on TT TEST deploy + post-deploy probe (per beat-65 timing estimate: ~5-15min after merge, first user-flow records MapCenterHistory PROD).
(b) `getGeolocationData()` may have its own browser-GPS prompt UX surface on first-call. Existing TIEMPO-324 deployment already exposes this prompt via VisitorTrack mount and UserLoginTrack login-flow — adding MapCenterTrack to the prompt-surface set doesn't introduce new prompting (helper has internal session-cache; subsequent calls are cached).

## Regression evidence

- ✅ **Pattern verbatim from working sibling writer:** VisitorTrack lines 28 + 69-74 use identical `getGeolocationData()` → flat-field merge pattern. Working in PROD for 7d (Dash empirical: VisitorTrackingHistory diverse).
- ✅ **BE contract pre-existing + working:** Fulton beat-05:18Z + 05:20Z confirms 3 writers share identical contract; BE persists ALL fields via spread.
- ✅ **No existing regression test on MapCenterTrack body builder shape** (gap noted; could be added in Sprint-6+ FE unit-test backfill); structural-identity-to-sibling-writer is the alternative validation evidence for this cycle.
- ✅ **Post-deploy validation plan:** Dash probes MapCenterHistory PROD source distribution post-TEST-promotion + after first user-flow records arrive; expects drift from 100% IPInfoIO toward diverse (GoogleBrowser + GoogleGeolocation + IPInfoIO).

## Tier-1/Tier-2 surface evidence

**Tier-2 (analytics-source correctness — per Quinn beat-49 user-impact-tier framing):**
- Fix corrects analytics-source attribution; not user-facing UX surface
- `/calendar` default view: UNAFFECTED (this fix is in MapCenterTrack writer, fires only on `LOCATION_CHANGED` event, not on `/calendar` mount)
- SEO `/tango/[parent]/[city]` routes: UNAFFECTED (different code path)
- Auth flows: UNAFFECTED (different code path)

**Tier-1 surfaces preserved:** No change to /calendar default rendering, /tango/[parent] rendering, or auth boundary. Tier-2 correctness fix only.

## Semantic-consistency check (Quinn beat-36 / Invariant 2)

✅ Fix respects `isDiscovered` semantic — no event-origin attribute touched. Different attribute domain (`source` on analytics records, governed by Invariant 8 candidate).

## Product-intent check (Pattern G / gate-5)

✅ No default user-perceived behavior change. Map-center tracking is invisible-to-user analytics; fix changes only the BE-stored `source` attribution which is consumed by admin dashboards (Dash CalOps), not user-paramount surfaces. Per Quinn beat-63 + beat-65 framing: Tier-2 correctness fix.

## Invariants applicability (Quinn beat-39 gate-6)

Per `MasterCalendar/docs/CALENDAR-INVARIANTS.md` v1.1 + Invariant 8 candidate (User-Geo Source-Attribution Priority Chain, Phase 5 locked beat-63):

| Invariant | Applies? | Direction |
|---|---|---|
| 1 — Default Calendar Renders Event Density | No (different code path) | n/a |
| 2 — Event-Origin Attribute Semantics | No (different attribute domain) | n/a |
| 3 — SEO Parent-Scoped Landings | No (different code path) | n/a |
| 4 — Schema Authority by Collection | Yes (cross-cutting) | Compliant — POST body uses appID=1 implicit via TT FE; no mastering collection touch |
| 5 — No Location Fallback | No (no location-fallback logic in this fix) | n/a |
| 6 — Discovery-Pipeline Provenance | No (not a discovery write) | n/a |
| 7 — Auth Boundary on Calendar | No (different surface) | n/a |
| **8 (candidate) — User-Geo Source-Attribution Priority Chain** | **Yes (cross-cutting)** | **POSITIVE FIX — restores chain compliance for MapCenterTrack writer** |

**Ratification protocol probes** (per Invariant 8 candidate framing beat-63):
- ≤80% IPInfoIO over 24h rolling window threshold = regression detection (post-deploy validation via Dash probe)
- Empirical baseline pre-fix: MapCenterHistory 100% IPInfoIO (Dash 05:18Z probe, n=157)
- Empirical target post-fix: MapCenterHistory diverse distribution matching VisitorTrackingHistory shape (GoogleGeo majority + GoogleBrowser minority + IPInfoIO residual)

## 4-precondition gate (Gotan beat-49)

| Precondition | Evidence |
|---|---|
| **PLAN** | Quinn beat-63 Phase 5 design lock + Gotan concurrence beat-after-63 + this PR description |
| **TEST** | Pattern-identity validation against working VisitorTrack sibling; post-deploy empirical validation plan in §Regression evidence |
| **ROLLBACK** | `git revert <merge-sha>` on TEST → next Vercel auto-deploy reverts ~3-5min. Atomic single-merge-commit. |
| **MERGEABILITY** | `git merge-tree` 0 conflicts vs origin/TEST (verified pre-PR-submission per Gotan 4-precondition discipline) ✅ |

## Backout one-liner

`git revert <merge-sha>` on TEST → Vercel TEST auto-deploys reverted code in ~3-5 min. No data migration needed; MapCenterHistory continues operating with pre-fix (IPInfoIO-only) behavior.

## Deploy mechanic

TEST-tier merge via standard CR-on-risky-only path per `GIT-BRANCHING-STRATEGY.md`. **5-10 line low-risk fix; standard sandbox→TEST merge.** Toby HITM NOT required for TEST-tier per `PROD-DEPLOY-PROTECTION.md` standing rule.

Vercel TEST auto-deploys on TEST branch push (per `DEPLOYMENT-MATRIX.md` — TT TEST = auto). No manual `vercel --prod` step at this tier.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)