### PR TITLE
feat(modal): TIEMPO-460 — MapCenterModal simplified prompt-mode layout (v1.28.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
- "version": "1.28.1",
+ "version": "1.28.2",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/components/Modals/misc/MapCenterModal.js
+++ b/src/app/components/Modals/misc/MapCenterModal.js
@@ -14,6 +14,7 @@ import {
   Slider,
   Switch,
   FormControlLabel,
+  Divider,
   useTheme,
   useMediaQuery,
   CircularProgress,
@@ -838,6 +839,142 @@ const MapCenterModal = ({
     }
   };
   
+  // TIEMPO-460: Simplified prompt-mode layout (L4 cascade — headerOverride set).
+  // Type city → pick → Save activates → tap Save → closes + writes tt_geo_v2_pick.
+  if (headerOverride) {
+    return (
+      <Dialog
+        open={open}
+        onClose={onClose}
+        maxWidth="xs"
+        fullWidth
+        data-testid="map-center-modal"
+      >
+        <DialogContent sx={{ pt: 4, pb: 3, px: 3, position: 'relative' }}>
+          <IconButton
+            onClick={onClose}
+            size="small"
+            data-testid="map-center-close"
+            sx={{ position: 'absolute', top: 8, right: 8 }}
+          >
+            <CloseIcon />
+          </IconButton>
+
+          <Typography variant="h6" align="center" sx={{ mb: 3, lineHeight: 1.4 }}>
+            {headerOverride}
+          </Typography>
+
+          <Autocomplete
+            freeSolo
+            size="small"
+            options={cityOptions}
+            getOptionLabel={(option) => {
+              if (typeof option === 'string') return option;
+              const location = option.divisionName || option.regionName || option.countryName || '';
+              return location ? `${option.cityName}, ${location}` : option.cityName;
+            }}
+            loading={citySearchLoading}
+            inputValue={citySearchQuery}
+            onInputChange={(e, value) => setCitySearchQuery(value || '')}
+            onChange={handleCitySelect}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                placeholder="Search city (e.g., Buenos Aires)"
+                variant="outlined"
+                size="small"
+                autoFocus={autoFocusCitySearch}
+                inputRef={citySearchInputRef}
+                helperText="↓ Pick a major city to start"
+                sx={{
+                  '@keyframes citySearchPulse': {
+                    '0%, 100%': { boxShadow: '0 0 0 0 rgba(139, 21, 56, 0.4)' },
+                    '50%':      { boxShadow: '0 0 0 6px rgba(139, 21, 56, 0)' },
+                  },
+                  '& .MuiOutlinedInput-root': {
+                    animation: 'citySearchPulse 1.8s ease-in-out infinite',
+                    '& fieldset': { borderColor: 'primary.main', borderWidth: 2 },
+                  },
+                  '& .MuiFormHelperText-root': {
+                    color: 'primary.main',
+                    fontWeight: 500,
+                    mt: 0.5,
+                  },
+                }}
+                inputProps={{
+                  ...params.inputProps,
+                  'data-testid': 'map-center-city-search',
+                }}
+                InputProps={{
+                  ...params.InputProps,
+                  endAdornment: (
+                    <>
+                      {citySearchLoading ? <CircularProgress size={16} /> : null}
+                      {params.InputProps.endAdornment}
+                    </>
+                  ),
+                }}
+              />
+            )}
+            renderOption={(props, option) => (
+              <li
+                {...props}
+                key={option._id || option.cityName}
+                data-testid={`city-option-${String(option.cityName || '').toLowerCase().trim().replace(/\s+/g, '-')}`}
+              >
+                <Box>
+                  <Typography variant="body2" sx={{ fontWeight: 500 }}>{option.cityName}</Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {[option.divisionName, option.regionName, option.countryName].filter(Boolean).join(', ')}
+                  </Typography>
+                </Box>
+              </li>
+            )}
+            noOptionsText={citySearchQuery.length < 2 ? 'Type 2+ characters' : 'No cities found'}
+          />
+
+          <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2, mb: !user ? 0 : 1 }}>
+            <Button
+              variant="contained"
+              onClick={handleSave}
+              disabled={loading || !centerLat || !centerLng}
+              data-testid="map-center-save"
+              startIcon={loading ? <CircularProgress size={14} color="inherit" /> : null}
+              sx={{ minWidth: 120 }}
+            >
+              {loading ? 'Saving...' : 'Save'}
+            </Button>
+          </Box>
+
+          {!user && (
+            <>
+              <Divider sx={{ my: 2 }} />
+              <Box sx={{ display: 'flex', justifyContent: 'center', gap: 2 }}>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={() => { window.location.href = '/auth/login'; }}
+                  data-testid="prompt-login"
+                >
+                  Log In
+                </Button>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  color="secondary"
+                  onClick={() => { window.location.href = '/auth/signup'; }}
+                  data-testid="prompt-signup"
+                >
+                  Sign Up
+                </Button>
+              </Box>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
   return (
     <Dialog
       open={open}
@@ -852,16 +989,16 @@ const MapCenterModal = ({
         }
       }}
     >
-      <DialogTitle sx={{ 
-        display: 'flex', 
-        alignItems: 'center', 
+      <DialogTitle sx={{
+        display: 'flex',
+        alignItems: 'center',
         justifyContent: 'space-between',
         borderBottom: 1,
         borderColor: 'divider'
       }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <LocationOnIcon color="primary" />
-          <Typography variant="h6">{headerOverride || 'Map Center Settings'}</Typography>
+          <Typography variant="h6">Map Center Settings</Typography>
         </Box>
         <IconButton onClick={onClose} size="small" data-testid="map-center-close">
           <CloseIcon />


### PR DESCRIPTION
## Summary
- When `headerOverride` is set (L4 cascade — anonymous first visit with CF country only), renders a compact prompt-mode dialog instead of the full Leaflet map modal:
  - Centered header text (the `headerOverride` string, e.g. "What major city would you like to see?")
  - City typeahead with pulsing maroon border + "↓ Pick a major city to start" helper text, autofocused on open
  - Save button centered below input — disabled until city picked from typeahead (not just typed)
  - `Divider` + **Log In** / **Sign Up** buttons below divider (anonymous users only, hidden when logged in)
  - Small X close button in top-right corner
- Full map layout (Leaflet, density pills, slider, My Location) unchanged — renders when no `headerOverride`
- Adds `Divider` to MUI imports

## Flow
type city → pick from typeahead → Save activates → tap Save → modal closes → `setSessionLocation` → `saveLastMapCenter` → `tt_geo_v2_pick` written to localStorage

## Test plan
- [ ] Trigger L4 path: anonymous user, no prior pick, clear localStorage — modal opens with simplified layout
- [ ] Header text centered: "What major city would you like to see?"
- [ ] Typeahead focused on open, pulsing maroon border, helper text visible
- [ ] Save button disabled until city selected from dropdown
- [ ] After pick: Save enables, tap Save → modal closes, calendar re-centers
- [ ] `tt_geo_v2_pick` in localStorage after Save
- [ ] Divider + Log In / Sign Up visible for anon users
- [ ] Divider + Login/Signup hidden for logged-in users (just header + typeahead + Save)
- [ ] X button dismisses modal without pick (cascade stays on country-center, re-fires on refresh)
- [ ] Normal user flow (header button): full Leaflet map modal unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)