### PR TITLE
fix(calendar): disable cascade L3b Google API tier (TIEMPO-457 v1.27.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
- "version": "1.27.0",
+ "version": "1.27.1",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/calendar/layout.js
+++ b/src/app/calendar/layout.js
@@ -60,7 +60,22 @@ const RootLayout = ({ children }) => {
         // and for Level-3 resolution.
         const browserGeoData = await getGeolocationData();
 
-        // Level 3 — browser GPS (Tier 1) or Google API (Tier 2). Silent.
+        // Level 3 — browser GPS (Tier 1). Silent.
+        //
+        // TIEMPO-457 v1.27.1: Tier 2 (Google API / `google_api_*`) is DISABLED
+        // pending Fulton's BE fix. The `/api/geo/google-geolocate` BE proxy
+        // calls Google from the server side, so Google sees Azure's egress IP
+        // and returns Northern Virginia (38.9847, -77.5619) for every user
+        // regardless of who they are — confirmed via Fulton's log pull
+        // (two different user IPs, identical google_api coordinates). The
+        // unblock condition is Fulton passing `CF-Connecting-IP` to Google's
+        // API call with `considerIp: false`. Re-enable the `else if` branch
+        // once BE returns user-specific google_api coords.
+        //
+        // Flat-field forwarding of `google_api_lat`/`google_api_long` in the
+        // tracking POST is preserved — the BE source-attribution chain still
+        // consumes those fields per Invariant 8, and incorrect coords land
+        // in the analytics history rather than the user-facing cascade.
         if (!resolved) {
           if (browserGeoData?.google_browser_lat && browserGeoData?.google_browser_long) {
             await setSessionLocation({
@@ -70,15 +85,6 @@ const RootLayout = ({ children }) => {
               source: 'browser-gps',
             });
             try { sessionStorage.setItem('locationCascadeSource', 'browser-gps'); } catch { /* sessionStorage unavailable */ }
-            resolved = true;
-          } else if (browserGeoData?.google_api_lat && browserGeoData?.google_api_long) {
-            await setSessionLocation({
-              lat: browserGeoData.google_api_lat,
-              lng: browserGeoData.google_api_long,
-              zoomRange: 75,
-              source: 'google-api',
-            });
-            try { sessionStorage.setItem('locationCascadeSource', 'google-api'); } catch { /* sessionStorage unavailable */ }
             resolved = true;
           }
         }


### PR DESCRIPTION
## Summary

Bug 1 of two surfaced by Quinn's 19:46Z log analysis on TT TEST. Defensive patch on top of v1.27.0.

**Root cause:** Fulton's log pull found `/api/geo/google-geolocate` BE proxy returns Azure's egress IP location (38.9847, -77.5619 — Northern Virginia) for every user. Two different user IPs, identical google_api coords. Google sees Azure, not the user, because the BE calls Google server-side without forwarding the user's real IP.

**Impact:** v1.27.0 cascade Level 3b would silently center every GPS-denied user on Northern Virginia. Better to fall through to Level 4 (Cloudflare country + Snackbar) which returns the user's real country.

## Change

`src/app/calendar/layout.js` — removed the `else if browserGeoData?.google_api_lat && browserGeoData?.google_api_long` branch from the priority cascade. Anonymous flow becomes:

`L1 logged-in saved → L2 localStorage → L3a browser GPS → (skip 3b) → L4 CF country + Snackbar → L5 default`

Telemetry tag `google-api` remains defined for re-enable. Flat-field forwarding `google_api_lat`/`google_api_long` in the tracking POST is **preserved** — the BE source-attribution chain (Invariant 8) still consumes those fields for analytics-side stamping, which is separate from the user-facing cascade trust question.

## Re-enable condition

Fulton's BE fix to `/api/geo/google-geolocate`:
- Pass `CF-Connecting-IP` header as authoritative user IP to Google API
- Set `considerIp: false` on Google Geolocation request
- Verify via curl POST with different `CF-Connecting-IP` headers → different coords returned

Once confirmed working in TT TEST traffic, the `else if` block is a single-block restore (~5 lines).

## Out of scope

- **Bug 2 (cascadeSource silently dropped by BE writer):** Fulton's lane (CALBEAF-1XX), parallel work
- **Audit doc update:** the Phase 2a audit doc predates this discovery; will fold L3b status into Sprint-6+ audit-doc cycle, not this patch

## Version

1.27.0 → 1.27.1 (patch).

## Test plan

- [ ] TT TEST auto-deploys post-merge; Sarah confirms `/api/version` shows 1.27.1
- [ ] Toby/Quinn verify test.tangotiempo.com /calendar anonymous mobile with GPS denied:
  - [ ] No "Loading Map Settings…" placeholder
  - [ ] No longer centers on Northern Virginia
  - [ ] Snackbar appears with CF-country center + "Select your city" CTA on big-country IPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)