### PR TITLE
fix(calendar): v1.27.3 polish — race fix + autoFocus + visual cue + L3b re-enable (TIEMPO-457)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
- "version": "1.27.2",
+ "version": "1.27.3",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/calendar/layout.js
+++ b/src/app/calendar/layout.js
@@ -55,22 +55,16 @@ const RootLayout = ({ children }) => {
         // and for Level-3 resolution.
         const browserGeoData = await getGeolocationData();
 
-        // Level 3 — browser GPS (Tier 1). Silent.
+        // Level 3 — browser GPS (Tier 1) or Google API / ipinfo proxy (Tier 2).
+        // Silent.
         //
-        // TIEMPO-457 v1.27.1: Tier 2 (Google API / `google_api_*`) is DISABLED
-        // pending Fulton's BE fix. The `/api/geo/google-geolocate` BE proxy
-        // calls Google from the server side, so Google sees Azure's egress IP
-        // and returns Northern Virginia (38.9847, -77.5619) for every user
-        // regardless of who they are — confirmed via Fulton's log pull
-        // (two different user IPs, identical google_api coordinates). The
-        // unblock condition is Fulton passing `CF-Connecting-IP` to Google's
-        // API call with `considerIp: false`. Re-enable the `else if` branch
-        // once BE returns user-specific google_api coords.
-        //
-        // Flat-field forwarding of `google_api_lat`/`google_api_long` in the
-        // tracking POST is preserved — the BE source-attribution chain still
-        // consumes those fields per Invariant 8, and incorrect coords land
-        // in the analytics history rather than the user-facing cascade.
+        // TIEMPO-457 v1.27.3: Tier 2 re-enabled. CALBEAF-189 swapped the
+        // `/api/geo/google-geolocate` backing impl from Google API
+        // (server-side, returned Azure egress 38.98/-77.56 for every user)
+        // to ipinfo.io with CF-Connecting-IP forwarding. Smoke verified
+        // 3 distinct IPs return 3 distinct correct locations (Mountain View
+        // / Brisbane / Ashburn — none Azure egress). FE consumes the same
+        // response shape; the endpoint name retained for future ADR.
         if (!resolved) {
           if (browserGeoData?.google_browser_lat && browserGeoData?.google_browser_long) {
             await setSessionLocation({
@@ -80,6 +74,15 @@ const RootLayout = ({ children }) => {
               source: 'browser-gps',
             });
             try { sessionStorage.setItem('locationCascadeSource', 'browser-gps'); } catch { /* sessionStorage unavailable */ }
+            resolved = true;
+          } else if (browserGeoData?.google_api_lat && browserGeoData?.google_api_long) {
+            await setSessionLocation({
+              lat: browserGeoData.google_api_lat,
+              lng: browserGeoData.google_api_long,
+              zoomRange: 75,
+              source: 'google-api',
+            });
+            try { sessionStorage.setItem('locationCascadeSource', 'google-api'); } catch { /* sessionStorage unavailable */ }
             resolved = true;
           }
         }

--- a/src/app/components/Modals/Welcome/WelcomeModal.js
+++ b/src/app/components/Modals/Welcome/WelcomeModal.js
@@ -35,7 +35,7 @@ const needsLocationSetup = () => {
 
 const WelcomeModal = () => {
   const { user } = useContext(AuthContext);
-  const { openMapCenterModal } = useGeoLocation();
+  const { openMapCenterModal, setMapCenterModalPrompt } = useGeoLocation();
   const [hasChecked, setHasChecked] = useState(false);
 
   useEffect(() => {
@@ -53,9 +53,14 @@ const WelcomeModal = () => {
       return;
     }
 
+    // TIEMPO-457 v1.27.3: set the prompt BEFORE opening so MapCenterModal
+    // mounts with headerOverride + autoFocusCitySearch already active. Without
+    // this WelcomeModal opens cold (t≈800ms) and the L4 cascade only sets the
+    // prompt later (t≈1-5s), by which point autoFocus is dead (mount-time only).
+    setMapCenterModalPrompt('What major city would you like to see?');
     openMapCenterModal();
     setHasChecked(true);
-  }, [hasChecked, openMapCenterModal, user]);
+  }, [hasChecked, openMapCenterModal, setMapCenterModalPrompt, user]);
 
   return null;
 };

--- a/src/app/components/Modals/misc/MapCenterModal.js
+++ b/src/app/components/Modals/misc/MapCenterModal.js
@@ -280,6 +280,22 @@ const MapCenterModal = ({
   headerOverride = null,
   autoFocusCitySearch = false,
 }) => {
+  // TIEMPO-457 v1.27.3: programmatic focus fallback for the prompt-driven open
+  // path. The TextField's `autoFocus` prop is mount-time-only and won't fire if
+  // autoFocusCitySearch flips from false→true while the modal is already open
+  // (race-condition path: WelcomeModal opens cold, L4 sets prompt later).
+  // This effect fires .focus() whenever (open && autoFocusCitySearch) becomes
+  // true, with a 100ms delay to give MUI Autocomplete + leaflet enough time
+  // to settle before we steal focus.
+  const citySearchInputRef = useRef(null);
+  useEffect(() => {
+    if (open && autoFocusCitySearch && citySearchInputRef.current) {
+      const t = setTimeout(() => {
+        citySearchInputRef.current?.focus();
+      }, 100);
+      return () => clearTimeout(t);
+    }
+  }, [open, autoFocusCitySearch]);
   const { user } = useContext(AuthContext);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -1008,7 +1024,26 @@ const MapCenterModal = ({
               variant="outlined"
               size="small"
               autoFocus={autoFocusCitySearch}
-              sx={{ mb: 1 }}
+              inputRef={citySearchInputRef}
+              helperText={autoFocusCitySearch ? '↓ Pick a major city to start' : undefined}
+              sx={autoFocusCitySearch ? {
+                mb: 1,
+                // TIEMPO-457 v1.27.3 visual cue: subtle pulse on the
+                // typeahead when the prompt-driven open path is active
+                '@keyframes citySearchPulse': {
+                  '0%, 100%': { boxShadow: '0 0 0 0 rgba(139, 21, 56, 0.4)' },
+                  '50%':      { boxShadow: '0 0 0 6px rgba(139, 21, 56, 0)' },
+                },
+                '& .MuiOutlinedInput-root': {
+                  animation: 'citySearchPulse 1.8s ease-in-out infinite',
+                  '& fieldset': { borderColor: 'primary.main', borderWidth: 2 },
+                },
+                '& .MuiFormHelperText-root': {
+                  color: 'primary.main',
+                  fontWeight: 500,
+                  mt: 0.5,
+                },
+              } : { mb: 1 }}
               inputProps={{
                 ...params.inputProps,
                 'data-testid': 'map-center-city-search',


### PR DESCRIPTION
## Summary

Polish pass on top of v1.27.2 — fixes the WelcomeModal/L4-cascade race that left the modal opening cold (default header, no autofocus) for Toby's anonymous-GPS-denied verify path, plus re-enables cascade L3b now that Fulton's CALBEAF-189 BE fix is live.

Per Quinn 20:28Z greenlight — single patch, 4 components.

## What changed

### (1) WelcomeModal sets prompt BEFORE opening
`src/app/components/Modals/Welcome/WelcomeModal.js`

Now calls `setMapCenterModalPrompt('What major city would you like to see?')` BEFORE `openMapCenterModal()`. The modal mounts with `headerOverride` and `autoFocusCitySearch` already true, so the title + autofocus apply at mount.

### (2) Bulletproof programmatic focus
`src/app/components/Modals/misc/MapCenterModal.js`

Adds `citySearchInputRef` + `useEffect([open, autoFocusCitySearch])` calling `.focus()` with 100ms delay. Covers iOS Safari and any prop-flip mid-modal race.

### (3) Visual cue
`src/app/components/Modals/misc/MapCenterModal.js`

When `autoFocusCitySearch=true` the city-search TextField gets:
- `helperText="↓ Pick a major city to start"` (brand primary color, medium weight)
- Pulsing box-shadow border in brand maroon (`#8B1538`) via CSS keyframes
- 2px primary-color border replacing default outlined border

Inert when modal opens via the normal flow path.

### (4) L3b cascade re-enable
`src/app/calendar/layout.js`

Restores the `else if browserGeoData?.google_api_lat && browserGeoData?.google_api_long` branch. CALBEAF-189 (Fulton v1.35.2) verified the BE returns user-specific coords (3-IP smoke: Mountain View / Brisbane / Ashburn).

## Files (4 files, +62 -19)

| File | Δ |
|---|---|
| `package.json` | 1.27.2 → 1.27.3 |
| `src/app/calendar/layout.js` | L3b re-enabled, comment updated |
| `src/app/components/Modals/misc/MapCenterModal.js` | useEffect+ref focus, helperText + pulse sx |
| `src/app/components/Modals/Welcome/WelcomeModal.js` | setMapCenterModalPrompt before openMapCenterModal |

## Test plan

- [ ] TT TEST `/api/version` returns 1.27.3
- [ ] Anonymous + no localStorage + GPS denied + CF country resolvable:
  - [ ] MapCenterModal opens automatically
  - [ ] Header reads "What major city would you like to see?"
  - [ ] City-search input has cursor focus (not just visually highlighted — cursor blinking)
  - [ ] Input has pulsing maroon border animating
  - [ ] Helper text below input: "↓ Pick a major city to start"
- [ ] User types in typeahead → results populate → pick → modal closes → calendar centered on city
- [ ] Refresh page → L2 hits localStorage, no modal pop, on persisted city
- [ ] User opens modal via header location selector (normal flow) → default "Map Center Settings" header, no pulse, no helper text, no autofocus
- [ ] Anonymous + GPS denied + Google API ipinfo resolvable (post-CALBEAF-189) → silent L3b resolution, no modal, cascadeSource='google-api' in MapCenterHistory
- [ ] No regression on /boston, /tango/[parent], /tango/[parent]/[city]

## Stacked-gates state (8 of N patches across TIEMPO-457 + CALBEAF)

| Lane | Live on TEST |
|---|---|
| TIEMPO-457 v1.27.0 4-component + cascade + Snackbar | ✅ |
| TIEMPO-457 v1.27.1 L3b strip | ✅ |
| TIEMPO-457 v1.27.2 typeahead-prompt + skipPersist | ✅ |
| TIEMPO-457 v1.27.3 polish (this PR) | pending merge |
| CALBEAF-187 keep-alive YAML | ✅ v1.35.0 |
| CALBEAF-188 cascadeSource persist | ✅ v1.35.1 |
| CALBEAF-189 Google→ipinfo egress | ✅ v1.35.2 |

After this lands + Toby's quick smoke → TEST→PROD CRK for the full TT FE stack + Fulton's CALBEAF PROD pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)