### PR TITLE
fix(geo): TIEMPO-465 — isPrivateRelay via POST body (not Azure BE header)

### DIFF
--- a/src/app/calendar/layout.js
+++ b/src/app/calendar/layout.js
@@ -148,6 +148,8 @@ const RootLayout = ({ children }) => {
           geoSource: sessionGeoSource,
           cascadeLevel: sessionCascadeLevel,
           userLocation: (() => { try { return JSON.parse(sessionStorage.getItem('cf_user_location')); } catch { return null; } })(),
+          // TIEMPO-465 addendum: pass CF-derived isPrivateRelay via POST body — Azure BE is not behind CF so header read would always be false
+          isPrivateRelay: cfGeo?.isPrivateRelay ?? false,
         };
 
         await fetch(`${afUrl}/api/visitor/track`, {


### PR DESCRIPTION
## Summary
One-line addendum to TIEMPO-465 (PR #382, already on TEST).

**Problem:** CALBEAF-194 reads `isPrivateRelay` from `cf-ip-organization` header on Azure BE side. Azure Functions is NOT behind Cloudflare — CF headers never reach Azure. `isPrivateRelay` would always be `false` in `sessiongeoanalytics`, making Dash's Private Relay % metric meaningless.

**Fix:** `cfGeo` (the `/api/geo/cf-location` response from Vercel, which IS behind CF) already returns `isPrivateRelay`. Include it in the visitor-track POST body so Fulton reads from `body.isPrivateRelay` instead of the header.

```js
// In sessionGeoPayload:
isPrivateRelay: cfGeo?.isPrivateRelay ?? false,
```

## Companion change
Fulton's CALBEAF-194 changes BE read from header → `body.isPrivateRelay === true`. No schema change to `sessiongeoanalytics`.

## Test plan
- [ ] visitor/track POST body includes `isPrivateRelay: false` on non-relay network
- [ ] No regression on other visitor-track fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)