### PR TITLE
docs(types): TIEMPO-462 — UserLocation JSDoc typedef (FE→BE contract)

### DIFF
--- a/src/app/calendar/layout.js
+++ b/src/app/calendar/layout.js
@@ -1,6 +1,21 @@
 //@/calendar/layout.js
 'use client'; // Enable client-side rendering
 
+/**
+ * @typedef {Object} UserLocation
+ * Canonical FE→BE contract for userLocation field in mapcenter-track and login-track POSTs.
+ * Written to sessionStorage key 'cf_user_location' once per session in this file.
+ * Read by AuthContext.js (login-track) and layout.js mapcenter-track.
+ *
+ * v1.28.3 shape (PROD today):
+ * @property {number} lat
+ * @property {number} lng
+ * @property {string} city
+ * @property {string} country
+ *
+ * TIEMPO-462 will extend with: source (string), confidence (number), cascadeLevel (number), region (string)
+ */
+
 import React, { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { AuthContext } from '@/contexts/AuthContext';


### PR DESCRIPTION
## Summary
- Adds `@typedef UserLocation` JSDoc comment to `layout.js` as the canonical FE→BE contract for the `userLocation` POST body field
- Documents the current v1.28.3 shape (4 fields: lat, lng, city, country)
- Notes TIEMPO-462 extension: source, confidence, cascadeLevel, region (per Fulton/CALBEAF-193 handshake)
- No runtime change — docs only

## Background
Fulton requested a formal typed contract so field renames break loudly rather than silently writing null to the DB. CALBEAF-193 is holding for this confirmation.

## Test plan
- [ ] No functional change — visual diff only
- [ ] Verify layout.js typedef is visible in IDE tooling

🤖 Generated with [Claude Code](https://claude.com/claude-code)