### PR TITLE
fix(calendar): L4 typeahead-prompt + skipPersist (TIEMPO-457 v1.27.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
- "version": "1.27.1",
+ "version": "1.27.2",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/calendar/layout.js
+++ b/src/app/calendar/layout.js
@@ -1,29 +1,24 @@
 //@/calendar/layout.js
 'use client'; // Enable client-side rendering
 
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Snackbar, Alert, Button } from '@mui/material';
 import { AuthContext } from '@/contexts/AuthContext';
 import { useGeoLocation } from '@/contexts/GeoLocationContext';
 import { fetchAllGeolocationData } from '@/utils/trackingHelper';
 import { getGeolocationData } from '@/utils/geolocationHelper'; // TIEMPO-324: 3-tier geolocation
 import { locationEventBus, LOCATION_EVENTS } from '@/utils/LocationEventBus';
 import { getOrCreateVisitorId, getLastMapCenter } from '@/utils/visitorTracking';
-import { getCountryCenter, getCountryMapLocation } from '@/utils/countryCenter';
-
-// TIEMPO-457: Country-size split for Level-4 fallback nudge. Big countries get a
-// "Select your city" CTA in the Snackbar because the country center is far from
-// most users; small countries omit the CTA because the center is effectively the
-// main metro.
-const BIG_COUNTRIES = new Set(['US', 'CA', 'AR', 'BR', 'AU', 'DE', 'ES', 'FR', 'IT', 'GB']);
+import { getCountryMapLocation } from '@/utils/countryCenter';
 
 const RootLayout = ({ children }) => {
   const { user } = useContext(AuthContext);
-  const { currentLocation, setSessionLocation, openMapCenterModal } = useGeoLocation();
-
-  // TIEMPO-457: Level-4 soft popup state. Null when not needed.
-  const [countryHint, setCountryHint] = useState(null);
+  const {
+    currentLocation,
+    setSessionLocation,
+    openMapCenterModal,
+    setMapCenterModalPrompt,
+  } = useGeoLocation();
 
   // TIEMPO-313 / TIEMPO-329 / TIEMPO-457: Calendar bootstrap.
   // Runs once on /calendar mount. Two responsibilities:
@@ -98,26 +93,28 @@ const RootLayout = ({ children }) => {
         // calculation. PHASE 1.2: 24-hour cache for visitor tracking.
         const geoData = await fetchAllGeolocationData(1440);
 
-        // Level 4 — Cloudflare country fallback (soft popup).
-        // fetchAllGeolocationData populates the CF cache, so we read its result
-        // directly rather than re-reading via getCachedGeolocation.
+        // Level 4 — Cloudflare country fallback. v1.27.2: replaces the prior
+        // Snackbar UX with an auto-opened MapCenterModal carrying a custom
+        // header copy + autoFocused typeahead. Per Quinn's storage-rule
+        // arbitration, this session-only context MUST NOT overwrite a prior
+        // user-explicit pick — so the setSessionLocation call passes
+        // skipPersist:true. A subsequent user typeahead pick inside the modal
+        // goes through setSessionLocation without skipPersist and IS persisted
+        // (Level 2 reuse on next visit).
         if (!resolved && geoData?.cloudflare?.country) {
           const country = String(geoData.cloudflare.country).toUpperCase();
-          const center = getCountryCenter(country);
           const mapLoc = getCountryMapLocation(country);
-          if (center && mapLoc) {
+          if (mapLoc) {
             await setSessionLocation({
               lat: mapLoc.lat,
               lng: mapLoc.lng,
               zoomRange: mapLoc.zoomRange || 200,
               source: 'cloudflare-country',
+              skipPersist: true,
             });
             try { sessionStorage.setItem('locationCascadeSource', 'cloudflare-country'); } catch { /* sessionStorage unavailable */ }
-            setCountryHint({
-              countryCode: country,
-              countryName: center.name,
-              isBig: BIG_COUNTRIES.has(country),
-            });
+            setMapCenterModalPrompt('What major city would you like to see?');
+            openMapCenterModal();
             resolved = true;
           }
         }
@@ -239,45 +236,7 @@ const RootLayout = ({ children }) => {
     return () => { unsubscribe(); };
   }, [user]);
 
-  return (
-    <>
-      {children}
-      {/* TIEMPO-457 Level-4 soft popup: CF country fallback notice */}
-      <Snackbar
-        open={!!countryHint}
-        autoHideDuration={countryHint?.isBig ? null : 8000}
-        onClose={(_event, reason) => {
-          if (reason === 'clickaway') return;
-          setCountryHint(null);
-        }}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      >
-        <Alert
-          severity="info"
-          onClose={() => setCountryHint(null)}
-          action={
-            countryHint?.isBig ? (
-              <Button
-                color="inherit"
-                size="small"
-                onClick={() => {
-                  openMapCenterModal();
-                  setCountryHint(null);
-                }}
-              >
-                Select your city
-              </Button>
-            ) : null
-          }
-          sx={{ width: '100%' }}
-        >
-          {countryHint
-            ? `No good location found — centering on ${countryHint.countryName}`
-            : ''}
-        </Alert>
-      </Snackbar>
-    </>
-  );
+  return <>{children}</>;
 };
 
 // Define prop types for validation
@@ -286,3 +245,6 @@ RootLayout.propTypes = {
 };
 
 export default RootLayout;
+/* v1.27.2 typeahead-prompt: prior Snackbar UX removed in favor of
+   auto-opened MapCenterModal with header override "What major city would
+   you like to see?" + autoFocused typeahead (per Quinn 19:49Z arbitration). */

--- a/src/app/components/Modals/misc/MapCenterModal.js
+++ b/src/app/components/Modals/misc/MapCenterModal.js
@@ -276,7 +276,9 @@ const MapCenterModal = ({
   onSetLocation,
   onSaveLocation,
   initialLocation = null, // No hardcoded default - use smart fallback from Providers
-
+  // TIEMPO-457 v1.27.2: prompt-driven open path (L4 cascade fallback).
+  headerOverride = null,
+  autoFocusCitySearch = false,
 }) => {
   const { user } = useContext(AuthContext);
   const theme = useTheme();
@@ -843,7 +845,7 @@ const MapCenterModal = ({
       }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <LocationOnIcon color="primary" />
-          <Typography variant="h6">Map Center Settings</Typography>
+          <Typography variant="h6">{headerOverride || 'Map Center Settings'}</Typography>
         </Box>
         <IconButton onClick={onClose} size="small" data-testid="map-center-close">
           <CloseIcon />
@@ -1005,6 +1007,7 @@ const MapCenterModal = ({
               placeholder="Search city (e.g., Los Angeles)"
               variant="outlined"
               size="small"
+              autoFocus={autoFocusCitySearch}
               sx={{ mb: 1 }}
               inputProps={{
                 ...params.inputProps,
@@ -1177,4 +1180,6 @@ MapCenterModal.propTypes = {
     }),
     PropTypes.oneOf([null])
   ]),
+  headerOverride: PropTypes.string,
+  autoFocusCitySearch: PropTypes.bool,
 };

--- a/src/app/components/Providers.js
+++ b/src/app/components/Providers.js
@@ -31,6 +31,7 @@ const MapCenterModal = dynamic(
 const MapCenterModalWrapper = () => {
   const {
     mapCenterModalOpen,
+    mapCenterModalPrompt,
     closeMapCenterModal,
     setSessionLocation,
     saveToCloudDefault,
@@ -81,6 +82,8 @@ const MapCenterModalWrapper = () => {
       onSaveLocation={saveToCloudDefault}
       initialLocation={getInitialLocation()}
       savedLocation={savedLocation}
+      headerOverride={mapCenterModalPrompt}
+      autoFocusCitySearch={!!mapCenterModalPrompt}
     />
   );
 };

--- a/src/app/contexts/GeoLocationContext.js
+++ b/src/app/contexts/GeoLocationContext.js
@@ -108,6 +108,10 @@ export const GeoLocationProvider = ({ children }) => {
 
   // State for MapCenterModal
   const [mapCenterModalOpen, setMapCenterModalOpen] = useState(false);
+  // TIEMPO-457 v1.27.2: optional header copy + autofocus signal driven by the
+  // L4 cascade ("What major city would you like to see?"). Null when the modal
+  // is opened via the normal UI path.
+  const [mapCenterModalPrompt, setMapCenterModalPrompt] = useState(null);
 
   // TIEMPO-381: State for onboarding modal (new users without mapCenter)
   const [needsOnboarding, setNeedsOnboarding] = useState(false);
@@ -435,10 +439,17 @@ export const GeoLocationProvider = ({ children }) => {
   const closeMapCenterModal = useCallback(() => {
     // TIEMPO-276: Security cleanup - removed modal logging
     setMapCenterModalOpen(false);
+    // TIEMPO-457 v1.27.2: clear cascade-prompt so a subsequent normal-flow open
+    // (e.g., user-tap from header) shows the default "Map Center Settings" header.
+    setMapCenterModalPrompt(null);
   }, []);
 
   // Set location for current session (used by MapCenterModal)
   // TIEMPO-388: Now fetches city name synchronously instead of relying on reactive useEffect
+  // TIEMPO-457 v1.27.2: Accepts `skipPersist: true` to avoid downgrading the
+  // saved `last_map_center` localStorage entry with a low-confidence cascade
+  // result (L4 CF country / L5 default). Only user-explicit picks (typeahead,
+  // map-click, saved-pref restore) should overwrite the stored location.
   const setSessionLocation = useCallback(async (locationData) => {
     const location = {
       lat: locationData.centerLocation?.lat || locationData.lat,
@@ -450,12 +461,17 @@ export const GeoLocationProvider = ({ children }) => {
     if (locationData.source) location.source = locationData.source;
     if (locationData.locked !== undefined) location.locked = locationData.locked;
 
-    // TIEMPO-388: Also save to localStorage for WelcomeModal check on next visit
-    saveLastMapCenter({
-      lat: location.lat,
-      lng: location.lng,
-      zoomRange: location.zoomRange
-    });
+    // TIEMPO-457 v1.27.2: skipPersist=true bypasses localStorage write so a
+    // session-only context (e.g. CF-country fallback) never overwrites a
+    // user-explicit prior pick.
+    if (!locationData.skipPersist) {
+      // TIEMPO-388: Also save to localStorage for WelcomeModal check on next visit
+      saveLastMapCenter({
+        lat: location.lat,
+        lng: location.lng,
+        zoomRange: location.zoomRange
+      });
+    }
 
     // Emit event to trigger refresh
     locationEventBus.emit(LOCATION_EVENTS.LOCATION_CHANGED, location);
@@ -675,6 +691,7 @@ export const GeoLocationProvider = ({ children }) => {
     savedLocation,
     currentLocation,
     mapCenterModalOpen,
+    mapCenterModalPrompt,
     needsOnboarding,
 
     // Functions
@@ -688,6 +705,7 @@ export const GeoLocationProvider = ({ children }) => {
     closeLocationSettings,
     openMapCenterModal,
     closeMapCenterModal,
+    setMapCenterModalPrompt,
     setSessionLocation,
     saveAndSetLocation,
     saveToCloudDefault,


### PR DESCRIPTION
## Summary

Replaces v1.27.0 L4 Snackbar UX with auto-opened MapCenterModal carrying "What major city would you like to see?" header copy + autoFocused typeahead. Adds no-downgrade save rule via `skipPersist` flag.

Per Quinn 19:49Z arbitration (5 items, all resolved):
1. Option (2) — auto-open MapCenterModal w/ custom header (faster ship vs inline banner; promote-able post-launch)
2. No-downgrade fix bundled here, Option (a) — `skipPersist: true` flag
3. L4 (CF country) does NOT persist to localStorage — server-of-last-resort context
4. Anonymous typeahead pick → localStorage (existing behavior, no change)
5. Logged-in typeahead pick → cloud only (existing behavior, no change)

**Net effect:** Only user-explicit picks (typeahead, map-click, saved-pref restore) persist. L4/L5 auto-resolved coordinates are session-only. Level 2 reuse on next visit restores only user-explicit choices.

## Changes (5 files, +59 -71)

| File | Change |
|---|---|
| `package.json` | 1.27.1 → 1.27.2 |
| `src/app/contexts/GeoLocationContext.js` | `mapCenterModalPrompt` state + setter exposed; `setSessionLocation({skipPersist:true})` bypasses `saveLastMapCenter`; `closeMapCenterModal` clears the prompt |
| `src/app/components/Providers.js` | MapCenterModalWrapper threads `mapCenterModalPrompt` → `headerOverride` + `autoFocusCitySearch` props |
| `src/app/components/Modals/misc/MapCenterModal.js` | New props `headerOverride: string`, `autoFocusCitySearch: bool`; DialogTitle + city-search TextField wired |
| `src/app/calendar/layout.js` | L4 cascade replaced: `setSessionLocation(skipPersist:true)` + `setMapCenterModalPrompt(...)` + `openMapCenterModal()`; removed Snackbar/Alert/Button imports + BIG_COUNTRIES list + countryHint state + Snackbar JSX |

## Test plan

- [ ] TT TEST auto-deploys post-merge; Sarah confirms `/api/version` shows 1.27.2
- [ ] Anonymous mobile + GPS denied + CF country resolved:
  - [ ] Calendar shell mounts immediately with CF country center coords
  - [ ] MapCenterModal opens automatically
  - [ ] Modal header reads "What major city would you like to see?"
  - [ ] Typeahead is focused (cursor blinking in input)
  - [ ] No prior Snackbar appears
- [ ] User typeahead pick → modal closes → calendar re-centers on picked city
- [ ] Refresh page → cascade hits L2 (localStorage) with picked city, NOT CF country (no-downgrade verify)
- [ ] User dismisses modal without picking → calendar stays on CF country for session; refresh → cascade re-fires L4 (sessionStorage `locationCascadeSource` is the only trace; localStorage `last_map_center` unset)
- [ ] User taps header location selector (normal flow) → modal opens with default "Map Center Settings" header (prompt cleared on prior close)
- [ ] No regression on /boston, /tango/[parent], /tango/[parent]/[city]
- [ ] cascadeSource still flows: re-trigger /calendar L4 → Dash queries MapCenterHistory → fresh records show `cascadeSource: "cloudflare-country"` (CALBEAF-188 v1.35.1 BE-side persists this; verified by Fulton smoke 19:53Z)

## Stacked-gates / ship-together

Pairs with:
- CALBEAF-187 ✅ TEST v1.35.0 (keep-alive YAML)
- CALBEAF-188 ✅ TEST v1.35.1 smoke-confirmed (cascadeSource persists)
- CALBEAF-189 ⏳ TEST v1.35.2 deploying (Google→ipinfo egress fix)
- TIEMPO-457 v1.27.0 ✅ TEST live
- TIEMPO-457 v1.27.1 ✅ TEST live (L3b strip)
- TIEMPO-457 v1.27.2 (this PR)
- Deferred: TIEMPO-457 v1.27.3 to re-enable L3b once CALBEAF-189 verified

All TT FE + CALBEAF BE patches must be Toby-verified on TEST before any DEPLOY-PROD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)