### PR TITLE
Geolocation cycle PROD-promote: MapCenterTrack 3-tier flat-field backfill (TIEMPO-324, Invariant 8 positive fix)

### DIFF
--- a/src/app/calendar/layout.js
+++ b/src/app/calendar/layout.js
@@ -94,6 +94,16 @@ const RootLayout = ({ children }) => {
       try {
         const afUrl = process.env.NEXT_PUBLIC_AF_URL || 'http://localhost:7071';
 
+        // TIEMPO-324 backfill (Geolocation cycle Phase 6, beat-65): 3-tier
+        // geolocation flat fields (browser GPS → Google API → ipinfo fallback)
+        // — matches the existing VisitorTrack + UserLoginTrack writers so BE
+        // source-attribution chain (GoogleBrowser > GoogleGeolocation > IPInfoIO)
+        // can stamp the canonical source per Invariant 8. Without this call,
+        // MapCenterTrack POSTs only the nested {cloudflare, google, ipapi}
+        // shape, which fails the BE's flat-field priority chain and falls
+        // through to 100% IPInfoIO attribution.
+        const browserGeoData = await getGeolocationData();
+
         // PHASE 1.2: Use 1-hour cache for map center changes
         const geoData = await fetchAllGeolocationData(60);
 
@@ -112,7 +122,13 @@ const RootLayout = ({ children }) => {
             timezoneOffset: -new Date().getTimezoneOffset(),
             cloudflare: geoData.cloudflare,
             google: geoData.google,
-            ipapi: geoData.ipapi
+            ipapi: geoData.ipapi,
+            // TIEMPO-324 backfill: 3-tier flat fields (Invariant 8 contract)
+            google_browser_lat: browserGeoData.google_browser_lat,
+            google_browser_long: browserGeoData.google_browser_long,
+            google_browser_accuracy: browserGeoData.google_browser_accuracy,
+            google_api_lat: browserGeoData.google_api_lat,
+            google_api_long: browserGeoData.google_api_long
           })
         });
       } catch (error) {


### PR DESCRIPTION
## 🟢 HITM-MERGE READY (pending Quinn ratification + Toby DEPLOY-PROD)

**Geolocation cycle PROD-promote** per Quinn beat-75 + Gotan beat-after-74 concurrence (independent PROD event; NOT bundled with Window 2). Triple-channel validated on TT TEST 05:52-05:59Z.

**Toby — DEPLOY-PROD phrase required + UI merge per PROD-DEPLOY-PROTECTION** when convenient (tonight or tomorrow AM, your call).

---

# CRK — Full per Quinn beat-40 + 4-precondition gate per Gotan beat-49 + Calendar-Protection Steward gates

## Confidence: 95%

## Scope

**Single-file FE-only change:** `src/app/calendar/layout.js:87-133` (MapCenterTrack body builder inside `useEffect([user])` callback for `locationEventBus.LOCATION_CHANGED`)

**Diff:** +17 / -1 lines (commit `fa65e019` on PR #363 → merged sandbox→TEST as `53be2a51`)

**Pattern:** TIEMPO-324-backfill-for-MapCenterTrack — adds `getGeolocationData()` call + merges 5 flat-named geolocation fields into POST body per established UserLoginTrack/VisitorTrack pattern. Pattern source: VisitorTrack at `calendar/layout.js:28` + `:69-74` (working in PROD 7d per Dash empirical).

## Empirical anchor evidence chain (per Quinn beat-75 explicit citation)

**Pre-fix baseline (TT TEST + PROD bug state):**
- TT TEST MapCenterHistory: **13/13 = 100% IPInfoIO** (Dash 05:48Z probe; n=13; 2-day window)
- PROD MapCenterHistory: **157/157 = 100% IPInfoIO** (Dash 21:18Z previous-day probe; n=157; 7d window)

**Post-fix triple-channel validation on TT TEST:**

| Lane | Method | Result |
|---|---|---|
| **BE (Fulton 05:52Z)** | Direct probe on calendar-be-af TEST AI for last 1h post-trigger | 8/8 MapCenterTrack POSTs success; **p50=184ms (BETTER than pre-fix PROD baseline 257ms)**; VisitorTrack + UserLoginTrack sibling collections regression-clean; no PROD regression |
| **CalOps (Dash 05:52Z)** | Probe `/api/analytics/map-center-history?appId=1` post-trigger | TT TEST distribution drift: **100% IPInfoIO → 100% GoogleBrowser** (Toby granted GPS permission) |
| **User-direct (Toby 05:59Z)** | Dashboard view + incognito-bonus-path exercise | Activity Map dashboard renders both Google paths correctly; **both GoogleBrowser (Priority 1) AND GoogleGeolocation Google-IP (Priority 2) user-confirmed via incognito GPS-declined session** |

**End-to-end chain validated (7 stages):**
1. ✅ TT FE forwards `google_browser_lat/long` in MapCenterTrack POST body
2. ✅ BE writer's source-attribution chain priority-1 stamp fires
3. ✅ MongoDB write persists `userLocation.source = 'GoogleBrowser'`
4. ✅ BE reader surfaces source faithfully
5. ✅ CalOps proxy forwards through with auth
6. ✅ CalOps Activity Map page SSR healthy
7. 🟢 Color rendering verified user-side (green dots emerging)

**This is the strongest empirical evidence base attached to a PROD-promote CRK in this team's history** (Gotan beat-after-74 observation).

## Risks (LOW)

(a) `getGeolocationData()` is an existing, already-imported, already-used-by-2-sibling-writers helper. No new dependency, no new behavior at the helper level.
(b) Outer try/catch graceful error handling already in place; adding another async call adds no new failure mode.
(c) Localhost skip-guard at line 89 preserved — fix only activates on non-localhost (TT PROD path identical to TEST validated path).
(d) BE side unchanged — contract has been correct since `calendar-be-af@40b4afc4` (CALBEAF-53). Fix is FE-only.
(e) No regression observed on sibling writers (Fulton confirmed: VisitorTrack + UserLoginTrack on TT TEST clean post-fix).

## Knowledge gaps

(a) PROD anonymous-mobile traffic patterns will exercise both GoogleBrowser and GoogleGeolocation paths organically over ~24h post-deploy; full diversity emergence is traffic-dependent. Fulton + Dash armed for post-deploy 24h validation probe.
(b) `getGeolocationData()` may prompt for browser GPS on PROD first-call sessions for users who haven't already encountered TIEMPO-324 prompt flow via VisitorTrack/UserLoginTrack — prompt UX is invisible to user-paramount /calendar mount path (only fires on map-pan / LOCATION_CHANGED event); no new UX surface for users who decline.

## Regression evidence

- ✅ TT TEST empirical: 100% IPInfoIO → 100% GoogleBrowser drift confirmed (Dash + Fulton + Toby cross-validation)
- ✅ Sibling writers preserved on TT TEST (Fulton regression check: VisitorTrack + UserLoginTrack clean)
- ✅ Latency healthy: p50 184ms post-fix BETTER than 257ms pre-fix PROD baseline
- ✅ `/calendar` Tier-1 surface no-regression on TT TEST (HTTP 200 / 34885 bytes post-deploy sanity)
- ✅ Pattern verbatim from sibling VisitorTrack writer (working in PROD 7d already)

## Tier-1/Tier-2 surface evidence

**Tier-2 (analytics-source correctness per Quinn beat-49 user-impact-tier framing):** Fix corrects analytics-source attribution; not user-facing UX surface.

**Tier-1 surfaces preserved (no impact):** /calendar default rendering, /tango/[parent] rendering, auth boundary — all UNAFFECTED. Different code paths.

## Semantic-consistency check (Quinn beat-36 / Invariant 2)

✅ Fix respects `isDiscovered` semantic — no event-origin attribute touched. Different attribute domain (`source` on analytics records, governed by Invariant 8 candidate per Phase 5 lock).

## Product-intent check (Pattern G / gate-5)

✅ No default user-perceived behavior change. Map-center tracking is invisible-to-user analytics; fix changes only the BE-stored `source` attribution which is consumed by admin dashboards (Dash CalOps), not user-paramount surfaces. Per Quinn beat-63 + beat-65 framing: Tier-2 correctness fix.

## Invariants applicability (Quinn beat-39 gate-6)

Per `MasterCalendar/docs/CALENDAR-INVARIANTS.md` v1.1 + Invariant 8 candidate (Phase 5 locked beat-63, ratified beat-64):

| Invariant | Applies? | Direction |
|---|---|---|
| 1 — Default Calendar Renders Event Density | No (different code path) | n/a |
| 2 — Event-Origin Attribute Semantics | No (different attribute domain) | n/a |
| 3 — SEO Parent-Scoped Landings | No (different code path) | n/a |
| 4 — Schema Authority by Collection | Yes (cross-cutting) | Compliant — POST body uses appID=1 implicit via TT FE; no mastering collection touch |
| 5 — No Location Fallback | No (no location-fallback logic in fix) | n/a |
| 6 — Discovery-Pipeline Provenance | No (not a discovery write) | n/a |
| 7 — Auth Boundary on Calendar | No (different surface) | n/a |
| **8 (candidate) — User-Geo Source-Attribution Priority Chain** | **Yes (cross-cutting)** | **POSITIVE FIX — restores chain compliance for MapCenterTrack writer; triple-channel-validated** |

## 4-precondition gate (Gotan beat-49)

| Precondition | Evidence |
|---|---|
| **PLAN** | Quinn beat-63 Phase 5 design lock + Gotan beat-after-63 concurrence + beat-75 PROD-promote ratification |
| **TEST** | TT TEST empirical 100% IPInfoIO → 100% GoogleBrowser drift; triple-channel validation chain (BE/CalOps/User) |
| **ROLLBACK** | `git revert <merge-sha>` on PROD branch + manual `vercel --prod` rollback to pre-fix HEAD ~5min. Atomic single-merge-commit. |
| **MERGEABILITY** | `git merge-tree` pre-flight check verified at PR submission |

## Backout one-liner

`git revert <merge-sha>` on PROD branch → manual `vercel --prod` deploy of post-revert HEAD to `tangotiempo-com` Vercel project → ~5 min from revert decision to PROD-live at pre-fix state.

## Deploy mechanic (CRITICAL — manual step required after Toby HITM-merge)

Per `MasterCalendar/docs/DEPLOYMENT-MATRIX.md`: TT PROD auto-deploy = ❌.

**After Toby HITM-merges this PR:**
1. TT PROD branch advances; merge commit lands
2. **Someone runs `vercel --prod`** from a checkout at the new PROD HEAD to push to `tangotiempo-com` Vercel project (Sarah will execute on-merge-notification)
3. Smoke verify on https://tangotiempo.com after deploy completes
4. Fulton + Dash 24h post-deploy probe armed for PROD source-distribution emergence

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)