### PR TITLE
fix(modal): SET → Save label on full-map modal confirm button (v1.28.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
- "version": "1.28.2",
+ "version": "1.28.3",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/components/Modals/misc/MapCenterModal.js
+++ b/src/app/components/Modals/misc/MapCenterModal.js
@@ -1076,7 +1076,7 @@ const MapCenterModal = ({
                 }
               } : {}}
             >
-              {loading ? 'Setting...' : 'SET'}
+              {loading ? 'Saving...' : 'Save'}
             </Button>
 
             {/* Show Events toggle */}


### PR DESCRIPTION
## Summary
- Changes "SET" / "Setting..." → "Save" / "Saving..." on the full-map modal confirm button (left-panel save action)
- Compact prompt-mode already used "Save" — this brings the full-map modal into alignment
- Patch version bump 1.28.2 → 1.28.3

## Change
`MapCenterModal.js` line ~1079: `{loading ? 'Setting...' : 'SET'}` → `{loading ? 'Saving...' : 'Save'}`

## Test plan
- [ ] Open MapCenterModal via header location button (full map view)
- [ ] Confirm button reads "Save" (not "SET")
- [ ] Click Save — confirm button reads "Saving..." during loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)