### PR TITLE
feat(geo): session geo capture — visitor-track POST + isPrivateRelay + localStorage rate-limit (v1.28.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tangotiempo",
- "version": "1.28.3",
+ "version": "1.28.4",
   "private": true,
   "proxy": "http://localhost:3010",
   "type": "module",

--- a/src/app/api/geo/cf-location/route.js
+++ b/src/app/api/geo/cf-location/route.js
@@ -16,6 +16,9 @@ export async function GET(request) {
   const validCoords    = lat !== null && lng !== null && isFinite(lat) && isFinite(lng);
   const unknownCountry = country === 'XX' || country === 'T1' || !country;
 
+  // TIEMPO-465: log Private Relay presence for analytics (do not bypass — CF already maps relay IPs to metro)
+  const isPrivateRelay = (h.get('cf-ip-organization') ?? '').toLowerCase().includes('icloud private relay');
+
   let confidence = 0.0;
   let source = 'default';
 
@@ -30,7 +33,7 @@ export async function GET(request) {
   }
 
   return Response.json(
-    { city, country, region, timezone, lat, lng, confidence, source, resolvedAt: Date.now() },
+    { city, country, region, timezone, lat, lng, confidence, source, isPrivateRelay, resolvedAt: Date.now() },
     { headers: { 'cache-control': 'private, max-age=0, no-store' } }
   );
 }

--- a/src/app/calendar/layout.js
+++ b/src/app/calendar/layout.js
@@ -140,9 +140,10 @@ const RootLayout = ({ children }) => {
           try { sessionStorage.setItem('locationCascadeSource', 'default-fallback'); } catch { /* sessionStorage unavailable */ }
         }
 
-        // TIEMPO-465: include session geo fields in visitor-track POST, rate-limited to 1x/day via sessionStorage flag.
-        const sessionGeoFlagKey = `sessiongeo_logged_${new Date().toISOString().slice(0, 10)}`;
-        const alreadyLoggedToday = (() => { try { return sessionStorage.getItem(sessionGeoFlagKey) === 'true'; } catch { return false; } })();
+        // TIEMPO-465: include session geo fields in visitor-track POST, rate-limited to 1x/day via localStorage flag.
+        // localStorage (not sessionStorage) so the flag survives tab close — true UTC-day dedup.
+        const sessionGeoFlagKey = `geo_logged_${new Date().toISOString().slice(0, 10)}`;
+        const alreadyLoggedToday = (() => { try { return localStorage.getItem(sessionGeoFlagKey) === 'true'; } catch { return false; } })();
         const sessionGeoPayload = alreadyLoggedToday ? {} : {
           geoSource: sessionGeoSource,
           cascadeLevel: sessionCascadeLevel,
@@ -172,7 +173,7 @@ const RootLayout = ({ children }) => {
         });
 
         if (!alreadyLoggedToday) {
-          try { sessionStorage.setItem(sessionGeoFlagKey, 'true'); } catch { /* sessionStorage unavailable */ }
+          try { localStorage.setItem(sessionGeoFlagKey, 'true'); } catch { /* localStorage unavailable */ }
         }
       } catch (error) {
         // Silent failure - don't break user experience

--- a/src/app/calendar/layout.js
+++ b/src/app/calendar/layout.js
@@ -97,6 +97,21 @@ const RootLayout = ({ children }) => {
         // calculation. PHASE 1.2: 24-hour cache for visitor tracking.
         const geoData = await fetchAllGeolocationData(1440);
 
+        // TIEMPO-465: translate internal cascade source strings → PascalCase GeoSourceEnum + numeric level.
+        // Internal sessionStorage strings stay unchanged; translation only at POST time.
+        const cascadeSrcRaw = (() => { try { return sessionStorage.getItem('locationCascadeSource'); } catch { return null; } })();
+        const GEO_SOURCE_MAP = {
+          'anon-cookie':        { geoSource: 'ModalPick',      cascadeLevel: 1 },
+          'cf-city':            { geoSource: 'CloudflareEdge', cascadeLevel: 3 },
+          'cloudflare-country': { geoSource: 'CloudflareEdge', cascadeLevel: 4 },
+          'default-fallback':   { geoSource: 'Unknown',        cascadeLevel: 5 },
+        };
+        const geoResolved = GEO_SOURCE_MAP[cascadeSrcRaw] ?? { geoSource: 'Unknown', cascadeLevel: 5 };
+        // L0: logged-in, cascade level=0. geoSource='Unknown' because the FE doesn't
+        // know which method originally resolved the saved profile location.
+        const sessionGeoSource    = user?.uid ? 'Unknown' : geoResolved.geoSource;
+        const sessionCascadeLevel = user?.uid ? 0 : geoResolved.cascadeLevel;
+
         // Level 4 — Cloudflare country fallback (modal). CF city was null at L3
         // (country-only resolution). Per storage-rule: skipPersist:true so a
         // session-only country-center never overwrites a prior explicit pick.
@@ -125,6 +140,15 @@ const RootLayout = ({ children }) => {
           try { sessionStorage.setItem('locationCascadeSource', 'default-fallback'); } catch { /* sessionStorage unavailable */ }
         }
 
+        // TIEMPO-465: include session geo fields in visitor-track POST, rate-limited to 1x/day via sessionStorage flag.
+        const sessionGeoFlagKey = `sessiongeo_logged_${new Date().toISOString().slice(0, 10)}`;
+        const alreadyLoggedToday = (() => { try { return sessionStorage.getItem(sessionGeoFlagKey) === 'true'; } catch { return false; } })();
+        const sessionGeoPayload = alreadyLoggedToday ? {} : {
+          geoSource: sessionGeoSource,
+          cascadeLevel: sessionCascadeLevel,
+          userLocation: (() => { try { return JSON.parse(sessionStorage.getItem('cf_user_location')); } catch { return null; } })(),
+        };
+
         await fetch(`${afUrl}/api/visitor/track`, {
           method: 'POST',
           headers: {
@@ -142,9 +166,14 @@ const RootLayout = ({ children }) => {
             cloudflare: geoData.cloudflare,
             google: geoData.google,
             ipapi: geoData.ipapi,
-            distance: geoData.distance
+            distance: geoData.distance,
+            ...sessionGeoPayload,
           })
         });
+
+        if (!alreadyLoggedToday) {
+          try { sessionStorage.setItem(sessionGeoFlagKey, 'true'); } catch { /* sessionStorage unavailable */ }
+        }
       } catch (error) {
         // Silent failure - don't break user experience
         console.warn('[Visitor Tracking] Failed:', error.message);

--- a/src/app/calendar/layout.js
+++ b/src/app/calendar/layout.js
@@ -148,6 +148,8 @@ const RootLayout = ({ children }) => {
           geoSource: sessionGeoSource,
           cascadeLevel: sessionCascadeLevel,
           userLocation: (() => { try { return JSON.parse(sessionStorage.getItem('cf_user_location')); } catch { return null; } })(),
+          // TIEMPO-465 addendum: pass CF-derived isPrivateRelay via POST body — Azure BE is not behind CF so header read would always be false
+          isPrivateRelay: cfGeo?.isPrivateRelay ?? false,
         };
 
         await fetch(`${afUrl}/api/visitor/track`, {


### PR DESCRIPTION
## Summary
- `/api/geo/cf-location`: adds `isPrivateRelay` boolean (cf-ip-organization header, log-only per GEO-CAPTURE-STANDARDS.md)
- visitor-track POST: adds `geoSource` (PascalCase enum), `cascadeLevel` (0–5), `userLocation`, `isPrivateRelay` on first daily load
- Rate-limit: `geo_logged_YYYY-MM-DD` in **localStorage** (survives tab close — true UTC-day dedup)
- `isPrivateRelay` passed via POST body to BE (Azure not behind CF — header read would always be false)

## Tickets
- TIEMPO-465 (main), TIEMPO-464 (closed Won't Do — superseded by standards)

## Gates
- TEST sweep: 10/10 PASS ✅
- CRK: Quinn-ratified 6/6 PASS ✅
- Regression: localStorage flag + rate-limit + cascade unchanged ✅
- Fulton CALBEAF-194: PROD confirmed 5/5 ✅
- Version: 1.28.3 → 1.28.4 ✅

## PRs included
#382 (main build) · #383 (isPrivateRelay POST body fix) · #384 (version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)