### PR TITLE
feat(geo): TIEMPO-459 — userLocation + entryDomain in tracking POSTs (v1.28.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
- "version": "1.28.0",
+ "version": "1.28.1",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/calendar/layout.js
+++ b/src/app/calendar/layout.js
@@ -59,6 +59,23 @@ const RootLayout = ({ children }) => {
           cfGeo = cfRes.ok ? await cfRes.json() : null;
         } catch { /* network error — fall to L4 */ }
 
+        // TIEMPO-459: persist userLocation (where user IS) once per session.
+        // Separate from mapCenter. Does not drive localStorage.
+        if (cfGeo) {
+          try {
+            sessionStorage.setItem('cf_user_location', JSON.stringify({
+              city: cfGeo.city, country: cfGeo.country,
+              lat: cfGeo.lat, lng: cfGeo.lng,
+            }));
+          } catch { /* sessionStorage unavailable */ }
+        }
+
+        // TIEMPO-459: capture entryDomain (?src= param) once per session.
+        try {
+          const src = new URLSearchParams(window.location.search).get('src');
+          if (src) sessionStorage.setItem('entry_domain', src);
+        } catch { /* sessionStorage unavailable */ }
+
         if (!resolved && cfGeo?.city && cfGeo.lat !== null && cfGeo.lng !== null) {
           await setSessionLocation({
             lat: cfGeo.lat,
@@ -177,7 +194,10 @@ const RootLayout = ({ children }) => {
             google: geoData.google,
             ipapi: geoData.ipapi,
                 // TIEMPO-457: telemetry — which cascade level resolved this location
-            cascadeSource
+            cascadeSource,
+            // TIEMPO-459: where the user IS (CF-inferred, session-start only)
+            userLocation: (() => { try { return JSON.parse(sessionStorage.getItem('cf_user_location')); } catch { return null; } })(),
+            entryDomain: (() => { try { return sessionStorage.getItem('entry_domain') || null; } catch { return null; } })()
           })
         });
       } catch (error) {

--- a/src/app/contexts/AuthContext.js
+++ b/src/app/contexts/AuthContext.js
@@ -22,7 +22,6 @@ import { auth, facebookProvider, googleProvider, appleProvider } from '@/utils/f
 import axios from 'axios';
 import { dedupeFetch } from '@/utils/dedupeFetch';
 import { fetchAllGeolocationData } from '@/utils/trackingHelper';
-import { getGeolocationData } from '@/utils/geolocationHelper'; // TIEMPO-324: 3-tier geolocation
 import { getApiBaseUrl } from '@/utils/apiUrlResolver';
 
 // Create Auth Context
@@ -109,38 +108,30 @@ export const AuthProvider = ({ children }) => {
       } else {
         const afUrl = process.env.NEXT_PUBLIC_AF_URL || 'http://localhost:7071';
 
-        // TIEMPO-324: Get 3-tier geolocation data (browser GPS → Google API → ipinfo fallback)
-        getGeolocationData().then(browserGeoData => {
-          // Fetch all geolocation data (Cloudflare, Google, IP API) with distance calculation
-          // TIEMPO-319: Use 8-hour cache for login tracking (480 minutes)
-          fetchAllGeolocationData(480).then(geoData => {
-            fetch(`${afUrl}/api/user/login-track`, {
-              method: 'POST',
-              headers: {
-                'Authorization': `Bearer ${idToken}`,
-                'Content-Type': 'application/json'
-              },
-              body: JSON.stringify({
-                loginType: loginType, // 'auto' or 'manual'
-                timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-                timezoneOffset: -new Date().getTimezoneOffset(),
+        // TIEMPO-459: login-track POST. TIEMPO-458 removed google-geolocate;
+        // userLocation is now the CF-inferred location captured at session start.
+        fetchAllGeolocationData(480).then(geoData => {
+          let userLocation = null;
+          try { userLocation = JSON.parse(sessionStorage.getItem('cf_user_location')); } catch { /* ignore */ }
 
-                // Existing geolocation data
-                cloudflare: geoData.cloudflare,
-                google: geoData.google,
-                ipapi: geoData.ipapi,
-                distance: geoData.distance,
-
-                // TIEMPO-324: 3-tier geolocation (browser GPS, Google API)
-                google_browser_lat: browserGeoData.google_browser_lat,
-                google_browser_long: browserGeoData.google_browser_long,
-                google_browser_accuracy: browserGeoData.google_browser_accuracy,
-                google_api_lat: browserGeoData.google_api_lat,
-                google_api_long: browserGeoData.google_api_long
-              })
-            }).catch(err => console.warn('[Login Tracking] Failed:', err.message));
-          }).catch(err => console.warn('[Login Tracking] Geo fetch failed:', err.message));
-        }).catch(err => console.warn('[Login Tracking] Browser geo failed:', err.message));
+          fetch(`${afUrl}/api/user/login-track`, {
+            method: 'POST',
+            headers: {
+              'Authorization': `Bearer ${idToken}`,
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              loginType: loginType,
+              timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+              timezoneOffset: -new Date().getTimezoneOffset(),
+              cloudflare: geoData.cloudflare,
+              google: geoData.google,
+              ipapi: geoData.ipapi,
+              distance: geoData.distance,
+              userLocation,
+            })
+          }).catch(err => console.warn('[Login Tracking] Failed:', err.message));
+        }).catch(err => console.warn('[Login Tracking] Geo fetch failed:', err.message));
       }
 
 // TIEMPO-276: Security cleanup - removed logging


### PR DESCRIPTION
## Summary
- **`userLocation`** (where user IS): captured from `cfGeo` at session start in `layout.js` init, stored in `sessionStorage['cf_user_location']`. Sent in every `mapcenter-track` and `login-track` POST. Does NOT drive localStorage or mapCenter cascade.
- **`entryDomain`**: reads `?src=` URL param at session start, stored in `sessionStorage['entry_domain']`. Included in `mapcenter-track` POST. Null until Toby wires CF redirect rule for `bostontangocalendar.com` (`?src=bostontangocalendar`).
- **AuthContext cleanup**: removed `getGeolocationData()` import and call (TIEMPO-458 followup — google-geolocate fully eliminated from auth layer). Removed `google_browser_*` flat fields from `login-track` POST body.

## Test plan
- [ ] Calendar loads with no console errors
- [ ] `sessionStorage['cf_user_location']` set after page load (city/country null on TEST — expected)
- [ ] `mapcenter-track` POST body includes `userLocation` field (network tab — will be null on TEST)
- [ ] `login-track` POST body includes `userLocation` field when user signs in
- [ ] `entryDomain` null when no `?src=` param; `entryDomain: 'bostontangocalendar'` when `?src=bostontangocalendar` appended to URL
- [ ] Network tab: no call to `/api/geo/google-geolocate` from AuthContext

## PROD behavior
- `userLocation` will have `{city, country, lat, lng}` from CF headers (verified at ship time)
- `entryDomain` captures traffic source for analytics

🤖 Generated with [Claude Code](https://claude.com/claude-code)