### PR TITLE
fix(calendar): TIEMPO-457 Window 2 — 4-component bundle + 5-level geo cascade (v1.27.0)

### DIFF
--- a/docs/TIEMPO-phase2a-calendar-anonymous-mobile-bootstrap-audit.md
+++ b/docs/TIEMPO-phase2a-calendar-anonymous-mobile-bootstrap-audit.md
@@ -1,0 +1,270 @@
+# Phase 2a Audit — TT /calendar LOC anonymous-mobile bootstrap failure
+
+**Author:** Sarah (TT FE)
+**Date:** 2026-05-12
+**Status:** Phase 2a complete; FE diagnosis locked. Awaiting Fulton's trace-stitch + Phase 2b output before Phase 3 convergence 2026-05-14 AM.
+**Coordinator:** Quinn
+**Cross-link:** CALBEAF-### (Fulton BE companion, to be created Phase 3)
+**Incident artifact:** CalOps "API Errors Report 7d" 2026-05-12 14:16:55 BOS (single Boston session, 5/12 12:53:42 PM, 6 traces)
+**Class:** "Always-mounted side-effecting conditional component" (Archie's naming, 2026-05-12T19:01Z)
+
+---
+
+## Summary
+
+The user-perceived bug — anonymous mobile iPhone visitor sees "Loading Map Settings…/Opening location selector" + zero events for 4s, then gives up — is the product of **two independent FE defects** that compound on a cold Azure Function instance:
+
+- **Defect 1 (fleet-wide):** an unguarded modal mount in the app shell causes `useServiceHealth` to fire 4 health-check fetches on **every page load for every user** including anonymous mobile.
+- **Defect 2 (/calendar-specific):** a conditional render gate at `src/app/calendar/page.js:1251` blocks `<FullCalendar>` (and therefore the events fetch) until `useGeoLocation()` resolves a location — for anonymous users with no saved location, that's a ~4s wait on a cold Google Geo API call.
+
+The "5-call burst aborting in a 28ms window" in the incident report is **not** a `Promise.all` rejection cascade or an `AbortController.timeout` firing. The timing math is decisive: aborts at 4267–4295ms are below the 5000ms `AbortSignal.timeout` floor. The aborts are mobile-Safari's cancel-all-in-flight on user backgrounding. The 28ms window is the browser's cancel-batch.
+
+**Fix shape:** two FE changes (gate the modal mount; remove the conditional render gate + default-location fallback), shipped together with Fulton's BE companion (keep-alive coverage extension + Mongo pool warmth) as a single coordinated PROD event under stacked-gates protocol per Quinn's ship-together contract.
+
+---
+
+## Mechanism — full call chain on anonymous-mobile /calendar mount
+
+```
+app/layout.js
+  ├─ <Providers>
+  │    └─ AuthProvider → LocationAPIProvider → GeoLocationProvider → EventDiscoveryProvider
+  │    └─ <UserLocationLoader/>          ← no-op for anonymous (bails at line 28)
+  │    └─ <MapCenterModalWrapper/>       ← passive
+  ├─ <SidebarDrawer/>                    ← Defect 1 entry: mounted unconditionally
+  │    └─ <ServiceStatusModal open={X}/> ← NO {X && ...} guard at line 657
+  │         └─ useServiceHealth()        ← hook called BEFORE any conditional return
+  │              └─ useEffect([]) fans out 4 fetches in parallel on every mount:
+  │                   ├─ checkGoogleGeoAPI    → /api/geo/google-geolocate
+  │                   ├─ checkMongoDB         → /api/health/mongodb
+  │                   ├─ checkAzureFunctions  → /api/health
+  │                   └─ checkCloudflare      → /api/cloudflare/info
+  │    └─ <DebugMenu open={X}/>          ← same anti-pattern, no fetches (verified)
+  └─ children (/calendar)
+       ├─ calendar/layout.js
+       │    └─ useEffect([]) on mount fires:
+       │         ├─ getGeolocationData()           → /api/geo/google-geolocate (2nd Geo trace)
+       │         ├─ fetchAllGeolocationData(1440)  → /api/cloudflare/info + /api/geo/google-geolocate (parallel via Promise.allSettled)
+       │         └─ fetch('/api/visitor/track')    → POST after geo resolves
+       └─ calendar/page.js
+            ├─ SiteHeader → useBackendHealth()    → /api/health (mount + 30s polling, unconditional)
+            └─ Line 1251: {noLocationSelected ? <Loading...> : <FullCalendar/>}
+                                   ↑
+                              DEFECT 2 GATE
+                              FullCalendar (and events fetch) blocked
+                              until useGeoLocation() resolves a location.
+```
+
+**Per-endpoint source attribution** (the 4 incident endpoints, ordered by call count on cold mount):
+
+| Endpoint (App Insights op_Name) | FE source(s) firing on /calendar mount | Notes |
+|---|---|---|
+| `/api/health` (Health_Basic) | 2 sources: `SiteHeader.useBackendHealth` (mount + 30s) **and** `useServiceHealth.checkAzureFunctions` (mount, via SidebarDrawer→ServiceStatusModal) | SiteHeader.useBackendHealth's return value is not destructured anywhere — side-effect-only. Hook can be removed without breaking any consumer. |
+| `/api/geo/google-geolocate` (Geo_GoogleGeolocate) | 3 sources: `useServiceHealth.checkGoogleGeoAPI` + `calendar/layout.js:28 getGeolocationData` + `calendar/layout.js:49 fetchAllGeolocationData(1440)`. Latter two share `GOOGLE_GEO_CACHE_KEY` sessionStorage so on a warm-cache visit some are deduped. Anonymous-no-cache fires all. | Incident's Geo×2 explained by cache state at the user's session. |
+| `/api/cloudflare/info` (Cloudflare_Info) | 2 sources: `useServiceHealth.checkCloudflare` + `trackingHelper.fetchAllGeolocationData` (parallel sibling of Google via `Promise.allSettled` at line 133). `trackingHelper` has 5-min sessionStorage cache (`CF_CACHE_KEY`) so it dedupes within session. | |
+| `/api/health/mongodb` (Health_MongoDB) | 1 source: `useServiceHealth.checkMongoDB` (mount, via SidebarDrawer→ServiceStatusModal) | Only call site in the codebase. |
+
+**Why all 5 hit cold instance:** per Fulton's BE-lane finding, calendar-be-af is on Azure Functions Consumption Y1/Dynamic. The existing keep-alive workflow (`.github/workflows/keep-alive-ping.yml`) pings ONLY `/api/geo/google-geolocate` every 15 min. Health_Basic, Health_MongoDB, and Cloudflare_Info are cold every cycle. Cold-start on Node 20 + first-Mongo-connection = 2-4s typical; stacks to ~4s easily, matching the incident durations.
+
+---
+
+## Defect 1 — fleet-wide health-check leak via unguarded modal mount
+
+### Mount-chain evidence
+
+- `src/app/layout.js:84`
+  ```jsx
+  <SidebarDrawer />  // mounted unconditionally in root layout
+  ```
+- `src/app/components/UI/SidebarDrawer.js:657`
+  ```jsx
+  <ServiceStatusModal open={serviceStatusOpen} onClose={() => setServiceStatusOpen(false)} />
+  // NO {serviceStatusOpen && ...} parent guard
+  ```
+- `src/app/components/DevTools/ServiceStatusModal.js:34` (body line 1)
+  ```jsx
+  const ServiceStatusModal = ({ open, onClose }) => {
+    const services = useServiceHealth();  // ← hook called before any conditional return
+    // ...
+    if (!open) return null;  // ← too late, hook already ran
+  };
+  ```
+- `src/app/hooks/useServiceHealth.js:55-112`
+  ```js
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_DISABLE_SERVICE_HEALTH_CHECKS === 'true') return;
+    checkExpressBackend(); checkFirebase(); checkMapbox();
+    checkMongoDB(); checkGoogleAnalytics();
+    if (!isLocalhost) { checkGoogleGeoAPI(); checkAzureFunctions(); }
+    checkCloudflare();
+  }, []);  // empty deps — fires once per mount
+  ```
+
+### Why this is the canonical "Always-mounted side-effecting conditional component" instance
+
+Parent (`SidebarDrawer`) always renders the modal component. The `open` prop only gates the modal's INTERNAL DOM output — React mounts the child as soon as the parent renders, so the child's hooks and mount-effects fire regardless of `open`. The modal's "I'm closed" state is invisible to its own side-effecting hooks.
+
+`<DebugMenu open={debugMenuOpen}/>` on the adjacent line (656) is the same anti-pattern — verified no fetches today, but in scope for the fix-for-consistency-only.
+
+### Reach
+
+`<SidebarDrawer/>` is in the root layout, so the 4-call burst fires on **every page, every user, every visit**, not just `/calendar`. This is the TT-wide P2 architectural defect Quinn called out in beat 5.
+
+### Cheapest fix (Phase 3 (b))
+
+```jsx
+// src/app/components/UI/SidebarDrawer.js:656-657
+{debugMenuOpen && <DebugMenu open={debugMenuOpen} onClose={() => setDebugMenuOpen(false)} />}
+{serviceStatusOpen && <ServiceStatusModal open={serviceStatusOpen} onClose={() => setServiceStatusOpen(false)} />}
+```
+
+Net effect: modals unmount on close + remount on open. Admin opening a diagnostic dialog gets fresh data on open — correct behavior. Latency cost moves from "every anonymous user every page" → "admin on-demand."
+
+### Belt-and-suspenders
+
+Keep `NEXT_PUBLIC_DISABLE_SERVICE_HEALTH_CHECKS` env-flag as a backup kill-switch even after the modal-gating fix. If Fulton confirms (env-flag ask from beat 5) the flag is unset in PROD today, that informs whether we need to also flip the flag at Phase 3 deploy.
+
+---
+
+## Defect 2 — /calendar LOC conditional render gate
+
+### Evidence
+
+`src/app/calendar/page.js:1251-1265`
+```jsx
+{noLocationSelected ? (
+  <div style={{ /* placeholder styling */ }}>
+    <h2 style={{ marginBottom: '20px', color: '#666' }}>Loading Map Settings...</h2>
+    <p style={{ fontSize: '16px', color: '#777' }}>Opening location selector</p>
+  </div>
+) : (
+  <div onTouchStart={onTouchStart} ...>
+    {/* ...spinner... */}
+    <NoEventsAlert .../>
+    <FullCalendar ... events={eventsWithPlaceholders} />
+  </div>
+)}
+```
+
+`noLocationSelected` is derived from `useEvents` (via `useCalendarPage.js:87`). When no location is selected, `useEvents` short-circuits the events fetch AND `noLocationSelected` is true, so the gate above renders the placeholder instead of `<FullCalendar/>`. **The events module is never even instantiated** until location resolves.
+
+For anonymous users with no saved location and no sessionStorage `currentLocation`, `noLocationSelected` stays `true` until one of:
+- `setSessionLocation()` is called (e.g., browser GPS resolves in `calendar/layout.js:30-40`)
+- User manually selects a location via MapCenterModal
+- `setCurrentLocationState()` fires from another path
+
+The 4s "Loading Map Settings" the user saw = waiting on `getGeolocationData()` to resolve, which is waiting on a cold Google Geo API call. User backgrounded at ~4s before geo resolved.
+
+### Cheapest fix (Phase 3 (a))
+
+Remove the conditional gate; add a default-location fallback chain so `<FullCalendar/>` mounts immediately with sensible coordinates:
+
+```jsx
+// Replace the {noLocationSelected ? <Loading> : <FullCalendar/>} block with:
+<div onTouchStart={onTouchStart} ...>
+  <NoEventsAlert .../>
+  <FullCalendar
+    {...}
+    events={eventsWithPlaceholders}
+    initialDate={getInitialDate()}
+    initialView={getInitialView()}
+  />
+</div>
+```
+
+`useEvents` updates `eventsWithPlaceholders` based on whatever location is set. Default-location chain (already exists in `Providers.MapCenterModalWrapper.getInitialLocation` lines 47-74):
+1. `currentLocation` (user explicit) — null for anonymous-no-cache
+2. `savedLocation` (user backend preference) — null for anonymous
+3. `getCachedGeolocation().google` — null on first visit
+4. Cloudflare country center (`getCountryMapLocation(cachedGeo?.cloudflare?.country)`) — null on first visit
+5. **NEW: Hardcoded sensible regional default** (e.g., "US continental center" + 75mi zoom) → triggers "no events nearby" empty state cleanly, OR alternatively a per-IP-region table baked at build time.
+
+Geo continues to resolve in the background and refines the visible list when it lands.
+
+### Side-effect: surfaces a downstream cold-start risk
+
+Per Fulton's prediction (beat 3): removing the gate exposes `/events` endpoint on the user critical path. Today it's masked because the gate prevents the events fetch from firing until geo resolves. After the fix, FullCalendar mounts immediately and `useEvents` fires its events fetch on a possibly-cold AF instance. **This is why ship-together with Fulton's keep-alive coverage extension is mandatory.**
+
+---
+
+## Recommendations summary (Phase 3 FE scope)
+
+| ID | Component | Change | File | Lines | Risk |
+|---|---|---|---|---|---|
+| (a) | /calendar LOC gate | Remove conditional render; add default-location fallback chain | `src/app/calendar/page.js` | 1251-1265 | LOW — `useEvents` already handles location-less state |
+| (b.1) | ServiceStatusModal mount | Wrap in `{serviceStatusOpen && ...}` parent guard | `src/app/components/UI/SidebarDrawer.js` | 657 | LOW |
+| (b.2) | DebugMenu mount | Same parent-guard for consistency | `src/app/components/UI/SidebarDrawer.js` | 656 | LOW — no current side-effects but prevents future leak |
+| (c) | SiteHeader.useBackendHealth | Remove import + invocation entirely | `src/app/components/UI/SiteHeader.js` | 7, 14 | LOW — return value never destructured anywhere |
+| (d) | env-flag belt-and-suspenders | Confirm `NEXT_PUBLIC_DISABLE_SERVICE_HEALTH_CHECKS=true` set in PROD before deploy | Vercel env | n/a | LOW |
+
+Plus Fulton's BE companion (separate CALBEAF-### scope): keep-alive coverage extension to events + Health_*/CF_Info; Mongo pool warmth check + eager-init if warranted.
+
+---
+
+## Cross-validation from Fulton's trace-stitch (added 2026-05-12T19:02Z)
+
+Fulton ran the 6-trace stitch in App Insights against the incident `operation_Id`s. The two Geo_GoogleGeolocate request rows decisively cross-validate this diagnosis:
+
+| Trace (BOS) | name | resultCode | total ms | funcExec ms | **cold-gap ms** | host instance | client UA |
+|---|---|---|---:|---:|---:|---|---|
+| op `1db1a05a` 12:53:42 | Geo_GoogleGeolocate | 499 | **4294** | **4.21** | **~4290** | 970c9ded | iPhone Safari 26.4, iOS 18.7, Boston |
+| op `4ed41e3b` 12:54:06 retry | Geo_GoogleGeolocate | 499 | **3449** | **59.76** | **~3389** | 3aac9397 | same user |
+
+Both threw `System.Threading.Tasks.TaskCanceledException`. **Function execution was 4-60ms; the 3-4s wait was container boot / scale-out delay on Consumption Y1 before code ran.** Different host instances on the two requests confirms the retry hit a freshly-scaled container, not a warm reuse — keep-alive (15-min cadence on `/geo` only) doesn't ping scale-out instances.
+
+**Update 2026-05-12T19:05Z — same-container empirical lock:** Fulton's raw `customDimensions` extraction shows all 4 first-burst traces (Geo + Health_MongoDB + Health_Basic + Cloudflare_Info) shared the **same `HostInstanceId` (`970c9ded-...`) + same `ProcessId` (3580)**, hitting one cold container serially. This empirically locks the "single user session, app-code burst" interpretation without needing `operation_ParentId` chain analysis. The retry trace (`3aac9397-.../7940`) on a fresh host instance confirms scale-out cold-start as a structurally separate path from baseline-warm cold-start. Per Archie 2026-05-12T19:04Z + Fulton 2026-05-12T19:05Z, keep-alive coverage extension solves baseline-warm but not scale-out — scale-out cold-start residual is a class artifact for a future tier-policy ADR (Toby dropped Premium-tier scope this incident).
+
+| Trace | endpoint | total ms | funcExec ms | HostInstanceId | ProcessId |
+|---|---|---:|---:|---|---:|
+| 16:53:42.853 | Geo_GoogleGeolocate | 4294 | 4.21 | `970c9ded-...` | 3580 |
+| 16:53:42.854 | Health_MongoDB | 4284 | 2.40 | `970c9ded-...` | 3580 |
+| 16:53:42.854 | Health_Basic | 4267 | 22.68 | `970c9ded-...` | 3580 |
+| 16:53:42.854 | Cloudflare_Info | 4287 | 2.14 | `970c9ded-...` | 3580 |
+| 16:54:06.429 | Geo (retry) | 3449 | 59.76 | `3aac9397-...` | 7940 |
+
+The 4 first-burst rows timestamped within 1ms of each other on the same `HostInstanceId`/`ProcessId` is the canonical empirical fingerprint of a single `useEffect` parallel fan-out (4 fetches kicked off synchronously by `useServiceHealth.js:55-112`).
+
+This is the canonical "BE was healthy, container wasn't" finding. The Boston user waited on container boot, not function code. Combined with FE diagnosis:
+
+- **Defect 2 surfaces the cold-start to the user** because the conditional render gate makes the geo call (which is on the cold-call critical path) block events render.
+- **Defect 1 amplifies cold-start load** by firing 4 endpoint checks unconditionally per page — each potentially hitting cold container instances post-scale-out.
+- **The user-perceived 4s wait = container boot time, full stop.** Not network, not function logic, not Mongo, not Google API. Container scale-out.
+
+This is why Fulton's BE companion (keep-alive coverage extension to events + Health_*/CF_Info + Mongo pool warmth) is the load-bearing co-fix. Without it, removing the gate just shifts the user's cold-start exposure from "Geo" to "Events."
+
+## Open items / data points still pending
+
+1. ~~**Fulton's 6-trace stitch**~~ — **DELIVERED 2026-05-12T19:02Z.** See cross-validation section above. Container boot dominance confirmed.
+2. ~~**Fulton's PROD env-flag check**~~ — **DELIVERED.** `NEXT_PUBLIC_DISABLE_SERVICE_HEALTH_CHECKS` is NOT SET in `tangotiempo-com` PROD env. Belt-and-suspenders Phase 3 work item: set the flag at deploy AS WELL AS landing the modal-gating fix.
+3. **Fulton's Phase 2b latency pull** — Mongo pool warmth + per-endpoint P50/P95/P99 for incident endpoints + Mongo-touching endpoints (Events / Categories / Venues / Organizers). EOD 2026-05-13.
+4. **AI instance mismatch finding (Fulton beat 10):** the `CalendarBEAF` App Insights resource visible in the RG is NOT the AI the Function App actually emits to (connection-string points to a different AI: appId `a9793e58-09db-...`). The RG-named resource is orphaned or used elsewhere. Worth Dash investigation as separate cleanup; out of Phase 3 scope.
+5. **calendar/layout.js double-call rationale** — `fetchAllGeolocationData` is called from line 49 (1440min, mount) and line 98 (60min, on LOCATION_CHANGED event only). Verified: only ONE fires on anonymous-cold-mount. The 60min one is event-gated. Documenting for completeness; no scope change.
+
+---
+
+## FTPNTD layering
+
+- **Data fix:** none. No bad data; this is a code-process and team-human gap.
+- **Code-process fix:** the 4 changes above. Single TIEMPO-### + CALBEAF-### paired PR.
+- **Team-human fix:**
+  - "Always-mounted side-effecting conditional component" (Archie) added to FE review checklist as named anti-pattern. Future PRs that render `<X open={...}/>` where X has mount-side-effects must use parent-conditional guard.
+  - "Predict second-order effects of structural fixes" (Quinn's beat 3, expanded Phase 3 §FTPNTD codification) — Fulton's "fix shifts symptom" prediction is the canonical instance.
+  - "Anonymous + mobile + Slow-4G as pre-deploy smoke condition for TT" — likely Gauge plate per charter; flagged for post-Phase-3 scoping.
+
+---
+
+## Cross-app implications (informational, post-Phase-3)
+
+Both defects are likely class instances, not TT-unique. Gotan and Archie have parallel cross-app investigations Toby-scoping-gated:
+- **Defect 1 class:** "Always-mounted side-effecting conditional component" likely present in HJ (Cord), NTTT (Compás), CalOps (Dash), TBaP/VH (Charlotte). Archie's "FE modal/drawer/panel mount-discipline standard" ADR candidate, post-Phase-3.
+- **Defect 1 specifics (health-check leak):** Cord's HJ and Compás's NTTT share TT's FE ancestry — likely same SiteHeader + SidebarDrawer + ServiceStatusModal pattern. Gotan's half-day audit candidate, post-Phase-3.
+
+---
+
+## Sign-off
+
+FE diagnosis locked per Quinn beat 7 (2026-05-12T19:00Z). EOD-tomorrow report deliverable: this document. Ship-together contract acknowledged: TIEMPO-### + CALBEAF-### paired PRs, single coordinated PROD event 2026-05-14 AM under stacked-gates protocol.
+
+Next FE action: standing by for Fulton's trace-stitch + Phase 2b output; Phase 3 convergence call 2026-05-14 AM with Quinn arbitrating.
+
+— Sarah 2026-05-12

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
- "version": "1.26.0",
+ "version": "1.27.0",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/calendar/layout.js
+++ b/src/app/calendar/layout.js
@@ -1,42 +1,86 @@
 //@/calendar/layout.js
 'use client'; // Enable client-side rendering
 
-import React, { useContext, useEffect } from 'react';
-import PropTypes from 'prop-types'; // Import prop-types
+import React, { useContext, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Snackbar, Alert, Button } from '@mui/material';
 import { AuthContext } from '@/contexts/AuthContext';
 import { useGeoLocation } from '@/contexts/GeoLocationContext';
 import { fetchAllGeolocationData } from '@/utils/trackingHelper';
 import { getGeolocationData } from '@/utils/geolocationHelper'; // TIEMPO-324: 3-tier geolocation
 import { locationEventBus, LOCATION_EVENTS } from '@/utils/LocationEventBus';
-import { getOrCreateVisitorId } from '@/utils/visitorTracking'; // TIEMPO-329: Visitor ID tracking
+import { getOrCreateVisitorId, getLastMapCenter } from '@/utils/visitorTracking';
+import { getCountryCenter, getCountryMapLocation } from '@/utils/countryCenter';
+
+// TIEMPO-457: Country-size split for Level-4 fallback nudge. Big countries get a
+// "Select your city" CTA in the Snackbar because the country center is far from
+// most users; small countries omit the CTA because the center is effectively the
+// main metro.
+const BIG_COUNTRIES = new Set(['US', 'CA', 'AR', 'BR', 'AU', 'DE', 'ES', 'FR', 'IT', 'GB']);
 
 const RootLayout = ({ children }) => {
   const { user } = useContext(AuthContext);
-  const { currentLocation, setSessionLocation } = useGeoLocation();
+  const { currentLocation, setSessionLocation, openMapCenterModal } = useGeoLocation();
 
-  // TIEMPO-313: Visitor tracking on calendar page load (fire and forget)
-  // TIEMPO-329: Now includes visitor_id cookie for persistent identity
+  // TIEMPO-457: Level-4 soft popup state. Null when not needed.
+  const [countryHint, setCountryHint] = useState(null);
+
+  // TIEMPO-313 / TIEMPO-329 / TIEMPO-457: Calendar bootstrap.
+  // Runs once on /calendar mount. Two responsibilities:
+  //   (1) Resolve the user's location for the calendar view if not already set.
+  //       Priority cascade Level 2 → 3 → 4 (Level 1 logged-in saved is upstream).
+  //   (2) Fire visitor-tracking POST.
   useEffect(() => {
-    const trackVisitor = async () => {
+    const init = async () => {
       try {
         const afUrl = process.env.NEXT_PUBLIC_AF_URL || 'http://localhost:7071';
-
-        // TIEMPO-329: Get or create persistent visitor_id (UUID cookie)
         const visitorId = getOrCreateVisitorId();
 
-        // TIEMPO-324: Get 3-tier geolocation data (browser GPS -> Google API -> ipinfo fallback)
+        // Skip the cascade if any prior layer already set a location.
+        const hasCurrentLocation = currentLocation?.lat && currentLocation?.lng;
+        let resolved = !!hasCurrentLocation;
+
+        // Level 2 — anonymous previously-set location restored from localStorage (silent).
+        if (!resolved) {
+          const lastCenter = getLastMapCenter();
+          if (lastCenter?.lat && lastCenter?.lng) {
+            await setSessionLocation({
+              lat: lastCenter.lat,
+              lng: lastCenter.lng,
+              zoomRange: lastCenter.zoomRange || 50,
+              source: 'anon-cookie',
+            });
+            try { sessionStorage.setItem('locationCascadeSource', 'anon-cookie'); } catch { /* sessionStorage unavailable */ }
+            resolved = true;
+          }
+        }
+
+        // TIEMPO-324: 3-tier geolocation data (browser GPS → Google API → ipinfo
+        // fallback). Always called — needed for the visitor-tracking POST below,
+        // and for Level-3 resolution.
         const browserGeoData = await getGeolocationData();
 
-        // TIEMPO-329 Phase 1.1: Auto-center map from GPS if no location selected
-        if ((!currentLocation?.lat && !currentLocation?.lng) &&
-            browserGeoData?.google_browser_lat &&
-            browserGeoData?.google_browser_long) {
-
-          setSessionLocation({
-            lat: browserGeoData.google_browser_lat,
-            lng: browserGeoData.google_browser_long,
-            zoomRange: 75  // 75-mile radius as requested
-          });
+        // Level 3 — browser GPS (Tier 1) or Google API (Tier 2). Silent.
+        if (!resolved) {
+          if (browserGeoData?.google_browser_lat && browserGeoData?.google_browser_long) {
+            await setSessionLocation({
+              lat: browserGeoData.google_browser_lat,
+              lng: browserGeoData.google_browser_long,
+              zoomRange: 75, // 75-mile radius
+              source: 'browser-gps',
+            });
+            try { sessionStorage.setItem('locationCascadeSource', 'browser-gps'); } catch { /* sessionStorage unavailable */ }
+            resolved = true;
+          } else if (browserGeoData?.google_api_lat && browserGeoData?.google_api_long) {
+            await setSessionLocation({
+              lat: browserGeoData.google_api_lat,
+              lng: browserGeoData.google_api_long,
+              zoomRange: 75,
+              source: 'google-api',
+            });
+            try { sessionStorage.setItem('locationCascadeSource', 'google-api'); } catch { /* sessionStorage unavailable */ }
+            resolved = true;
+          }
         }
 
         // Skip AF tracking calls on localhost
@@ -44,9 +88,40 @@ const RootLayout = ({ children }) => {
           return;
         }
 
-        // Fetch all geolocation data (Cloudflare, Google, IP API) with distance calculation
-        // PHASE 1.2: Use 24-hour cache for visitor tracking
-        const geoData = await fetchAllGeolocationData(1440); // 1440 minutes = 24 hours
+        // Fetch all geolocation data (Cloudflare, Google, IP API) with distance
+        // calculation. PHASE 1.2: 24-hour cache for visitor tracking.
+        const geoData = await fetchAllGeolocationData(1440);
+
+        // Level 4 — Cloudflare country fallback (soft popup).
+        // fetchAllGeolocationData populates the CF cache, so we read its result
+        // directly rather than re-reading via getCachedGeolocation.
+        if (!resolved && geoData?.cloudflare?.country) {
+          const country = String(geoData.cloudflare.country).toUpperCase();
+          const center = getCountryCenter(country);
+          const mapLoc = getCountryMapLocation(country);
+          if (center && mapLoc) {
+            await setSessionLocation({
+              lat: mapLoc.lat,
+              lng: mapLoc.lng,
+              zoomRange: mapLoc.zoomRange || 200,
+              source: 'cloudflare-country',
+            });
+            try { sessionStorage.setItem('locationCascadeSource', 'cloudflare-country'); } catch { /* sessionStorage unavailable */ }
+            setCountryHint({
+              countryCode: country,
+              countryName: center.name,
+              isBig: BIG_COUNTRIES.has(country),
+            });
+            resolved = true;
+          }
+        }
+
+        // Level 5 — no action. Toby confirmed browser provides something 99%+ of
+        // the time; if everything fails, the existing default map center applies
+        // and the header location selector remains available on-demand.
+        if (!resolved) {
+          try { sessionStorage.setItem('locationCascadeSource', 'default-fallback'); } catch { /* sessionStorage unavailable */ }
+        }
 
         await fetch(`${afUrl}/api/visitor/track`, {
           method: 'POST',
@@ -79,7 +154,7 @@ const RootLayout = ({ children }) => {
       }
     };
 
-    trackVisitor();
+    init();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Empty dependency array - only fire once on mount
 
@@ -112,6 +187,14 @@ const RootLayout = ({ children }) => {
           headers['Authorization'] = `Bearer ${user.token}`;
         }
 
+        // TIEMPO-457: cascadeSource = which level of the priority chain provided
+        // this location. Falls back to sessionStorage when the emit didn't carry
+        // it (e.g., LOCATION_CHANGED fired from a non-cascade caller).
+        let cascadeSource = location.source || null;
+        if (!cascadeSource && typeof sessionStorage !== 'undefined') {
+          cascadeSource = sessionStorage.getItem('locationCascadeSource') || null;
+        }
+
         await fetch(`${afUrl}/api/user/mapcenter-track`, {
           method: 'POST',
           headers,
@@ -128,7 +211,9 @@ const RootLayout = ({ children }) => {
             google_browser_long: browserGeoData.google_browser_long,
             google_browser_accuracy: browserGeoData.google_browser_accuracy,
             google_api_lat: browserGeoData.google_api_lat,
-            google_api_long: browserGeoData.google_api_long
+            google_api_long: browserGeoData.google_api_long,
+            // TIEMPO-457: telemetry — which cascade level resolved this location
+            cascadeSource
           })
         });
       } catch (error) {
@@ -148,7 +233,45 @@ const RootLayout = ({ children }) => {
     return () => { unsubscribe(); };
   }, [user]);
 
-  return <>{children}</>;
+  return (
+    <>
+      {children}
+      {/* TIEMPO-457 Level-4 soft popup: CF country fallback notice */}
+      <Snackbar
+        open={!!countryHint}
+        autoHideDuration={countryHint?.isBig ? null : 8000}
+        onClose={(_event, reason) => {
+          if (reason === 'clickaway') return;
+          setCountryHint(null);
+        }}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          severity="info"
+          onClose={() => setCountryHint(null)}
+          action={
+            countryHint?.isBig ? (
+              <Button
+                color="inherit"
+                size="small"
+                onClick={() => {
+                  openMapCenterModal();
+                  setCountryHint(null);
+                }}
+              >
+                Select your city
+              </Button>
+            ) : null
+          }
+          sx={{ width: '100%' }}
+        >
+          {countryHint
+            ? `No good location found — centering on ${countryHint.countryName}`
+            : ''}
+        </Alert>
+      </Snackbar>
+    </>
+  );
 };
 
 // Define prop types for validation

--- a/src/app/calendar/page.js
+++ b/src/app/calendar/page.js
@@ -1248,24 +1248,9 @@ const CalendarPage = () => {
         </div>
       </div>
 
-      {noLocationSelected ? (
-        <div style={{
-          textAlign: 'center',
-          padding: '60px 20px',
-          backgroundColor: '#f5f5f5',
-          borderRadius: '8px',
-          margin: '20px',
-        }}>
-          <h2 style={{ marginBottom: '20px', color: '#666' }}>
-            Loading Map Settings...
-          </h2>
-          <p style={{ fontSize: '16px', color: '#777' }}>
-            Opening location selector
-          </p>
-        </div>
-      ) : (
-        <div
-          onTouchStart={onTouchStart}
+      {/* TIEMPO-457: removed noLocationSelected conditional render gate (audit Defect 2). FullCalendar mounts immediately; useEvents short-circuits its fetch when no location is set; default-location fallback chain is supplied by Providers.getInitialLocation. */}
+      <div
+        onTouchStart={onTouchStart}
           onTouchMove={onTouchMove}
           onTouchEnd={onTouchEnd}
           style={{
@@ -1568,9 +1553,8 @@ const CalendarPage = () => {
           // Future days: default styling (no background color override)
         }}
       />
-        </div>
-      )}
-      
+      </div>
+
       {/* SubMenu */}
       <CalendarSubMenu
         menuAnchor={menuAnchor}

--- a/src/app/components/UI/SidebarDrawer.js
+++ b/src/app/components/UI/SidebarDrawer.js
@@ -653,8 +653,9 @@ const SidebarDrawer = ({ open, onClose }) => {
           setSelectedOrganizers(selected);
         }}
       />
-      <DebugMenu open={debugMenuOpen} onClose={() => setDebugMenuOpen(false)} /> {/* DEBUG MENU */}
-      <ServiceStatusModal open={serviceStatusOpen} onClose={() => setServiceStatusOpen(false)} />
+      {/* TIEMPO-457: parent-conditional guard prevents always-mounted side-effecting modals from firing health-check hooks on every page load (audit Defect 1) */}
+      {debugMenuOpen && <DebugMenu open={debugMenuOpen} onClose={() => setDebugMenuOpen(false)} />}
+      {serviceStatusOpen && <ServiceStatusModal open={serviceStatusOpen} onClose={() => setServiceStatusOpen(false)} />}
     </>
   );
 };

--- a/src/app/components/UI/SiteHeader.js
+++ b/src/app/components/UI/SiteHeader.js
@@ -4,14 +4,12 @@ import React, { useContext, useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
 import { RoleContext } from '@/contexts/RoleContext';
 import { useGeoLocation } from '@/contexts/GeoLocationContext';
-import { useBackendHealth } from '@/hooks/useBackendHealth';
 import packageJson from '../../../../package.json';
 
 const SiteHeader = () => {
   const { selectedRole } = useContext(RoleContext);
   // TIEMPO-388: Read cityName from context instead of local state
   const { currentLocation, openMapCenterModal } = useGeoLocation();
-  useBackendHealth();
   const appVersion = `v${packageJson.version}`; // Dynamically read from package.json
 
   // Pulse animation state - triggers on mount and location changes


### PR DESCRIPTION
## Summary

Fixes anonymous-mobile /calendar perceived failure: user saw "Loading Map Settings… / Opening location selector" for 4s then gave up. Two compounding FE defects per Phase 2a audit, plus an active priority-chain location resolver so first-paint always lands on something useful.

**Ships paired with Fulton's CALBEAF-187 BE companion** (keep-alive coverage extension + Mongo pool warmth) under Quinn's ship-together contract.

**Toby pre-fix baseline:** test.tangotiempo.com /calendar anonymous → "Loading Map Settings / Opening location selector" + zero events.
**Post-fix:** /calendar anonymous → calendar shell mounts immediately; location resolved via cascade L2→L3→L4 silently; L4 fallback shows non-blocking Snackbar with optional "Select your city" CTA on big countries.

## What changed

### Component (a) — conditional gate removed
`src/app/calendar/page.js:1251` — removed `{noLocationSelected ? <Loading> : <FullCalendar>}` ternary. FullCalendar mounts immediately; `useEvents` short-circuits its fetch when location is null. Audit Defect 2.

### Component (a+) — 5-level geo-resolution cascade
`src/app/calendar/layout.js` bootstrap rewritten per Quinn 19:10Z + 19:12Z spec:

| Level | Path | UX |
|---|---|---|
| 1 | logged-in saved (upstream — AuthContext) | silent |
| 2 | localStorage \`last_map_center\` restore | silent |
| 3a | browser GPS (Tier 1) | silent |
| 3b | Google API (Tier 2 — IP-based) | silent |
| 4 | Cloudflare country center + MUI Snackbar | soft popup |
| 5 | existing default map center | no forced action |

Big-country list (US/CA/AR/BR/AU/DE/ES/FR/IT/GB) get "Select your city" Snackbar action. Small countries get dismiss-only.

### Component (b) — modal-mount guards
\`src/app/components/UI/SidebarDrawer.js:656-657\` — wrapped \`<DebugMenu>\` + \`<ServiceStatusModal>\` in parent \`{open && ...}\` guards. Audit Defect 1 (fleet-wide health-check leak). Closed modals now unmount; their hooks no longer fire on every page load.

### Component (c) — useBackendHealth removed
\`src/app/components/UI/SiteHeader.js:7,14\` — removed import + invocation. Return value never destructured; the hook fired \`/api/health\` on mount + 30s poll purely as side-effect.

### Telemetry (per Quinn 19:13Z)
Each cascade level stamps \`source\` on \`setSessionLocation\` + mirrors to sessionStorage. \`/api/user/mapcenter-track\` POST body extended with new \`cascadeSource\` field:
- \`anon-cookie\` / \`browser-gps\` / \`google-api\` / \`cloudflare-country\` / \`default-fallback\`

Fulton can index this in MapCenterHistory for distribution analysis after ~1 week of PROD traffic.

## Out of scope

- **(d) Vercel env flag** \`NEXT_PUBLIC_DISABLE_SERVICE_HEALTH_CHECKS=true\` — UI task, set on Vercel project before deploy as belt-and-suspenders alongside (b).
- **Pre-existing lint** in \`page.js:17\` (MapIcon) + \`SidebarDrawer.js:33\` (FormatIndentIncreaseIcon) — both pre-existed at sandbox cut.

## Version

1.26.0 → 1.27.0 (minor; absorbs missed v1.26.1 patch from PR #364 per Quinn beat-77 corrective).

## Test plan

- [ ] TT TEST auto-deploys post-merge; Sarah confirms deploy URL + v1.27.0 in /api/version
- [ ] Toby/Quinn verify test.tangotiempo.com /calendar anonymous mobile:
  - [ ] No "Loading Map Settings…" placeholder
  - [ ] Calendar shell mounts immediately
  - [ ] Location resolved silently when GPS allowed
  - [ ] Snackbar appears + dismisses correctly when GPS denied + CF country available
  - [ ] Snackbar "Select your city" opens MapCenterModal (big country only)
- [ ] CalOps Activity Map shows \`cascadeSource\` distribution accumulating in MapCenterHistory (Dash to verify within ~24h post-merge)
- [ ] No new console errors on /calendar mount
- [ ] No regression on /boston, /tango/[parent], /tango/[parent]/[city]

## Files

\`\`\`
 docs/TIEMPO-phase2a-calendar-anonymous-mobile-bootstrap-audit.md | +270 (new)
 package.json                                                     | +1 -1
 src/app/calendar/layout.js                                       | +175 -16
 src/app/calendar/page.js                                         | +3 -23
 src/app/components/UI/SidebarDrawer.js                           | +3 -2
 src/app/components/UI/SiteHeader.js                              | -2
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)