### PR TITLE
chore: v1.28.4 — TIEMPO-465 session geo capture

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
- "version": "1.28.3",
+ "version": "1.28.4",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",


### PR DESCRIPTION
Version bump for TIEMPO-465. PRs #382 + #383 already on TEST.