### PR TITLE
debug(geo): CF header debug route — TIEMPO-458 step 0

### DIFF
--- a/src/app/api/geo/debug-headers/route.js
+++ b/src/app/api/geo/debug-headers/route.js
@@ -1,0 +1,11 @@
+export async function GET(request) {
+  return Response.json({
+    cfIpCity:    request.headers.get('cf-ipcity'),
+    cfLat:       request.headers.get('cf-iplatitude'),
+    cfLng:       request.headers.get('cf-iplongitude'),
+    cfCountry:   request.headers.get('cf-ipcountry'),
+    cfRegion:    request.headers.get('cf-region'),
+    cfTimezone:  request.headers.get('cf-timezone'),
+    xVercelCity: request.headers.get('x-vercel-ip-city'),
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `/api/geo/debug-headers` route that echoes back CF geo headers + x-vercel-ip-city for comparison
- STEP 0 verify: confirms whether CF Managed Transform headers reach Next.js at Vercel
- No functional change to app — pure diagnostic endpoint

## Test plan
- [ ] Merge triggers auto-deploy to tangotiempo-test
- [ ] Hit `https://test.tangotiempo.com/api/geo/debug-headers` from browser
- [ ] Verify `cfIpCity` returns real city (GREEN) or null (STOP — ping Quinn)
- [ ] Check `xVercelCity` — expected wrong/missing per Compass doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)